### PR TITLE
Record the server-plane architecture decision

### DIFF
--- a/docs/ServerPlaneArchitecture.md
+++ b/docs/ServerPlaneArchitecture.md
@@ -1,0 +1,335 @@
+# Server Plane Architecture — Decision Record
+
+Status: **accepted** (design session, 2026-08-09). Nothing here is implemented yet; this
+records the decisions and the pre-work the implementation must respect.
+
+## Context
+
+Today one deployable, `kinotic-server`, serves every participant type — application
+end-users, organization users, system operators, and machines — with one
+`SecurityService`, one event bus, and zone rules (`ZoneRules`) as the sole partition.
+Three pressures forced this decision:
+
+- **Trust gradient.** The app surface terminates arbitrary customer code and end-user
+  traffic; the org surface serves authenticated org members; the system surface controls
+  workload orchestration on our VMs. One binary means one blast radius.
+- **System-plane buildout.** PR #319 (merged) split the frontend into `apps/portal` and
+  `apps/system`; system users are moving to Entra SSO; SYSTEM machines (vm-manager) need
+  a provisioning story that does not distribute secrets — today (#396) vm-manager
+  authenticates with machine client-credentials as an interim.
+- **Job pipeline.** GitHub events must trigger grind jobs that start workloads via
+  vm-manager, and org/MCP users must be able to re-run them.
+
+A full service-to-plane inventory (every `@Publish`ed service, REST route, and
+client→service edge in the codebase) was produced before deciding; its findings are
+folded in below.
+
+## Decisions
+
+### 1. Three deployables, under one name
+
+**Kinotic OS** is the entire system described here — the brand's "Operating System for
+the Cloud" names the umbrella, so no single deployable claims the `os` name. Each server
+is named for the participant plane it serves. Names that describe the OS as a whole keep
+their `os` prefix (`os-api` — the OS's public API; `os-data` — the OS's own state).
+
+- **`kinotic-org-server`** — the organization plane (today's `kinotic-server` module,
+  renamed). Public gateway. Assembles: core, domain, gateway, os-api, persistence,
+  github. Serves: portal SPA, CLI (device-grant delegates), MCP hosts, GitHub webhooks.
+- **`kinotic-system-server`** — the system plane. Gateway reachable from the internet only
+  over VPN; reachable directly inside the Azure VNet. Assembles: core, domain, gateway,
+  orchestrator, system services. Serves: `apps/system` SPA, system users, vm-manager
+  nodes.
+- **`kinotic-app-server`** — the application plane. Public gateway. Assembles: core,
+  domain, gateway, persistence (app-api services). Serves: application end-users,
+  APPLICATION machines, customer microservices (which publish into `app.<org>.<app>`
+  zones).
+
+Assembly is the isolation mechanism: a plane's excluded modules are *absent from the
+binary*, not disabled by configuration. No `@Profile`-gated or property-gated security
+beans — each deployable wires its own.
+
+### 2. Two buses, split along the trust gradient
+
+- **OS bus** (one Vert.x cluster): `kinotic-org-server` + `kinotic-system-server` +
+  vm-manager nodes — together the **OS core**. Org-and-system traffic shares this bus,
+  so the github → grind → workload chain is ordinary in-cluster invocation — no bridge,
+  no polling.
+- **App bus** (its own cluster): `kinotic-app-server` alone, hosting `app-api` and the
+  customer `app.<org>.<app>` zones.
+- The buses are Vert.x event-bus clusters; the cluster manager (Ignite today) is an
+  implementation detail behind them and stays swappable.
+- **No bus link between the two clusters — ever.** Everything that crosses is state, and
+  it flows through the shared data stores (§9).
+
+### 3. One `SecurityService` per plane, selected by assembly
+
+- `KinoticSecurityService` is renamed `OrgSecurityService` — it was always the security
+  service for org participants, and the rename puts the three siblings in one shape —
+  and moves out of kinotic-domain's blanket component scan into the `kinotic-org-server`
+  deployable (resolving its standing FIXME). It keeps: org session cookie,
+  email/password headers, machine client-credentials, Kinotic JWTs.
+- `SystemSecurityService` (new, system plane): Entra SSO sessions for system users and
+  Entra workload-identity Bearer tokens for machines. It contains **no** password path,
+  no client-secret path, and no Kinotic-JWT path.
+- `AppSecurityService` (new, app plane): application participants only — app OIDC/local
+  login and APPLICATION machine client-credentials. Org and system participants cannot
+  authenticate here.
+
+### 4. SYSTEM machines authenticate with Entra workload identity — no secrets
+
+The C/D/E provisioning question closes as **E-direct**: the VM's managed-identity token
+(minted by IMDS, `aud` = the kinotic app registration) is presented as the Bearer
+credential on every (re)connect and validated by `SystemSecurityService` against the
+same tenant trust used for system-user SSO. Consequences:
+
+- A SYSTEM machine's `MachineParticipantIdentity` row carries the Entra principal's
+  `oid` (the `(oidcSubject, oidcConfigId)` shape users already have) and **no
+  `IdentityCredential`**. `AuthType` gains this dichotomy for machines; the
+  `beforeSave` pin to `CLIENT_CREDENTIALS` relaxes accordingly.
+- Registration is **explicit**: a system operator registers the managed identity's `oid`
+  through the system console. Trust-on-first-use via Entra app-role assignment was
+  rejected — it would move the machine-registry authority out of kinotic.
+- The kinotic-side `enabled` flag remains a kill switch independent of Entra.
+- APPLICATION machines keep client credentials (org customers have no access to our
+  tenant), as does any non-Azure deployment of vm-manager.
+
+### 5. `app-api` is dual-hosted
+
+kinotic-persistence's three app-api services (`JsonEntitiesRepository`,
+`AdminJsonEntitiesRepository`, `NamedQueriesService`) are assembled on **both**
+`kinotic-app-server` and `kinotic-org-server`. They are stateless over the shared entity ES,
+so the portal's entity browsing is served locally on the OS bus while app clients
+are served on the app bus. With separate buses this is required, not optional.
+
+### 6. GitHub module stays on the org plane; workers get tokens, never services
+
+Of kinotic-github's responsibilities, four pin to the org plane without tension: the
+webhook handler (GitHub must reach it from the internet; the system gateway is VPN'd),
+the install flow, the repo provisioner, and installation/repo state writes.
+
+The cross-cutting fifth — repo credentials for workloads — is handled at **dispatch
+time**: when the org plane dispatches a job, it mints the short-lived GitHub
+installation token and passes it by **secret reference** (`SecretStorageService` /
+`SecretReferenceResolver`), which the vm node resolves at execution. Workers never call
+GitHub services; the credential is the entire interface. If a job class ever outlives
+the ~1h token TTL, the planned evolution is extracting a `github-core` token library
+into the system-server assembly (it can read installation rows from shared os-data ES) — not a
+cross-plane call path.
+
+`GitHubProjectRepoService` stays unpublished.
+
+### 7. Job pipeline and the narrow waist
+
+```text
+GitHub → webhook handler (org plane) → JobDispatchService → grind engine
+       → WorkloadOrchestrationService → VmManagerProxy(@Scope nodeId) → vm-manager → workload
+```
+
+All hops are on the OS bus. Although the shared bus makes the orchestration
+services directly reachable, the webhook and re-run paths go **only** through
+`JobDispatchService` — a deliberately narrow contract (roughly
+`dispatch(trigger, projectId, secretRefs) → jobRunId`, `watch(jobRunId) → stream`).
+The org plane reports that a job is warranted; the system plane owns what a job *is*.
+This narrow waist is also the exit hatch: if the planes ever need physical separation
+(§ Alternatives), it is already the bridge contract.
+
+User-facing re-runs enter through a small os-api-zone service that verifies the caller's
+org owns the `JobRun` (read from shared ES) before forwarding. Live status streams over
+the bus (`watch`); shared ES serves only cold reads (history pages, ownership checks).
+The current `evt://github/...` fan-out (which has zero subscribers) is replaced by the
+explicit dispatch call. Webhook dispatch remains at-most-once, matching today's
+semantics; a durable dispatch-outbox in ES is the designated upgrade if a lost event
+ever costs something.
+
+### 8. Supervisor RBAC, and narrowing machine authority
+
+Declarative access control is added at the `ServiceInvocationSupervisor` — the one place
+that already resolves the calling `Participant` for injection:
+
+- `@Publish`ed interfaces declare their required participant type/roles once, replacing
+  the hand-written `requireParticipant`/`requireUserParticipant` scatter and covering
+  the services the inventory found guarded by zone alone (`MigrationService`,
+  `AdminJsonEntitiesRepository`, both orchestration services, `LogManager`,
+  `KinoticClusterInfoService`).
+- The long-empty `Participant.roles` field starts carrying data.
+- **Machine participants lose blanket authority.** Today `ZoneRules` gives every
+  `SystemParticipant` `sendAnyZone = true`; on a shared OS bus, a workload
+  escaping its sandbox would inherit a connection that can invoke anything. Machines get
+  role-narrowed grants instead — vm-manager may invoke `VmNodeOrchestrationService` and
+  host its own scoped `VmManager`, nothing else.
+- Server-initiated in-cluster calls get a defined **node identity** (today they carry no
+  participant at all), which is what the webhook→dispatch path invokes with.
+
+### 9. No org↔app connection; shared data stores are the only coupling
+
+- Both sides mount **os-data ES**: the OS core reads/writes identities, OIDC
+  configs, machine credentials, entity definitions, job runs; the app plane reads
+  identities (login verification) and entity-definition/named-query metadata (the
+  repositories need it to operate).
+- Org plane and app plane both mount **entity ES** (portal browsing, migrations,
+  insights vs. tenant data operations).
+- The app plane's store access rides a **least-privilege ES principal from day one**: an
+  index-scoped role granting read/write on entity indices and read-only on exactly the
+  os-data indices it needs (identities, entity definitions, named queries). This needs
+  only index-level RBAC and API keys — Elasticsearch's free Basic tier — with security
+  enabled on the deployed clusters (the dev compose keeps it off). Index-scoped roles
+  work within a single cluster — this does not wait for the cluster split; the split
+  later adds physical separation on top.
+- The planned os-data / entity-data ES cluster split must preserve the app plane's
+  os-data **read** access — it is a two-cluster split that app-server mounts both of,
+  not one-cluster-per-plane.
+- Org participants' currently-granted (and provably unused) ability to address
+  `app.<org>.*` zones is severed. If a real org→app use case appears (support tooling),
+  the decision then is a machine-bridge vs. relaxing `AppSecurityService` — neither is
+  built ahead of a consumer.
+
+## Topology
+
+```mermaid
+flowchart TB
+  %% ═════════════ INTERNET — untrusted ═════════════
+  custS["Customer microservices<br/>+ app machines"]
+  appU["App end users"]
+  gh["GitHub webhooks"]
+  orgU["Org users (portal SPA)"]
+  cliU["CLI / MCP hosts"]
+  sysU["System users<br/>(system console)"]
+
+  %% public ingress — never touches the VPN
+  custS & appU ==>|"public HTTPS"| appgw
+  gh ==>|"public HTTPS + HMAC"| osgw
+  orgU & cliU ==>|"public HTTPS"| osgw
+  %% the ONLY internet path to the system plane
+  sysU ==>|"VPN tunnel"| vpn
+
+  subgraph vnet["KINOTIC OS — private Azure VNet, no other inbound"]
+    direction TB
+
+    subgraph appisland["APP PLANE — isolated island"]
+      appgw["kinotic-app-server (public gateway)<br/>AppSecurityService: app participants ONLY<br/>app-api · app.&lt;org&gt;.&lt;app&gt; customer zones"]
+      abus(["APP BUS — Vert.x cluster B"])
+      appgw --- abus
+    end
+
+    subgraph oscore["OS CORE"]
+      osgw["kinotic-org-server (public gateway)<br/>OrgSecurityService: org users · delegates · machine creds<br/>os-api zone · GitHub webhook · app-api (dual-hosted)"]
+      vpn{{"VPN<br/>gateway"}}
+      sysgw["kinotic-system-server — NO public listener<br/>SystemSecurityService: Entra SSO + workload identity ONLY<br/>system zone · orchestrator · system console"]
+      pbus(["OS BUS — Vert.x cluster A · zone rules + supervisor RBAC"])
+      vpn ==> sysgw
+      osgw --- pbus
+      sysgw --- pbus
+      osgw -->|"job dispatch — narrow waist,<br/>node identity under RBAC"| sysgw
+    end
+
+    subgraph wnodes["WORKLOAD NODES (Azure VMs)"]
+      vmm["vm-manager<br/>Entra workload identity"]
+      box["workloads — sandboxed (boxlite)<br/>repo access via secret-ref tokens"]
+      vmm --- box
+    end
+    vmm -->|"VNet-internal (no VPN)<br/>Entra token on upgrade"| sysgw
+    sysgw -->|"VmManagerProxy<br/>@Scope nodeId"| vmm
+
+    subgraph stores["SHARED DATA — the only coupling between the buses"]
+      oses[("os-data ES")]
+      entes[("entity ES")]
+      loki[("Loki logs")]
+    end
+    osgw -.- oses
+    osgw -.- entes
+    sysgw -.- oses
+    sysgw -.- loki
+    appgw -.-|"persistence services: every query participant-scoped<br/>index-scoped creds · os-data read-only"| entes
+    appgw -.- oses
+    box -.- loki
+  end
+
+
+  %% ── theme-stable styling ──
+  classDef client fill:#f8fafc,stroke:#94a3b8,color:#0f172a
+  class orgU,cliU,gh,sysU,appU,custS client
+  style vnet      fill:#f1f5f9,stroke:#64748b,color:#0f172a
+  style oscore    fill:#e0e7ff,stroke:#4f46e5,color:#1e1b4b
+  style appisland fill:#dcfce7,stroke:#16a34a,color:#14532d
+  style osgw      fill:#ffffff,stroke:#6366f1,color:#1e1b4b
+  style sysgw     fill:#ffffff,stroke:#7c3aed,color:#2e1065
+  style appgw     fill:#ffffff,stroke:#22c55e,color:#14532d
+  style pbus      fill:#c7d2fe,stroke:#4f46e5,color:#1e1b4b
+  style abus      fill:#bbf7d0,stroke:#16a34a,color:#14532d
+  style wnodes    fill:#fef3c7,stroke:#d97706,color:#451a03
+  style stores    fill:#fce7f3,stroke:#db2777,color:#500724
+  style vpn       fill:#fee2e2,stroke:#dc2626,color:#450a0a
+```
+
+**Defense in depth, layer by layer:**
+
+1. **Network** — two public HTTPS gateways plus the VPN gate; the system gateway is VPN/VNet-only; the two buses are never linked.
+2. **Authentication** — a dedicated `SecurityService` per plane; each speaks only its participant types.
+3. **Authorization** — zone rules + supervisor RBAC; machine identities role-narrowed, one per node.
+4. **Isolation** — workloads sandboxed; credentials reach them only as short-lived secret references.
+5. **Data** — every access scoped System, Org, or App over shared clusters, with
+   least-privilege storage principals underneath.
+
+In OS terms: the system plane is kernel space — privileged, no public listener — and
+applications run in user space on their own bus.
+
+## Alternatives considered
+
+- **Three buses (full physical separation).** Strongest isolation; rejected for its tax:
+  a Java remote client as required plumbing, cross-plane contracts, and cross-process
+  timing couplings — for a boundary (org↔system) where both sides are our own
+  authenticated constituents. Kept as the designated evolution; the `JobDispatchService`
+  narrow waist is its ready-made bridge contract, and a Java Kinotic client remains
+  attractive independently as a customer-facing JVM SDK.
+- **One bus for everything, RBAC only.** Cheapest; rejected because the app plane
+  terminates arbitrary customer code, and a missed annotation there would be a privilege
+  escalation into workload orchestration. The trust boundary belongs between "our code"
+  and "their code".
+- **ES-projection return path for job status.** Rejected — it is a polling loop wearing
+  a database. Live status streams over the bus; ES serves cold reads only.
+- **Enrollment-style machine provisioning (bootstrap tokens, orchestrator-injected
+  secrets).** Superseded by workload-identity federation (§4), which eliminates the
+  secret lifecycle those options existed to manage.
+
+## Accepted residual risks
+
+- A compromised org-gateway node has OS-bus reach toward the system zone, bounded
+  by supervisor RBAC, the narrow waist, and the VPN'd system gateway — not by the
+  network. Accepted because the org surface is authenticated and far narrower than the
+  app surface.
+- Even index-scoped, `kinotic-app-server`'s ES principal spans every org's entity
+  indices — per-org isolation inside entity ES is enforced by the persistence services'
+  participant scoping, not by the store. Accepted as the standard multi-tenant
+  data-plane shape; the per-org/app index layout keeps a per-tenant-credential
+  evolution open if it is ever warranted.
+- The vm-manager heartbeat interval (node-side) and heartbeat timeout (server-side)
+  become a cross-process timing contract; a config mismatch silently marks healthy nodes
+  OFFLINE and fails their workloads.
+
+## Pre-work: defects the inventory surfaced
+
+These predate the split and should be fixed (or verified) before or alongside it:
+
+1. **Dangling TS proxies.** `IVmNodeService`/`IWorkloadService` target Java classes that
+   do not exist; `IOrganizationService` targets an unpublished service; `LogManager` TS
+   says os-api while Java says system; `LogService` is not wired into `OsApiPlugin`.
+   Delete or repair.
+2. **`DefaultLogService` → orchestrator `WorkloadService.findById`** is the single
+   in-process cross-plane edge in the codebase (authorization read of
+   `workload.organizationId`). Replace with a read of the workload row from shared ES;
+   this also lets os-api drop its build dependency on kinotic-orchestrator.
+3. **Zone-only-guarded services** (no in-method participant check):
+   `MigrationService`, `AdminJsonEntitiesRepository`, `WorkloadOrchestrationService`,
+   `VmNodeOrchestrationService`, `LogManager`, `KinoticClusterInfoService` — their
+   access control today is the zone rules alone.
+4. **`ITestService` ships in kinotic-server's main sources** on the os-api zone. Confirm
+   its gating, or move it out of main.
+
+## Open items
+
+- `JobDispatchService` contract details (trigger shape, watch semantics, error model).
+- System-console UX for machine registration (oid entry vs. Entra Graph pick-list).
+- Sequencing against the ES cluster split (os-data / entity-data).
+- Whether the system-user SSO config and the machine-federation trust are one
+  `OidcConfiguration` row or two rows sharing the new unscoped type.

--- a/website/app/components/content/ArchitectureDiagram.vue
+++ b/website/app/components/content/ArchitectureDiagram.vue
@@ -1,0 +1,269 @@
+<template>
+  <div class="arch-diagram-wrap">
+    <svg class="arch-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1172 825" role="img" aria-label="Kinotic three-plane network architecture: internet clients reach two public gateways over HTTPS; the system server is reachable only through a VPN gate or from inside the Azure VNet; the app plane is an isolated island; shared data stores are the only coupling between the buses.">
+
+      <defs>
+        <marker id="ma-ink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <polygon class="mk-ink" points="0,0 10,5 0,10"></polygon>
+        </marker>
+        <marker id="ma-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <polygon class="mk-red" points="0,0 10,5 0,10"></polygon>
+        </marker>
+        <marker id="ma-ind" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <polygon class="mk-ind" points="0,0 10,5 0,10"></polygon>
+        </marker>
+        <marker id="ma-vio" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <polygon class="mk-vio" points="0,0 10,5 0,10"></polygon>
+        </marker>
+      </defs>
+
+      <!-- ═════════ internet band ═════════ -->
+      <text class="t-tag" x="24" y="26">INTERNET · UNTRUSTED</text>
+
+      <rect class="chip" x="40" y="44" width="205" height="46" rx="8"></rect>
+      <text class="t-chip" x="142" y="63" text-anchor="middle">Customer microservices</text>
+      <text class="t-sub"  x="142" y="79" text-anchor="middle">+ app machines</text>
+
+      <rect class="chip" x="262" y="44" width="118" height="46" rx="8"></rect>
+      <text class="t-chip" x="321" y="72" text-anchor="middle">App end users</text>
+
+      <rect class="chip" x="396" y="44" width="146" height="46" rx="8"></rect>
+      <text class="t-chip" x="469" y="72" text-anchor="middle">GitHub webhooks</text>
+
+      <rect class="chip" x="560" y="44" width="150" height="46" rx="8"></rect>
+      <text class="t-chip" x="635" y="72" text-anchor="middle">Org users · portal</text>
+
+      <rect class="chip" x="728" y="44" width="140" height="46" rx="8"></rect>
+      <text class="t-chip" x="798" y="72" text-anchor="middle">CLI / MCP hosts</text>
+
+      <rect class="chip" x="955" y="44" width="160" height="46" rx="8"></rect>
+      <text class="t-chip" x="1035" y="63" text-anchor="middle">System users</text>
+      <text class="t-sub"  x="1035" y="79" text-anchor="middle">system console</text>
+
+      <!-- public ingress arrows (never through the VPN) -->
+      <line class="flow" x1="142" y1="90" x2="142" y2="246" marker-end="url(#ma-ink)"></line>
+      <line class="flow" x1="321" y1="90" x2="321" y2="246" marker-end="url(#ma-ink)"></line>
+      <line class="flow" x1="469" y1="90" x2="469" y2="246" marker-end="url(#ma-ink)"></line>
+      <line class="flow" x1="635" y1="90" x2="635" y2="246" marker-end="url(#ma-ink)"></line>
+      <line class="flow" x1="798" y1="90" x2="775" y2="246" marker-end="url(#ma-ink)"></line>
+      <!-- the only internet path to the system plane -->
+      <line class="flow-red" x1="1035" y1="90" x2="1035" y2="154" marker-end="url(#ma-red)"></line>
+
+      <!-- ═════════ VNet wall ═════════ -->
+      <rect class="wall" x="24" y="170" width="1124" height="618" rx="12"></rect>
+      <text class="t-tag" x="36" y="196">KINOTIC OS · PRIVATE AZURE VNET — NO OTHER INBOUND</text>
+
+      <!-- listener labels at the wall crossings -->
+      <text class="t-tiny" x="152" y="164">:443</text>
+      <text class="t-tiny" x="479" y="164">:443</text>
+      <text class="t-tiny" x="645" y="164">:443</text>
+      <text class="t-tiny" x="797" y="164">:443</text>
+
+      <!-- ═════════ app plane island ═════════ -->
+      <rect class="encl-app" x="40" y="214" width="330" height="372" rx="10"></rect>
+      <text class="t-plane-a" x="56" y="238">APP PLANE — ISOLATED ISLAND</text>
+
+      <rect class="gw gw-app" x="60" y="250" width="290" height="112" rx="8"></rect>
+      <text class="t-name" x="205" y="273" text-anchor="middle">kinotic-app-server</text>
+      <text class="t-sub"  x="205" y="289" text-anchor="middle">public gateway</text>
+      <line class="sep" x1="78" y1="298" x2="332" y2="298"></line>
+      <text class="t-mono" x="205" y="315" text-anchor="middle">AppSecurityService · app participants only</text>
+      <text class="t-mono" x="205" y="330" text-anchor="middle">app-api zone</text>
+      <text class="t-mono" x="205" y="345" text-anchor="middle">app.&lt;org&gt;.&lt;app&gt; customer zones</text>
+
+      <line class="link" x1="205" y1="362" x2="205" y2="430"></line>
+      <rect class="bus-a" x="60" y="430" width="290" height="32" rx="16"></rect>
+      <text class="t-bus t-bus-a" x="205" y="450" text-anchor="middle">APP BUS · VERT.X CLUSTER B</text>
+
+      <!-- ═════════ platform plane ═════════ -->
+      <rect class="encl-plat" x="400" y="214" width="736" height="372" rx="10"></rect>
+      <text class="t-plane-p" x="416" y="238">OS CORE</text>
+
+      <rect class="gw gw-os" x="430" y="250" width="360" height="112" rx="8"></rect>
+      <text class="t-name" x="610" y="273" text-anchor="middle">kinotic-org-server</text>
+      <text class="t-sub"  x="610" y="289" text-anchor="middle">public gateway</text>
+      <line class="sep" x1="448" y1="298" x2="772" y2="298"></line>
+      <text class="t-mono" x="610" y="315" text-anchor="middle">OrgSecurityService · org users · delegates · machines</text>
+      <text class="t-mono" x="610" y="330" text-anchor="middle">os-api zone · GitHub webhook (HMAC)</text>
+      <text class="t-mono" x="610" y="345" text-anchor="middle">app-api (dual-hosted)</text>
+
+      <!-- system enclosure: the inner boundary -->
+      <rect class="encl-sys" x="884" y="226" width="236" height="276" rx="10"></rect>
+      <text class="t-plane-s" x="896" y="246">VPN + VNET-INTERNAL ONLY</text>
+
+      <rect class="gw gw-sys" x="900" y="260" width="204" height="130" rx="8"></rect>
+      <text class="t-name" x="1002" y="282" text-anchor="middle">kinotic-system-server</text>
+      <text class="t-no"   x="1002" y="299" text-anchor="middle">NO public listener</text>
+      <line class="sep" x1="916" y1="308" x2="1088" y2="308"></line>
+      <text class="t-mono" x="1002" y="324" text-anchor="middle">SystemSecurityService</text>
+      <text class="t-mono" x="1002" y="339" text-anchor="middle">Entra SSO · workload identity</text>
+      <text class="t-mono" x="1002" y="354" text-anchor="middle">system zone · orchestrator</text>
+      <text class="t-mono" x="1002" y="369" text-anchor="middle">system console SPA</text>
+
+      <!-- VPN gate straddling the wall -->
+      <polygon class="vpn" points="1003,178 1019,156 1051,156 1067,178 1051,200 1019,200"></polygon>
+      <text class="t-vpn" x="1035" y="182" text-anchor="middle">VPN</text>
+      <line class="flow-red" x1="1035" y1="200" x2="1035" y2="254" marker-end="url(#ma-red)"></line>
+
+      <!-- narrow waist dispatch -->
+      <line class="flow-ind" x1="790" y1="306" x2="894" y2="306" marker-end="url(#ma-ind)"></line>
+      <text class="t-tiny" x="840" y="290" text-anchor="middle">job dispatch</text>
+      <text class="t-tiny" x="840" y="326" text-anchor="middle">narrow waist</text>
+      <text class="t-tiny" x="840" y="338" text-anchor="middle">RBAC</text>
+
+      <!-- platform bus -->
+      <line class="link" x1="610" y1="362" x2="610" y2="520"></line>
+      <line class="link" x1="930" y1="390" x2="930" y2="520"></line>
+      <rect class="bus-p" x="430" y="520" width="560" height="32" rx="16"></rect>
+      <text class="t-bus t-bus-p" x="710" y="540" text-anchor="middle">OS BUS · VERT.X CLUSTER A — ZONE RULES + RBAC</text>
+
+      <!-- ═════════ workload nodes ═════════ -->
+      <rect class="wbox" x="808" y="600" width="312" height="112" rx="10"></rect>
+      <text class="t-plane-w" x="964" y="621" text-anchor="middle">WORKLOAD NODES · AZURE VMS</text>
+      <rect class="chip" x="824" y="634" width="138" height="62" rx="8"></rect>
+      <text class="t-chip" x="893" y="654" text-anchor="middle">vm-manager</text>
+      <text class="t-tiny" x="893" y="670" text-anchor="middle">Entra workload</text>
+      <text class="t-tiny" x="893" y="682" text-anchor="middle">identity</text>
+      <rect class="chip" x="972" y="634" width="134" height="62" rx="8"></rect>
+      <text class="t-chip" x="1039" y="652" text-anchor="middle">workloads</text>
+      <text class="t-tiny" x="1039" y="667" text-anchor="middle">boxlite sandbox</text>
+      <text class="t-tiny" x="1039" y="681" text-anchor="middle">secret-ref tokens</text>
+
+      <!-- vm-manager ↔ system server (VNet-internal, no VPN) -->
+      <line class="flow-vio" x1="1015" y1="600" x2="1015" y2="504" marker-end="url(#ma-vio)"></line>
+      <line class="flow-vio" x1="1062" y1="504" x2="1062" y2="598" marker-end="url(#ma-vio)"></line>
+      <text class="t-tiny" x="1008" y="566" text-anchor="end">Entra token</text>
+      <text class="t-tiny" x="1008" y="578" text-anchor="end">VNet-internal</text>
+      <text class="t-tiny" x="1069" y="554">start</text>
+      <text class="t-tiny" x="1069" y="566">workloads</text>
+      <text class="t-tiny" x="1069" y="578">@node</text>
+
+      <!-- ═════════ shared data ═════════ -->
+      <text class="t-tag" x="40" y="636">SHARED DATA</text>
+
+      <!-- every store sits behind one enforcement point; no line touches a store directly -->
+      <rect class="acl" x="150" y="646" width="570" height="42" rx="21"></rect>
+      <text class="t-acl" x="435" y="663" text-anchor="middle">SCOPED ACCESS — SYSTEM · ORG · APP</text>
+      <text class="t-tiny" x="435" y="679" text-anchor="middle">the only coupling between the buses</text>
+
+      <!-- entity ES -->
+      <path class="cyl" d="M 194 714 a 56 9 0 0 0 112 0 v 38 a 56 9 0 0 1 -112 0 z"></path>
+      <ellipse class="cyl" cx="250" cy="714" rx="56" ry="9"></ellipse>
+      <text class="t-chip" x="250" y="740" text-anchor="middle">entity ES</text>
+      <text class="t-tiny" x="250" y="776" text-anchor="middle">tenant entity data</text>
+
+      <!-- os-data ES -->
+      <path class="cyl" d="M 414 714 a 56 9 0 0 0 112 0 v 38 a 56 9 0 0 1 -112 0 z"></path>
+      <ellipse class="cyl" cx="470" cy="714" rx="56" ry="9"></ellipse>
+      <text class="t-chip" x="470" y="740" text-anchor="middle">os-data ES</text>
+      <text class="t-tiny" x="470" y="776" text-anchor="middle">identities · configs · defs · job runs</text>
+
+      <!-- Loki -->
+      <path class="cyl" d="M 604 714 a 56 9 0 0 0 112 0 v 38 a 56 9 0 0 1 -112 0 z"></path>
+      <ellipse class="cyl" cx="660" cy="714" rx="56" ry="9"></ellipse>
+      <text class="t-chip" x="660" y="740" text-anchor="middle">Loki logs</text>
+      <text class="t-tiny" x="660" y="776" text-anchor="middle">workload logs</text>
+
+      <!-- data access: one dotted line per plane, terminating at the principal bar -->
+      <line class="data" x1="205" y1="462" x2="240" y2="644"></line>
+      <text class="t-tiny" x="228" y="536">entity R/W</text>
+      <text class="t-tiny" x="228" y="548">os-data read-only</text>
+      <line class="data" x1="610" y1="552" x2="540" y2="644"></line>
+      <line class="data" x1="808" y1="678" x2="722" y2="662"></line>
+      <text class="t-tiny" x="766" y="654" text-anchor="middle">logs</text>
+    </svg>
+  </div>
+</template>
+
+<style>
+/* Palette follows the site color-mode class, so the diagram tracks the theme toggle. */
+svg.arch-diagram {
+    --bg: #F6F7F9;
+    --surface: #FFFFFF;
+    --ink: #1A2332;
+    --muted: #5C6879;
+    --line: #D8DDE5;
+    --indigo: #4A5FD0;
+    --indigo-tint: rgba(74, 95, 208, 0.10);
+    --green: #2C8F5E;
+    --green-tint: rgba(44, 143, 94, 0.10);
+    --violet: #7C4FD0;
+    --violet-tint: rgba(124, 79, 208, 0.08);
+    --red: #C64A4A;
+    --red-tint: rgba(198, 74, 74, 0.10);
+    --amber: #A97C22;
+    --amber-tint: rgba(169, 124, 34, 0.10);
+    --pink: #B0487E;
+    --vnet-tint: rgba(100, 116, 139, 0.07);
+}
+.dark svg.arch-diagram {
+  --bg: #0D1320;
+  --surface: #151D2D;
+  --ink: #E6EBF4;
+  --muted: #96A2B6;
+  --line: #2B3648;
+  --indigo: #7E8EF0;
+  --indigo-tint: rgba(126, 142, 240, 0.14);
+  --green: #48B482;
+  --green-tint: rgba(72, 180, 130, 0.13);
+  --violet: #A47EF0;
+  --violet-tint: rgba(164, 126, 240, 0.12);
+  --red: #E06A6A;
+  --red-tint: rgba(224, 106, 106, 0.14);
+  --amber: #D3A24C;
+  --amber-tint: rgba(211, 162, 76, 0.13);
+  --pink: #D879AC;
+  --vnet-tint: rgba(148, 163, 184, 0.08);
+}
+
+.arch-diagram-wrap { overflow-x: auto; }
+svg.arch-diagram { min-width: 700px; width: 100%; height: auto; display: block; }
+
+  /* ── SVG vocabulary ─────────────────────────────── */
+  svg.arch-diagram .wall      { fill: var(--vnet-tint); stroke: var(--line); stroke-width: 1.5; }
+  svg.arch-diagram .chip      { fill: var(--surface); stroke: var(--line); stroke-width: 1.25; }
+  svg.arch-diagram .gw        { fill: var(--surface); stroke-width: 2; }
+  svg.arch-diagram .gw-os     { stroke: var(--indigo); }
+  svg.arch-diagram .gw-sys    { stroke: var(--violet); }
+  svg.arch-diagram .gw-app    { stroke: var(--green); }
+  svg.arch-diagram .encl-app  { fill: var(--green-tint);  stroke: var(--green);  stroke-width: 1.25; stroke-dasharray: 6 5; }
+  svg.arch-diagram .encl-plat { fill: var(--indigo-tint); stroke: var(--indigo); stroke-width: 1.25; stroke-dasharray: 6 5; }
+  svg.arch-diagram .encl-sys  { fill: var(--violet-tint); stroke: var(--violet); stroke-width: 1.5;  stroke-dasharray: 6 5; }
+  svg.arch-diagram .bus-p     { fill: var(--indigo-tint); stroke: var(--indigo); stroke-width: 1.5; }
+  svg.arch-diagram .bus-a     { fill: var(--green-tint);  stroke: var(--green);  stroke-width: 1.5; }
+  svg.arch-diagram .wbox      { fill: var(--amber-tint);  stroke: var(--amber);  stroke-width: 1.5; }
+  svg.arch-diagram .vpn       { fill: var(--red-tint);    stroke: var(--red);    stroke-width: 2; }
+  svg.arch-diagram .cyl       { fill: var(--surface); stroke: var(--pink); stroke-width: 1.5; }
+  svg.arch-diagram .acl       { fill: var(--surface); stroke: var(--pink); stroke-width: 1.5; }
+  svg.arch-diagram .t-acl     { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; letter-spacing: 0.1em; font-weight: 600; fill: var(--pink); }
+  svg.arch-diagram .sep       { stroke: var(--line); stroke-width: 1; }
+
+  svg.arch-diagram .flow      { stroke: var(--ink);    stroke-width: 1.6; fill: none; }
+  svg.arch-diagram .flow-red  { stroke: var(--red);    stroke-width: 2;   fill: none; }
+  svg.arch-diagram .flow-ind  { stroke: var(--indigo); stroke-width: 1.8; fill: none; }
+  svg.arch-diagram .flow-vio  { stroke: var(--violet); stroke-width: 1.6; fill: none; }
+  svg.arch-diagram .link      { stroke: var(--muted);  stroke-width: 1.4; fill: none; }
+  svg.arch-diagram .data      { stroke: var(--muted);  stroke-width: 1.3; fill: none; stroke-dasharray: 2 4; stroke-linecap: round; }
+
+  svg.arch-diagram .mk-ink { fill: var(--ink); }
+  svg.arch-diagram .mk-red { fill: var(--red); }
+  svg.arch-diagram .mk-ind { fill: var(--indigo); }
+  svg.arch-diagram .mk-vio { fill: var(--violet); }
+
+  svg.arch-diagram text { font-family: "Avenir Next", "Segoe UI", system-ui, sans-serif; }
+  svg.arch-diagram .t-name  { font-size: 13px; font-weight: 600; fill: var(--ink); }
+  svg.arch-diagram .t-sub   { font-size: 11px; fill: var(--muted); }
+  svg.arch-diagram .t-chip  { font-size: 12px; font-weight: 500; fill: var(--ink); }
+  svg.arch-diagram .t-mono  { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; fill: var(--muted); }
+  svg.arch-diagram .t-tag   { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; letter-spacing: 0.14em; fill: var(--muted); }
+  svg.arch-diagram .t-tiny  { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 9.5px; fill: var(--muted); }
+  svg.arch-diagram .t-bus   { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; letter-spacing: 0.1em; font-weight: 600; }
+  svg.arch-diagram .t-bus-p { fill: var(--indigo); }
+  svg.arch-diagram .t-bus-a { fill: var(--green); }
+  svg.arch-diagram .t-plane-p { font-family: ui-monospace, Menlo, monospace; font-size: 11px; letter-spacing: 0.14em; font-weight: 600; fill: var(--indigo); }
+  svg.arch-diagram .t-plane-a { font-family: ui-monospace, Menlo, monospace; font-size: 11px; letter-spacing: 0.14em; font-weight: 600; fill: var(--green); }
+  svg.arch-diagram .t-plane-s { font-family: ui-monospace, Menlo, monospace; font-size: 9.5px; letter-spacing: 0.1em; font-weight: 600; fill: var(--violet); }
+  svg.arch-diagram .t-plane-w { font-family: ui-monospace, Menlo, monospace; font-size: 11px; letter-spacing: 0.12em; font-weight: 600; fill: var(--amber); }
+  svg.arch-diagram .t-vpn   { font-size: 11px; font-weight: 700; fill: var(--red); }
+  svg.arch-diagram .t-no    { font-size: 11px; font-weight: 700; fill: var(--violet); }
+</style>

--- a/website/content/02.platform/06.defense-in-depth.md
+++ b/website/content/02.platform/06.defense-in-depth.md
@@ -14,6 +14,23 @@ Two principles run through all of it:
 - **Enforcement is structural, not pattern-based.** Authorization decisions read typed values — the participant type, the zone parsed from the [CRI](/platform/reference/cri-format) — never string patterns a crafted input might slip past.
 - **Internal faults are logged, not leaked.** When an internal invariant is violated, the full detail (CRIs, ids) goes to the server log for operators, and the caller receives a generic error indistinguishable from a routine failure.
 
+## Network Architecture
+
+The target deployment shape gives every participant type its own plane — its own server, gateway, and credential surface — so isolation comes from what code exists where and what listens where, not from configuration flags.
+
+::architecture-diagram
+::
+
+Reading the diagram: solid lines are network paths (every internet crossing is one of two public HTTPS listeners, or the VPN gate); dotted lines are data access; dashed enclosures are security boundaries. The system server has no public listener — its only ingress is the VPN gate for operators, the VNet-internal path from workload nodes, and the OS-bus cluster interconnect. The two buses are never linked; shared data stores — every access scoped System, Org, or App — are the only coupling between the buses.
+
+The layers, from the outside in:
+
+1. **Network** — three internet ingress points: two public HTTPS gateways and a VPN gate. The system server is reachable only through the VPN or from inside the VNet; the two buses are never linked.
+2. **Authentication** — a dedicated SecurityService per plane; each accepts only its own participant types, with the others' code absent, not disabled.
+3. **Authorization** — zone rules plus service-level RBAC; machine identities are role-narrowed, one identity per node, instantly revocable.
+4. **Isolation** — workloads run sandboxed; credentials reach them only as short-lived secret references, resolved at execution.
+5. **Data** — every access scoped System, Org, or App over shared clusters, with least-privilege storage principals underneath.
+
 ## Zone Authorization
 
 Every routable address carries its zone in the CRI itself, so the isolation boundary travels with the message and is validated wherever the message goes. Which zones a participant may address is derived from the participant type in one place — `ZoneRules` — and every enforcement point uses that same derivation. The full participant × zone matrix is in the [CRI format reference](/platform/reference/cri-format).


### PR DESCRIPTION
Adds `docs/ServerPlaneArchitecture.md` — the decision record from the server-plane design session. Documentation only; nothing here is implemented yet.

The record captures:

- **Kinotic OS naming convention** — "OS" names the whole system; each deployable is named for its plane: `kinotic-org-server` (today's `kinotic-server`, renamed), `kinotic-system-server`, `kinotic-app-server`. `os-api` / `os-data` keep their prefix as names for the OS as a whole.
- **Two Vert.x-clustered buses** split along the trust gradient: the OS bus (org + system + vm-manager — the OS core) and the app bus (`kinotic-app-server` alone), never linked; shared, principal-scoped data stores are the only coupling between the buses.
- **One `SecurityService` per plane, selected by assembly** — `OrgSecurityService` (renamed from `KinoticSecurityService`), `SystemSecurityService` (Entra SSO + workload identity only), `AppSecurityService` (app participants only).
- **SYSTEM machines authenticate with Entra workload identity** (E-direct) — no secrets, explicit registration, `enabled` kill switch.
- **Job pipeline through the `JobDispatchService` narrow waist**, supervisor RBAC with role-narrowed machine authority, dual-hosted `app-api`, GitHub module staying on the org plane with dispatch-time secret references.
- **Topology diagram**, alternatives considered, accepted residual risks, pre-work defects the service inventory surfaced, and open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh

---
_Generated by [Claude Code](https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh)_