### PR TITLE
Break the Connect GitHub explainer into bullets and flag the sudo check

### DIFF
--- a/kinotic-frontend/apps/portal/src/pages/signup/CompleteOrg.vue
+++ b/kinotic-frontend/apps/portal/src/pages/signup/CompleteOrg.vue
@@ -20,10 +20,11 @@
         <p class="connect-github__text">
           Almost there! One quick trip to GitHub to install the Kinotic app — then your projects will have a home.
         </p>
+        <h3 class="connect-github__why">Why the extra trip?</h3>
         <ul class="connect-github__points">
           <li>Signing in proved who you are — installing the app is what authorizes repository access.</li>
           <li>Kinotic uses that access to create and manage the GitHub repositories that back your projects.</li>
-          <li>GitHub may ask you to confirm access first — a code emailed to you (subject "Sudo email verification code") or your usual two-factor prompt. That's a standard GitHub security check.</li>
+          <li>Heads up: GitHub may ask you to confirm access — a code emailed to you (subject "Sudo email verification code") or your usual two-factor prompt. That's a standard GitHub security check.</li>
         </ul>
         <Button
           label="Continue to GitHub"
@@ -224,6 +225,14 @@ function displayError(text: string) {
   margin: 0 auto 1.5rem;
   max-width: 24rem;
   line-height: 1.5;
+}
+
+.connect-github__why {
+  margin: 0 auto 0.5rem;
+  max-width: 26rem;
+  text-align: left;
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
 /* Bullets read left-aligned inside the centered card */

--- a/kinotic-frontend/apps/portal/src/pages/signup/CompleteOrg.vue
+++ b/kinotic-frontend/apps/portal/src/pages/signup/CompleteOrg.vue
@@ -18,7 +18,7 @@
         </span>
         <h2 class="signup-title">Your organization is ready</h2>
         <p class="connect-github__text">
-          One more step: we'll send you back to GitHub to install the Kinotic app.
+          Almost there! One quick trip to GitHub to install the Kinotic app — then your projects will have a home.
         </p>
         <ul class="connect-github__points">
           <li>Signing in proved who you are — installing the app is what authorizes repository access.</li>

--- a/kinotic-frontend/apps/portal/src/pages/signup/CompleteOrg.vue
+++ b/kinotic-frontend/apps/portal/src/pages/signup/CompleteOrg.vue
@@ -19,10 +19,12 @@
         <h2 class="signup-title">Your organization is ready</h2>
         <p class="connect-github__text">
           One more step: we'll send you back to GitHub to install the Kinotic app.
-          Signing in proved who you are — installing the app authorizes repository
-          access, so Kinotic can create and manage the GitHub repositories that back
-          your projects.
         </p>
+        <ul class="connect-github__points">
+          <li>Signing in proved who you are — installing the app is what authorizes repository access.</li>
+          <li>Kinotic uses that access to create and manage the GitHub repositories that back your projects.</li>
+          <li>GitHub may ask you to confirm access first — a code emailed to you (subject "Sudo email verification code") or your usual two-factor prompt. That's a standard GitHub security check.</li>
+        </ul>
         <Button
           label="Continue to GitHub"
           icon="pi pi-arrow-right"
@@ -222,5 +224,18 @@ function displayError(text: string) {
   margin: 0 auto 1.5rem;
   max-width: 24rem;
   line-height: 1.5;
+}
+
+/* Bullets read left-aligned inside the centered card */
+.connect-github__points {
+  margin: 0 auto 1.5rem;
+  max-width: 26rem;
+  padding-left: 1.25rem;
+  text-align: left;
+  line-height: 1.5;
+}
+
+.connect-github__points li + li {
+  margin-top: 0.5rem;
 }
 </style>


### PR DESCRIPTION
The Connect GitHub step's single paragraph ran together. It's now a one-line lead-in plus three bullets covering what the user needs before the redirect: why there's a second GitHub round-trip, what the repository access is used for, and that GitHub may ask them to confirm access — naming the "Sudo email verification code" email explicitly so it reads as the standard GitHub security check it is, not phishing.

Bullets are left-aligned inside the centered card via a new `connect-github__points` style. Full frontend `pnpm build` passes.

Docs deliberately untouched — the getting-started section is being revisited separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRocpXFV9Hgrj2WuBDEcze

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRocpXFV9Hgrj2WuBDEcze)_