### PR TITLE
Raise the portal's os-api floor to 5.0.0-beta.9

### DIFF
--- a/kinotic-frontend/apps/portal/package.json
+++ b/kinotic-frontend/apps/portal/package.json
@@ -16,7 +16,7 @@
     "@kinotic-ai/core": "^5.0.0-beta.5",
     "@kinotic-ai/frontend-common": "workspace:*",
     "@kinotic-ai/idl": "^5.0.0-beta.0",
-    "@kinotic-ai/os-api": "^5.0.0-beta.8",
+    "@kinotic-ai/os-api": "^5.0.0-beta.9",
     "@kinotic-ai/persistence": "^5.0.0-beta.3",
     "@mdi/js": "^7.4.47",
     "@primeuix/themes": "^2.0.3",

--- a/kinotic-frontend/pnpm-lock.yaml
+++ b/kinotic-frontend/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^5.0.0-beta.0
         version: 5.0.0-beta.1
       '@kinotic-ai/os-api':
-        specifier: ^5.0.0-beta.8
-        version: 5.0.0-beta.8(@kinotic-ai/core@5.0.0-beta.5)
+        specifier: ^5.0.0-beta.9
+        version: 5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.5)
       '@kinotic-ai/persistence':
         specifier: ^5.0.0-beta.3
         version: 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.5)
@@ -329,8 +329,8 @@ packages:
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.4'
 
-  '@kinotic-ai/os-api@5.0.0-beta.8':
-    resolution: {integrity: sha512-AqVEPGRvsVZGQmAHyuGD4SZX2awhumoPYRMgN9TSqswW/Ixh9nxtgFpE9c1OBPSW9iWHULVWbDhaJAVvlylgQA==}
+  '@kinotic-ai/os-api@5.0.0-beta.9':
+    resolution: {integrity: sha512-c1OFv36dVF+KwF1GuhEijls89feyly+esDq4VbWjizq679vD0c8H1ocPpd7hbL1218CeqXXb9NhcK5qDx27mGA==}
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.5'
 
@@ -1725,7 +1725,7 @@ snapshots:
       '@kinotic-ai/persistence': 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4)
       rxjs: 7.8.2
 
-  '@kinotic-ai/os-api@5.0.0-beta.8(@kinotic-ai/core@5.0.0-beta.5)':
+  '@kinotic-ai/os-api@5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.5)':
     dependencies:
       '@kinotic-ai/core': 5.0.0-beta.5
       '@kinotic-ai/idl': 5.0.0-beta.1


### PR DESCRIPTION
Follow-up to #410, which added `ProfilePage` and the published `ProfileService`. The page calls `Kinotic.profile`, which ships in os-api `5.0.0-beta.9`:

```
src/pages/ProfilePage.vue(52,35): error TS2339: Property 'profile' does not exist on type 'KinoticSingleton'.
src/pages/ProfilePage.vue(67,35): error TS2339: Property 'profile' does not exist on type 'KinoticSingleton'.
```

The declared floor was already satisfied by the version in the lockfile, so `pnpm install` had no reason to move and kept resolving to beta.8:

```jsonc
// apps/portal/package.json — before
"@kinotic-ai/os-api": "^5.0.0-beta.8",
```
```yaml
# pnpm-lock.yaml — before
'@kinotic-ai/os-api@5.0.0-beta.8':
```

Raising the floor is what forces the re-resolve, the same fix as #401 and #411:

```jsonc
"@kinotic-ai/os-api": "^5.0.0-beta.9",
```
```yaml
'@kinotic-ai/os-api@5.0.0-beta.9':
```

The published beta.9 carries the accessor:

```
$ grep 'profile: IProfileService' node_modules/@kinotic-ai/os-api/dist/index.d.ts
profile: IProfileService
```

## Verification

`pnpm build` exits 0 — `vue-tsc -b && vite build` clean for both `apps/portal` and `apps/system`.

## Note on the branch

#410 merged while this was in flight and its branch was deleted, so `claude/authorized-access-sidebar-org-9y4sfx` was restarted from the merged `develop` rather than stacking onto finished history. This PR is a single commit on top of `57848b5`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016qbx65D1DC8s6vHUZJDfyo)_