### PR TITLE
One-origin tunnel dev: vite proxy for GitHub/OIDC callbacks

### DIFF
--- a/kinotic-frontend/apps/portal/.env.tunnel
+++ b/kinotic-frontend/apps/portal/.env.tunnel
@@ -1,0 +1,7 @@
+# Tunnel mode: SPA and backend behind ONE origin (ngrok -> vite dev server -> kinotic-server).
+# Clearing the host makes apiUrl() and Kinotic.connect() resolve same-origin, so the vite
+# proxy (vite.config.ts server.proxy) carries /api, /v1 (WebSocket), /.well-known, and /mcp
+# to the local kinotic-server.
+VITE_KINOTIC_HOST=
+VITE_KINOTIC_PORT=
+VITE_KINOTIC_USE_SSL=

--- a/kinotic-frontend/apps/portal/ENV_SETUP.md
+++ b/kinotic-frontend/apps/portal/ENV_SETUP.md
@@ -7,11 +7,38 @@ This document explains how to configure the Continuum WebSocket connection using
 | Command | Environment | Use Case |
 |---------|-------------|----------|
 | `npm run dev` | `.env.development` | Local development with default settings |
+| `npm run dev:tunnel` | `.env.tunnel` | One-origin dev behind an ngrok tunnel (GitHub/OIDC callbacks) |
 | `npm run dev:kind` | `.env.kind` | Development against Kind cluster |
 | `npm run build` | `.env` | Production build |
 | `npm run build:kind` | `.env.kind` | Build for Kind cluster deployment |
 | `npm run preview` | Production build | Preview production build locally |
 | `npm run preview:kind` | Kind build | Preview kind build locally |
+
+## Tunnel Mode (ngrok + GitHub/OIDC callbacks)
+
+`pnpm dev:tunnel` serves the SPA and the backend from ONE origin: `.env.tunnel` clears
+`VITE_KINOTIC_HOST`, so `apiUrl()` and `Kinotic.connect()` go same-origin, and the vite
+proxy (`vite.config.ts` `server.proxy`) forwards `/api`, `/v1` (STOMP WebSocket),
+`/.well-known`, and `/mcp` to the local kinotic-server on 58503. Every external callback
+URL can then point at a single ngrok tunnel:
+
+```bash
+pnpm dev:tunnel          # vite on :5173, proxying the backend
+ngrok http 5173          # one public origin for SPA + API
+```
+
+Then:
+
+1. Point the GitHub App / OAuth callback and webhook URLs at the ngrok origin
+   (callbacks are under `/api/...`, so they ride the proxy to kinotic-server).
+2. Set the server's `kinotic.domain.appBaseUrl` to the ngrok origin (env var
+   `KINOTIC_DOMAIN_APPBASEURL=https://<id>.ngrok-free.app`, or edit
+   `application-development.yml`) — OIDC `redirect_uri`s and email links are built
+   server-side from it, and `apiBaseUrl` falls back to it, which is correct here since
+   SPA and API share the tunnel origin.
+
+The vite dev server accepts ngrok hostnames via `server.allowedHosts`
+(`.ngrok-free.app`, `.ngrok.app`, `.ngrok.dev`, `.ngrok.io`).
 
 ## Quick Reference
 

--- a/kinotic-frontend/apps/portal/ENV_SETUP.md
+++ b/kinotic-frontend/apps/portal/ENV_SETUP.md
@@ -38,7 +38,7 @@ Then:
    SPA and API share the tunnel origin.
 
 The vite dev server accepts ngrok hostnames via `server.allowedHosts`
-(`.ngrok-free.app`, `.ngrok.app`, `.ngrok.dev`, `.ngrok.io`).
+(`.ngrok-free.app`, `.ngrok-free.dev`, `.ngrok.app`, `.ngrok.dev`, `.ngrok.io`).
 
 ## Quick Reference
 

--- a/kinotic-frontend/apps/portal/package.json
+++ b/kinotic-frontend/apps/portal/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:tunnel": "vite --mode tunnel",
     "build": "vue-tsc -b && vite build",
     "build:dev": "vue-tsc -b && vite build --mode development",
     "build:kind": "vue-tsc -b && vite build --mode kind",

