### PR TITLE
Point the portal at the published core and os-api

### DIFF
--- a/kinotic-frontend/apps/portal/package.json
+++ b/kinotic-frontend/apps/portal/package.json
@@ -13,10 +13,10 @@
   "dependencies": {
     "@headlessui/vue": "^1.7.23",
     "@heroicons/vue": "^2.2.0",
-    "@kinotic-ai/core": "^5.0.0-beta.3",
+    "@kinotic-ai/core": "^5.0.0-beta.5",
     "@kinotic-ai/frontend-common": "workspace:*",
     "@kinotic-ai/idl": "^5.0.0-beta.0",
-    "@kinotic-ai/os-api": "^5.0.0-beta.7",
+    "@kinotic-ai/os-api": "^5.0.0-beta.8",
     "@kinotic-ai/persistence": "^5.0.0-beta.3",
     "@mdi/js": "^7.4.47",
     "@primeuix/themes": "^2.0.3",

--- a/kinotic-frontend/pnpm-lock.yaml
+++ b/kinotic-frontend/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(vue@3.5.41(typescript@5.8.3))
       '@kinotic-ai/core':
-        specifier: ^5.0.0-beta.3
-        version: 5.0.0-beta.4
+        specifier: ^5.0.0-beta.5
+        version: 5.0.0-beta.5
       '@kinotic-ai/frontend-common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -26,11 +26,11 @@ importers:
         specifier: ^5.0.0-beta.0
         version: 5.0.0-beta.1
       '@kinotic-ai/os-api':
-        specifier: ^5.0.0-beta.7
-        version: 5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.4)
+        specifier: ^5.0.0-beta.8
+        version: 5.0.0-beta.8(@kinotic-ai/core@5.0.0-beta.5)
       '@kinotic-ai/persistence':
         specifier: ^5.0.0-beta.3
-        version: 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4)
+        version: 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.5)
       '@mdi/js':
         specifier: ^7.4.47
         version: 7.4.47
@@ -318,6 +318,9 @@ packages:
   '@kinotic-ai/core@5.0.0-beta.4':
     resolution: {integrity: sha512-loAF90XFnlFRxHWtsgM2lR7FXXQ1O/WBYrELu+m7kNqRayWauQhikgXbwTf+OIUze8lLypBDanaRl80Crqzd0g==}
 
+  '@kinotic-ai/core@5.0.0-beta.5':
+    resolution: {integrity: sha512-tIqDmPrE0eYgRQe9XG5MMawX8KB+74rpT55qKAIIQjDefA1j9mtHUd+/w6EhyTcXnwbFggB75j4Ma9HTwjGV0g==}
+
   '@kinotic-ai/idl@5.0.0-beta.1':
     resolution: {integrity: sha512-zM4NGbHQ5JMKYMh+SU/+Q4GL3UPZsJ5oQWbPAlzRvD9SiLzbnD9mVJpukRVbWnu7zxuk3Z6o3WNQ/7YAokEbDg==}
 
@@ -326,15 +329,20 @@ packages:
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.4'
 
-  '@kinotic-ai/os-api@5.0.0-beta.7':
-    resolution: {integrity: sha512-IUKefs7x1lFcu2wwXRh51A2Yso4smL4Cg16nYeO4zvaEmmkmyrbQME17NXkmFUFcefSopQyZPV/yLTAaMLtmXA==}
+  '@kinotic-ai/os-api@5.0.0-beta.8':
+    resolution: {integrity: sha512-AqVEPGRvsVZGQmAHyuGD4SZX2awhumoPYRMgN9TSqswW/Ixh9nxtgFpE9c1OBPSW9iWHULVWbDhaJAVvlylgQA==}
     peerDependencies:
-      '@kinotic-ai/core': '>=5.0.0-beta.4'
+      '@kinotic-ai/core': '>=5.0.0-beta.5'
 
   '@kinotic-ai/persistence@5.0.0-beta.4':
     resolution: {integrity: sha512-IKkNHpVz4n6vDXNq4PzAANFSpiV1TgfhKbCo201qQw+wRlS8WS9U+3XQme8R3DDpfiyHLz70884IokXAuGQ+rg==}
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.4'
+
+  '@kinotic-ai/persistence@5.0.0-beta.5':
+    resolution: {integrity: sha512-OhpkJbOvb1gcDHrbAi5F+OhXs9HzLOocTForm9J77HiryY7n3Dwr38A2ukm9MYsiO0mRdXGr7m20880iUzKQZQ==}
+    peerDependencies:
+      '@kinotic-ai/core': '>=5.0.0-beta.5'
 
   '@mdi/js@7.4.47':
     resolution: {integrity: sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==}