--- a/kinotic-frontend/apps/portal/vite.config.ts
+++ b/kinotic-frontend/apps/portal/vite.config.ts
@@ -56,7 +56,7 @@ export default defineConfig(
             headers: {
                 'Cache-Control': 'no-store'
             },
-            allowedHosts: ['.ngrok-free.app', '.ngrok.app', '.ngrok.dev', '.ngrok.io'],
+            allowedHosts: ['.ngrok-free.app', '.ngrok-free.dev', '.ngrok.app', '.ngrok.dev', '.ngrok.io'],
             // One origin for SPA + backend, so a single ngrok tunnel to this dev server can
             // receive GitHub/OIDC callbacks: `pnpm dev:tunnel` clears VITE_KINOTIC_HOST, making
             // apiUrl() and Kinotic.connect() same-origin, and these routes forward to the local

--- a/kinotic-frontend/apps/portal/vite.config.ts
+++ b/kinotic-frontend/apps/portal/vite.config.ts
@@ -55,6 +55,20 @@ export default defineConfig(
             open: false,
             headers: {
                 'Cache-Control': 'no-store'
+            },
+            allowedHosts: ['.ngrok-free.app', '.ngrok.app', '.ngrok.dev', '.ngrok.io'],
+            // One origin for SPA + backend, so a single ngrok tunnel to this dev server can
+            // receive GitHub/OIDC callbacks: `pnpm dev:tunnel` clears VITE_KINOTIC_HOST, making
+            // apiUrl() and Kinotic.connect() same-origin, and these routes forward to the local
+            // kinotic-server. In plain `pnpm dev` the app calls localhost:58503 directly and
+            // this proxy sits idle.
+            proxy: {
+                '/api': { target: 'http://localhost:58503', changeOrigin: true },
+                // STOMP WebSocket (ApiGatewayVertcleFactory.STOMP_WEBSOCKET_PATH)
+                '/v1': { target: 'http://localhost:58503', changeOrigin: true, ws: true },
+                // OAuth 2.1 metadata + MCP endpoint, so MCP hosts can use the tunnel too
+                '/.well-known': { target: 'http://localhost:58503', changeOrigin: true },
+                '/mcp': { target: 'http://localhost:58503', changeOrigin: true },
             }
         },
         build: {

--- a/kinotic-frontend/package.json
+++ b/kinotic-frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter kinotic-portal dev",
+    "dev:tunnel": "pnpm --filter kinotic-portal dev:tunnel",
     "build": "pnpm -r build",
     "build:dev": "pnpm -r build:dev",
     "build:kind": "pnpm -r build:kind",

--- a/kinotic-frontend/packages/common/src/vite-env.d.ts
+++ b/kinotic-frontend/packages/common/src/vite-env.d.ts
@@ -1,0 +1,27 @@
+// Minimal ambient typing for the vite-injected import.meta.env, so this package type-checks
+// as its own project (IDE/editor) without a vite dependency. In an app build these interfaces
+// merge with the app's vite/client types.
+interface ImportMetaEnv {
+  readonly VITE_KINOTIC_HOST?: string
+  readonly VITE_KINOTIC_PORT?: string
+  readonly VITE_KINOTIC_USE_SSL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
+// Asset modules the components import; in an app build vite/client provides these instead
+// (this file is not part of app programs — nothing imports it, and app tsconfigs don't include it).
+declare module '*.png' {
+  const src: string
+  export default src
+}
+
+declare module '*.svg' {
+  const src: string
+  export default src
+}
+
+declare module '*.css' {}
+

--- a/kinotic-frontend/packages/common/tsconfig.json
+++ b/kinotic-frontend/packages/common/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.app-base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"]
+}

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -5,20 +5,14 @@ kinotic:
     webhookSecret: "-"
     appPrivateKey: "-"
   domain:
-    # IDE dev runs the SPA on vite (5173); kinotic-server is just the backend on 58503.
-    # appBaseUrl builds SPA links (verification emails, post-auth redirects) — the SPA's
-    # origin. apiBaseUrl builds the OAuth2/OIDC redirect_uris, which must land on the
-    # backend: the vite server has no /api proxy, so an IdP callback sent to 5173
-    # dead-ends in the SPA router. IdP callback URLs are registered against apiBaseUrl.
-    appBaseUrl: http://localhost:5173
-    apiBaseUrl: http://localhost:58503
-    oauth:
-      # An MCP host exchanges its authorization code from its own backend, which cannot reach
-      # localhost, so the OAuth surface is published on a tunnel to 58503 instead. Only the
-      # metadata, the endpoints it advertises and the /mcp resource document move — the OIDC
-      # redirect_uris stay on apiBaseUrl, so the IdP registrations above are unaffected.
-      # Set this to whichever tunnel is running, or comment it out to fall back to apiBaseUrl.
-      issuerBaseUrl: https://platinum-protector-thesis.ngrok-free.dev
+    # One-origin tunnel dev: the ngrok tunnel fronts the vite dev server (pnpm dev:tunnel),
+    # whose proxy forwards /api, /v1 (WebSocket), /.well-known, and /mcp to 58503. With
+    # appBaseUrl on the tunnel origin, apiBaseUrl and oauth.issuerBaseUrl fall back to it,
+    # so SPA links, OIDC/OAuth redirect_uris, GitHub callbacks, and the MCP surface all
+    # share the one origin. For plain localhost dev (pnpm dev, no tunnel) use instead:
+    #   appBaseUrl: http://localhost:5173
+    #   apiBaseUrl: http://localhost:58503
+    appBaseUrl: https://platinum-protector-thesis.ngrok-free.dev
     email:
       # No real ACS in dev — EmailService logs verification URLs instead of sending.
       # To test against real ACS, flip enabled=true (endpoint/sender are pre-filled).


### PR DESCRIPTION
Serves the portal SPA and the backend from a single origin during development, so one ngrok tunnel to the vite dev server carries every external callback (GitHub App, OAuth/OIDC, webhooks, MCP hosts).

## Frontend

`pnpm dev:tunnel` runs the portal in a new `tunnel` mode. `.env.tunnel` clears `VITE_KINOTIC_HOST`, which flips the existing same-origin seam — `apiUrl()` returns bare paths and `Kinotic.connect()` resolves from the page location — and the new vite proxy forwards the backend surface to `localhost:58503`:

```ts
// apps/portal/vite.config.ts
proxy: {
    '/api': { target: 'http://localhost:58503', changeOrigin: true },
    // STOMP WebSocket (ApiGatewayVertcleFactory.STOMP_WEBSOCKET_PATH)
    '/v1': { target: 'http://localhost:58503', changeOrigin: true, ws: true },
    // OAuth 2.1 metadata + MCP endpoint, so MCP hosts can use the tunnel too
    '/.well-known': { target: 'http://localhost:58503', changeOrigin: true },
    '/mcp': { target: 'http://localhost:58503', changeOrigin: true },
}
```

`server.allowedHosts` admits ngrok hostnames (`.ngrok-free.app`, `.ngrok-free.dev`, `.ngrok.app`, `.ngrok.dev`, `.ngrok.io`); everything else keeps vite's 403 host protection. Plain `pnpm dev` is unchanged — with `VITE_KINOTIC_HOST` set the app calls `:58503` directly and the proxy sits idle.

## Development properties

With the proxy in place, the split URLs collapse to one property — `apiBaseUrl` and `oauth.issuerBaseUrl` are removed and fall back to it, so SPA links, OIDC/OAuth `redirect_uri`s, GitHub callbacks, and the MCP surface all share the tunnel origin:

```yaml
# application-development.yml
appBaseUrl: https://platinum-protector-thesis.ngrok-free.dev
# localhost pair kept as a commented toggle for tunnel-less dev
```

The previous `issuerBaseUrl` tunnel-to-58503 arrangement existed only because vite had no `/api` proxy.

## Verified

- `/` serves the SPA; `/api/auth/me` through the dev server returns a proxy 502 with no backend up (forwarded, not swallowed by the SPA fallback)
- `Host: platinum-protector-thesis.ngrok-free.dev` → 200; unknown hosts → 403
- `pnpm -r build` green for both apps

Documented in `apps/portal/ENV_SETUP.md` ("Tunnel Mode" section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS

---
_Generated by [Claude Code](https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS)_