@@ -1691,6 +1699,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@kinotic-ai/core@5.0.0-beta.5':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@stomp/rx-stomp': 2.4.0(@stomp/stompjs@7.3.0)(rxjs@7.8.2)(uuid@13.0.1)
+      '@stomp/stompjs': 7.3.0
+      debug: 4.4.3
+      p-tap: 4.0.0
+      rxjs: 7.8.2
+      typescript-optional: 3.0.0-alpha.3
+      uuid: 13.0.1
+      ws: 8.21.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@kinotic-ai/idl@5.0.0-beta.1': {}
 
   '@kinotic-ai/os-api@5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.4)':
@@ -1700,16 +1725,28 @@ snapshots:
       '@kinotic-ai/persistence': 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4)
       rxjs: 7.8.2
 
-  '@kinotic-ai/os-api@5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.4)':
+  '@kinotic-ai/os-api@5.0.0-beta.8(@kinotic-ai/core@5.0.0-beta.5)':
     dependencies:
-      '@kinotic-ai/core': 5.0.0-beta.4
+      '@kinotic-ai/core': 5.0.0-beta.5
       '@kinotic-ai/idl': 5.0.0-beta.1
-      '@kinotic-ai/persistence': 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4)
+      '@kinotic-ai/persistence': 5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.5)
       rxjs: 7.8.2
 
   '@kinotic-ai/persistence@5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4)':
     dependencies:
       '@kinotic-ai/core': 5.0.0-beta.4
+      '@kinotic-ai/idl': 5.0.0-beta.1
+      rxjs: 7.8.2
+
+  '@kinotic-ai/persistence@5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.5)':
+    dependencies:
+      '@kinotic-ai/core': 5.0.0-beta.5
+      '@kinotic-ai/idl': 5.0.0-beta.1
+      rxjs: 7.8.2
+
+  '@kinotic-ai/persistence@5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.5)':
+    dependencies:
+      '@kinotic-ai/core': 5.0.0-beta.5
       '@kinotic-ai/idl': 5.0.0-beta.1
       rxjs: 7.8.2
 


### PR DESCRIPTION
Follow-up to #408, which added `ICrudServiceProxy.deleteByIdSync` and bumped `@kinotic-ai/core` to `5.0.0-beta.5`. Those packages are now published, so this raises the portal's declared floors to the versions that actually carry the method.

## Changes

```diff
  "dependencies": {
-   "@kinotic-ai/core": "^5.0.0-beta.3",
+   "@kinotic-ai/core": "^5.0.0-beta.5",
    "@kinotic-ai/frontend-common": "workspace:*",
    "@kinotic-ai/idl": "^5.0.0-beta.0",
-   "@kinotic-ai/os-api": "^5.0.0-beta.7",
+   "@kinotic-ai/os-api": "^5.0.0-beta.8",
```

plus the matching `pnpm-lock.yaml` resolution.

## Why

`ProjectList.vue:134` calls a method that only exists from `core@5.0.0-beta.5` onward:

```ts
await Kinotic.projects.deleteByIdSync(item.id!)
```

The old `^5.0.0-beta.3` range would resolve high enough on a fresh install, but the manifest should state the real minimum rather than depend on that. Against the previous floor the portal failed to compile:

```
src/components/ProjectList.vue(134,28): error TS2551: Property 'deleteByIdSync' does not exist on type 'IProjectService'. Did you mean 'deleteById'?
```

## Verification

Resolved versions in the portal after `pnpm install`:

```
@kinotic-ai/core     5.0.0-beta.5
@kinotic-ai/os-api   5.0.0-beta.8

node_modules/@kinotic-ai/core/dist/index.d.ts:1104
	deleteByIdSync(id: string): Promise<void>;
```

- `pnpm --filter kinotic-portal build` (`vue-tsc -b` + `vite build`) — passes
- `:kinotic-os-api:compileJava` — passes
- `bun run type-check` across all six `kinotic-js/workspace` packages — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVJksNHXvL4Xs6DvojyjjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVJksNHXvL4Xs6DvojyjjQ)_