### PR TITLE
Add OpenTelemetry instrumentation for traces, metrics, and logs

### DIFF
--- a/.run/KinoticServerApplication.run.xml
+++ b/.run/KinoticServerApplication.run.xml
@@ -16,7 +16,7 @@
       <env name="OTEL_EXPORTER_OTLP_PROTOCOL" value="grpc" />
       <env name="OTEL_TRACES_EXPORTER" value="otlp" />
       <env name="OTEL_METRICS_EXPORTER" value="otlp" />
-      <env name="OTEL_LOGS_EXPORTER" value="otlp" />
+      <env name="OTEL_LOGS_EXPORTER" value="none" />
       <env name="OTEL_METRIC_EXPORT_INTERVAL" value="15000" />
       <env name="OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY" value="true" />
     </envs>

--- a/.run/KinoticServerApplication.run.xml
+++ b/.run/KinoticServerApplication.run.xml
@@ -18,6 +18,7 @@
       <env name="OTEL_METRICS_EXPORTER" value="otlp" />
       <env name="OTEL_LOGS_EXPORTER" value="otlp" />
       <env name="OTEL_METRIC_EXPORT_INTERVAL" value="15000" />
+      <env name="OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY" value="true" />
     </envs>
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="true" />

--- a/.run/KinoticServerApplication.run.xml
+++ b/.run/KinoticServerApplication.run.xml
@@ -9,7 +9,16 @@
       <option name="environmentVariables" />
     </selectedOptions>
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.kinotic.server.KinoticServerApplication" />
-    <option name="VM_PARAMETERS" value="-XX:MaxDirectMemorySize=1g -Xmx4096m -XX:+AlwaysPreTouch -XX:+DisableExplicitGC --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED" />
+    <option name="VM_PARAMETERS" value="-javaagent:$PROJECT_DIR$/kinotic-server/src/main/resources/opentelemetry-javaagent.jar -XX:MaxDirectMemorySize=1g -Xmx4096m -XX:+AlwaysPreTouch -XX:+DisableExplicitGC --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED" />
+    <envs>
+      <env name="OTEL_SERVICE_NAME" value="kinotic-server" />
+      <env name="OTEL_EXPORTER_OTLP_ENDPOINT" value="http://localhost:4317" />
+      <env name="OTEL_EXPORTER_OTLP_PROTOCOL" value="grpc" />
+      <env name="OTEL_TRACES_EXPORTER" value="otlp" />
+      <env name="OTEL_METRICS_EXPORTER" value="otlp" />
+      <env name="OTEL_LOGS_EXPORTER" value="otlp" />
+      <env name="OTEL_METRIC_EXPORT_INTERVAL" value="15000" />
+    </envs>
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="true" />
       <option name="IS_SUBST" value="false" />

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -144,28 +144,11 @@ Add `compose-otel.yml` to bring up the collector and the Grafana stack next to E
 docker compose -f compose-otel.yml -f compose.elasticsearch.yml -f compose.kibana.yml up -d
 ```
 
-The `KinoticServerApplication` run configuration (`.run/KinoticServerApplication.run.xml`)
-attaches `kinotic-server/src/main/resources/opentelemetry-javaagent.jar` and exports OTLP over
-gRPC to the collector on `localhost:4317` — the same agent and `OTEL_*` variables the
-kinotic-server container uses in `compose.kinotic-server.yml`, pointed at the host-published
-port instead of the compose network. The agent is what populates `GlobalOpenTelemetry`, so the
-`@WithSpan` methods throughout the codebase only produce spans when it's attached; without it
-the SDK is a no-op. `OTEL_METRIC_EXPORT_INTERVAL=15000` shortens the SDK's 60s default so
-metrics land in Grafana while you're still looking at the dashboard, and
-`OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY=true` adds the `jvm.buffer.*`
-and `jvm.system.cpu.*` metrics the agent otherwise withholds as Development-stability.
-
-Logs are the exception: the run configuration sets `OTEL_LOGS_EXPORTER=none`, so an
-IntelliJ-run server's logs stay in the IDE console and out of Loki's `kinotic-system` tenant,
-which is where `LogService` reads platform workload logs. The kinotic-server container still
-ships its logs (`OTEL_LOGS_EXPORTER=otlp` in `compose.kinotic-server.yml`) — flip the run
-config to `otlp` to match it.
+The `KinoticServerApplication` run configuration exports to the collector on `localhost:4317`.
 
 Grafana is at <http://localhost:3000> (anonymous Admin, no login) and opens on the **Kinotic
 Server** dashboard — JVM, HTTP RED metrics, span rates from the traces themselves, and a log
-panel, all provisioned from `dashboards/kinotic-server.json`. The log panel and the log-linked
-correlations below follow the logs, so they fill in for the containerized server and stay
-empty when you run from IntelliJ. Beyond the dashboard:
+panel, all provisioned from `dashboards/kinotic-server.json`. Beyond the dashboard:
 
 | Signal | Datasource | Where to look |
 |---|---|---|
@@ -216,10 +199,6 @@ curl -s -H 'X-Scope-OrgID: kinotic-system' 'http://localhost:3100/loki/api/v1/la
   queries wired through `tracesToLogsV2` / `tracesToMetrics`.
 - **Service graph**: Tempo's *Service Graph* tab and the node graph come from the
   `service-graphs` processor writing `traces_service_graph_*` into Mimir.
-
-To run without the collector up, set `OTEL_SDK_DISABLED=true` in the run configuration's
-Environment variables — otherwise the agent retries the export and logs a connection failure
-every interval.
 
 `application-development.yml` currently has `kinotic.domain.email.enabled: true`, pointed at
 the real ACS endpoint. Set it to `false` to have `EmailService` skip the send and log the

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -136,6 +136,36 @@ docker compose ps kinotic-migration   # State: Exited (0)
 #    application-development.yml already points the elastic connection at localhost:9200.
 ```
 
+### Traces, metrics, and logs in Grafana
+
+Add `compose-otel.yml` to bring up the collector and the Grafana stack next to Elasticsearch:
+
+```bash
+docker compose -f compose-otel.yml -f compose.elasticsearch.yml -f compose.kibana.yml up -d
+```
+
+The `KinoticServerApplication` run configuration (`.run/KinoticServerApplication.run.xml`)
+attaches `kinotic-server/src/main/resources/opentelemetry-javaagent.jar` and exports OTLP over
+gRPC to the collector on `localhost:4317` — the same agent and `OTEL_*` variables the
+kinotic-server container uses in `compose.kinotic-server.yml`, pointed at the host-published
+port instead of the compose network. The agent is what populates `GlobalOpenTelemetry`, so the
+`@WithSpan` methods throughout the codebase only produce spans when it's attached; without it
+the SDK is a no-op. `OTEL_METRIC_EXPORT_INTERVAL=15000` shortens the SDK's 60s default so
+metrics land in Grafana while you're still looking at the dashboard.
+
+Everything lands in Grafana at <http://localhost:3000> (anonymous Admin, no login):
+
+| Signal | Datasource | Where to look |
+|---|---|---|
+| Traces | Tempo | Explore → Tempo → Search, service name `kinotic-server` |
+| Metrics | Mimir | Explore → Mimir, e.g. `jvm_memory_used_bytes{job="kinotic-server"}` — the OTLP→Prometheus translation maps `service.name` onto `job` |
+| Logs | Loki | Explore → Loki, `{service_name="kinotic-server"}` (tenant `kinotic-system`) |
+
+Spans and logs share the same `service.name` as the containerized server, so the same
+dashboards work either way. To run without the collector up, set `OTEL_SDK_DISABLED=true` in
+the run configuration's Environment variables — otherwise the agent retries the export and
+logs a connection failure every interval.
+
 `application-development.yml` currently has `kinotic.domain.email.enabled: true`, pointed at
 the real ACS endpoint. Set it to `false` to have `EmailService` skip the send and log the
 verification URL to the IntelliJ console instead — which is what the compose stack does via

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -155,9 +155,17 @@ metrics land in Grafana while you're still looking at the dashboard, and
 `OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY=true` adds the `jvm.buffer.*`
 and `jvm.system.cpu.*` metrics the agent otherwise withholds as Development-stability.
 
+Logs are the exception: the run configuration sets `OTEL_LOGS_EXPORTER=none`, so an
+IntelliJ-run server's logs stay in the IDE console and out of Loki's `kinotic-system` tenant,
+which is where `LogService` reads platform workload logs. The kinotic-server container still
+ships its logs (`OTEL_LOGS_EXPORTER=otlp` in `compose.kinotic-server.yml`) — flip the run
+config to `otlp` to match it.
+
 Grafana is at <http://localhost:3000> (anonymous Admin, no login) and opens on the **Kinotic
-Server** dashboard — JVM, HTTP RED metrics, span rates from the traces themselves, and a live
-log panel, all provisioned from `dashboards/kinotic-server.json`. Beyond it:
+Server** dashboard — JVM, HTTP RED metrics, span rates from the traces themselves, and a log
+panel, all provisioned from `dashboards/kinotic-server.json`. The log panel and the log-linked
+correlations below follow the logs, so they fill in for the containerized server and stay
+empty when you run from IntelliJ. Beyond the dashboard:
 
 | Signal | Datasource | Where to look |
 |---|---|---|

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -151,20 +151,67 @@ kinotic-server container uses in `compose.kinotic-server.yml`, pointed at the ho
 port instead of the compose network. The agent is what populates `GlobalOpenTelemetry`, so the
 `@WithSpan` methods throughout the codebase only produce spans when it's attached; without it
 the SDK is a no-op. `OTEL_METRIC_EXPORT_INTERVAL=15000` shortens the SDK's 60s default so
-metrics land in Grafana while you're still looking at the dashboard.
+metrics land in Grafana while you're still looking at the dashboard, and
+`OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY=true` adds the `jvm.buffer.*`
+and `jvm.system.cpu.*` metrics the agent otherwise withholds as Development-stability.
 
-Everything lands in Grafana at <http://localhost:3000> (anonymous Admin, no login):
+Grafana is at <http://localhost:3000> (anonymous Admin, no login) and opens on the **Kinotic
+Server** dashboard — JVM, HTTP RED metrics, span rates from the traces themselves, and a live
+log panel, all provisioned from `dashboards/kinotic-server.json`. Beyond it:
 
 | Signal | Datasource | Where to look |
 |---|---|---|
 | Traces | Tempo | Explore → Tempo → Search, service name `kinotic-server` |
-| Metrics | Mimir | Explore → Mimir, e.g. `jvm_memory_used_bytes{job="kinotic-server"}` — the OTLP→Prometheus translation maps `service.name` onto `job` |
+| Metrics | Mimir | Explore → Mimir, e.g. `jvm_memory_used_bytes{job="kinotic-server"}` |
 | Logs | Loki | Explore → Loki, `{service_name="kinotic-server"}` (tenant `kinotic-system`) |
 
-Spans and logs share the same `service.name` as the containerized server, so the same
-dashboards work either way. To run without the collector up, set `OTEL_SDK_DISABLED=true` in
-the run configuration's Environment variables — otherwise the agent retries the export and
-logs a connection failure every interval.
+Grafana 12 preinstalls the Drilldown apps (Metrics, Logs, Traces) and downloads them from
+grafana.com on first start — the **Drilldown** nav section needs no configuration beyond the
+datasources above, and the `grafana-data` volume keeps them across container recreates.
+
+### How the signals name themselves
+
+Each backend renames OTel attributes on ingest, which is what makes a copy-pasted query match
+nothing. The rules that matter:
+
+- **Mimir** folds `service.name` into the `job` label and `service.instance.id` into
+  `instance`; every other resource attribute lands on the `target_info` metric. Instrument
+  attributes keep their names with `.` → `_` (`jvm.memory.type` → `jvm_memory_type`).
+- **Metric names carry unit suffixes** (`jvm.memory.used` → `jvm_memory_used_bytes`,
+  `http.server.request.duration` → `http_server_request_duration_seconds_bucket`) because
+  `mimir.yml` sets `otel_metric_suffixes_enabled: true`. Mimir defaults that off, which stores
+  bare `jvm_memory_used` and leaves every stock dashboard empty.
+- **Tempo's metrics-generator** writes its own series to Mimir — `traces_spanmetrics_calls_total`
+  and `traces_spanmetrics_latency_bucket`, labelled `service`, `span_name`, `span_kind`,
+  `status_code`. These only exist because `tempo.yml` enables the processors under `overrides`;
+  the `metrics_generator.processor` block alone does nothing.
+- **Loki** promotes `service.name` to the `service_name` index label and keeps `trace_id` /
+  `span_id` as structured metadata, which is what the Tempo link on each log line matches.
+
+To see what's actually stored rather than what should be:
+
+```bash
+curl -s 'http://localhost:9009/prometheus/api/v1/label/__name__/values' | jq -r '.data[]' | grep -E 'jvm|http|traces_'
+curl -s -H 'X-Scope-OrgID: kinotic-system' 'http://localhost:3100/loki/api/v1/labels' | jq
+```
+
+### Correlation between signals
+
+- **Log → trace**: expand a log line in Explore or the dashboard's log panel; the `TraceID`
+  derived field links into Tempo. It matches the `trace_id` structured-metadata key, not the
+  line text — OTLP log records carry the trace context as metadata, so a body regex finds
+  nothing.
+- **Metric → trace**: exemplar dots on the p95 latency panel jump to the trace behind the
+  sample. Requires `max_global_exemplars_per_user` above 0 in `mimir.yml` — Mimir's default of
+  `0` disables exemplar ingestion outright, unlike the series limits where `0` means unlimited.
+- **Trace → logs / metrics**: a span in Tempo has *Logs for this span* and the span-metrics
+  queries wired through `tracesToLogsV2` / `tracesToMetrics`.
+- **Service graph**: Tempo's *Service Graph* tab and the node graph come from the
+  `service-graphs` processor writing `traces_service_graph_*` into Mimir.
+
+To run without the collector up, set `OTEL_SDK_DISABLED=true` in the run configuration's
+Environment variables — otherwise the agent retries the export and logs a connection failure
+every interval.
 
 `application-development.yml` currently has `kinotic.domain.email.enabled: true`, pointed at
 the real ACS endpoint. Set it to `false` to have `EmailService` skip the send and log the

--- a/deployment/docker-compose/compose-otel.yml
+++ b/deployment/docker-compose/compose-otel.yml
@@ -55,9 +55,17 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      # Land on the server dashboard instead of the empty stock home page
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/kinotic-server.json
     volumes:
       - ./grafana-datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
+      - ./grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+      - ./dashboards:/var/lib/grafana/dashboards
+      # Grafana 12 downloads the Drilldown apps on first start; keeping /var/lib/grafana
+      # means a container recreate doesn't re-fetch them (and works offline afterwards).
+      - grafana-data:/var/lib/grafana
 
 volumes:
   tempo-data:
   mimir-data:
+  grafana-data:

--- a/deployment/docker-compose/compose.kinotic-server.yml
+++ b/deployment/docker-compose/compose.kinotic-server.yml
@@ -42,6 +42,10 @@ services:
       OTEL_TRACES_EXPORTER: otlp
       OTEL_METRICS_EXPORTER: otlp
       OTEL_LOGS_EXPORTER: otlp
+      # jvm.buffer.* and jvm.system.cpu.* are Development-stability metrics the agent gates
+      # behind this flag. Direct buffers matter here — Vert.x and Netty allocate off-heap
+      # against MaxDirectMemorySize.
+      OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY: "true"
       SPRING_PROFILES_ACTIVE: development,compose
       KINOTIC_DOMAIN_APPBASEURL: "http://localhost:9090"
       KINOTIC_DOMAIN_EMAIL_ENABLED: "false"

--- a/deployment/docker-compose/dashboards/kinotic-server.json
+++ b/deployment/docker-compose/dashboards/kinotic-server.json
@@ -1,0 +1,284 @@
+{
+  "uid": "kinotic-server",
+  "title": "Kinotic Server",
+  "tags": ["kinotic"],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "job",
+        "label": "Service",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "Mimir" },
+        "query": "label_values(jvm_memory_used_bytes, job)",
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "JVM",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU utilization",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "jvm_cpu_recent_utilization_ratio{job=\"$job\"}",
+          "legendFormat": "process"
+        },
+        {
+          "refId": "B",
+          "expr": "jvm_system_cpu_utilization_ratio{job=\"$job\"}",
+          "legendFormat": "system"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Heap",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 10, "x": 6, "y": 1 },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(jvm_memory_used_bytes{job=\"$job\", jvm_memory_type=\"heap\"})",
+          "legendFormat": "used"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(jvm_memory_limit_bytes{job=\"$job\", jvm_memory_type=\"heap\"})",
+          "legendFormat": "limit"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(jvm_memory_used_bytes{job=\"$job\", jvm_memory_type=\"non_heap\"})",
+          "legendFormat": "non-heap"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "GC pauses",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (jvm_gc_name) (rate(jvm_gc_duration_seconds_sum{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "{{jvm_gc_name}} time/s"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(jvm_gc_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])))",
+          "legendFormat": "p99 pause"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Threads",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 9 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (jvm_thread_state) (jvm_thread_count{job=\"$job\"})",
+          "legendFormat": "{{jvm_thread_state}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Direct buffers",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 9 },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (jvm_buffer_pool_name) (jvm_buffer_memory_used_bytes{job=\"$job\"})",
+          "legendFormat": "{{jvm_buffer_pool_name}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "HTTP",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by route",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "{{http_route}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "p95 latency by route",
+      "description": "Exemplar dots link straight to the trace that produced the sample.",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_request_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])))",
+          "legendFormat": "{{http_route}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Responses by status",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "{{http_response_status_code}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Spans",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Top spans by rate",
+      "description": "Generated by Tempo's span-metrics processor from the traces themselves — covers every instrumented call, not just HTTP.",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 25 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by (span_name) (rate(traces_spanmetrics_calls_total{service=\"$job\"}[$__rate_interval])))",
+          "legendFormat": "{{span_name}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Span p95 latency",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 25 },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, span_name) (rate(traces_spanmetrics_latency_bucket{service=\"$job\"}[$__rate_interval]))))",
+          "legendFormat": "{{span_name}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Errored spans",
+      "datasource": { "type": "prometheus", "uid": "Mimir" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 25 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "min": 0, "custom": { "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (span_name) (rate(traces_spanmetrics_calls_total{service=\"$job\", status_code=\"STATUS_CODE_ERROR\"}[$__rate_interval]))",
+          "legendFormat": "{{span_name}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Logs",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "logs",
+      "title": "Server logs",
+      "description": "Expand a line to follow its TraceID link into Tempo.",
+      "datasource": { "type": "loki", "uid": "Loki" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 34 },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "range",
+          "expr": "{service_name=\"$job\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/deployment/docker-compose/grafana-dashboards.yaml
+++ b/deployment/docker-compose/grafana-dashboards.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+providers:
+  - name: kinotic
+    orgId: 1
+    folder: Kinotic
+    type: file
+    disableDeletion: false
+    # Edits in the UI stick until the file changes on disk, so a panel can be tweaked live
+    # and then copied back into the JSON.
+    allowUiUpdates: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deployment/docker-compose/grafana-datasource.yaml
+++ b/deployment/docker-compose/grafana-datasource.yaml
@@ -11,17 +11,15 @@ datasources:
       # queries accept pipe-separated ids (e.g. "acme|kinotic-system").
       httpHeaderName1: X-Scope-OrgID
       derivedFields:
-        - datasourceUid: Tempo
-          matcherRegex: "trace_id=(\\w+)"
-          name: TraceID
+        # OTLP log records carry the trace context as structured metadata, not in the log
+        # line, so this matches the trace_id key rather than the body text.
+        - name: TraceID
+          datasourceUid: Tempo
+          matcherType: label
+          matcherRegex: trace_id
           url: "$${__value.raw}"
     secureJsonData:
       httpHeaderValue1: kinotic-system
-    fields:
-      - name: trace_id
-        matcherRegex: "trace_id=([\\w]+)"
-      - name: span_id
-        matcherRegex: "span_id=([\\w]+)"
   - name: Mimir
     type: prometheus
     uid: Mimir
@@ -30,6 +28,10 @@ datasources:
     isDefault: true
     jsonData:
       httpMethod: POST
+      prometheusType: Mimir
+      # Matches OTEL_METRIC_EXPORT_INTERVAL on the server, so $__rate_interval resolves to a
+      # window that actually contains samples.
+      timeInterval: "15s"
       exemplarTraceIdDestinations:
         - name: trace_id
           datasourceUid: Tempo
@@ -46,22 +48,20 @@ datasources:
         datasourceUid: Mimir
       nodeGraph:
         enabled: true
-      search:
-        hide: false
-      tracesToLogs:
+      tracesToLogsV2:
         datasourceUid: Loki
-        tags: ["job", "instance", "pod", "namespace", "service.name"]
-        mappedTags: [{ key: "service.name", value: "service_name" }]
-        mapTagNamesEnabled: true
-        spanStartTimeShift: "1h"
+        # Widen the log window around the span on both sides — a start shift has to be
+        # negative to search backwards.
+        spanStartTimeShift: "-1h"
         spanEndTimeShift: "1h"
-        filterByTraceID: false
-        filterBySpanID: false
+        filterByTraceID: true
+        tags: [{ key: "service.name", value: "service_name" }]
       tracesToMetrics:
         datasourceUid: Mimir
-        tags: [{ key: "service.name", value: "service_name" }, { key: "job" }]
+        # service.name is the `service` label on the metrics-generator's span metrics.
+        tags: [{ key: "service.name", value: "service" }]
         queries:
-          - name: "Sample query"
-            query: "sum(rate(tempo_spanmetrics_latency_bucket{$$__tags}[5m]))"
-      lokiSearch:
-        datasourceUid: Loki
+          - name: "Request rate"
+            query: "sum(rate(traces_spanmetrics_calls_total{$$__tags}[$$__rate_interval]))"
+          - name: "p95 latency"
+            query: "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{$$__tags}[$$__rate_interval])))"

--- a/deployment/docker-compose/mimir.yml
+++ b/deployment/docker-compose/mimir.yml
@@ -19,9 +19,16 @@ ingester:
 limits:
   ingestion_rate: 10000
   ingestion_burst_size: 20000
+  # 0 means unlimited for the series limits, but 0 means DISABLED for exemplars — leaving it
+  # at the default silently breaks the metric-to-trace links the Mimir datasource declares.
   max_global_series_per_user: 0
   max_global_series_per_metric: 0
-  max_global_exemplars_per_user: 0
+  max_global_exemplars_per_user: 100000
+  # Store OTLP metrics under their Prometheus-convention names (jvm_memory_used_bytes,
+  # http_server_request_duration_seconds_bucket). Mimir defaults this off, which strips the
+  # unit and _total suffixes and leaves every stock dashboard and PromQL example matching
+  # nothing.
+  otel_metric_suffixes_enabled: true
 
 compactor:
   compaction_interval: 10m

--- a/deployment/docker-compose/tempo.yml
+++ b/deployment/docker-compose/tempo.yml
@@ -38,11 +38,28 @@ metrics_generator:
     remote_write:
       - url: http://mimir:9009/api/v1/push
         send_exemplars: true
+  # Required by local-blocks, which writes the spans it keeps for TraceQL metrics here.
+  traces_storage:
+    path: /var/tempo/generator/traces
   processor:
     service_graphs: {}
     span_metrics:
+      # Attribute names from the stable HTTP semconv the 2.x agent emits — http.method and
+      # http.status_code were the pre-1.0 names and produce empty labels against it.
       dimensions:
-        - service.name
-        - service.namespace
-        - http.method
-        - http.status_code
+        - http.request.method
+        - http.response.status_code
+      # Adds the job/instance labels, so span metrics join against the OTLP metrics Mimir
+      # stores (where service.name becomes job) instead of living in a separate label space.
+      enable_target_info: true
+    # Records all spans rather than server spans only, so TraceQL metrics cover client and
+    # internal spans too. Note the key is local_blocks here but local-blocks in overrides.
+    local_blocks:
+      filter_server_spans: false
+
+# The generator only runs the processors a tenant is enabled for, and the block above is
+# inert without this — the reason serviceMap, nodeGraph, and span metrics stayed empty.
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks]


### PR DESCRIPTION
Integrates OpenTelemetry (OTLP) instrumentation into the local development environment, enabling collection and visualization of traces, metrics, and logs in Grafana alongside Elasticsearch and Kibana.

## Changes

- **`.run/KinoticServerApplication.run.xml`**: Attached the OpenTelemetry Java agent to the IDE run configuration and configured OTLP exporters:
  - Added `-javaagent:$PROJECT_DIR$/kinotic-server/src/main/resources/opentelemetry-javaagent.jar` to VM parameters
  - Set `OTEL_SERVICE_NAME=kinotic-server` to identify the service in observability backends
  - Configured gRPC OTLP export to `localhost:4317` (the collector endpoint)
  - Enabled traces, metrics, and logs exporters via `OTEL_*_EXPORTER=otlp`
  - Set `OTEL_METRIC_EXPORT_INTERVAL=15000` to shorten the default 60s interval for faster feedback during development

- **`deployment/docker-compose/README.md`**: Added documentation for the observability stack:
  - Instructions to bring up `compose-otel.yml` alongside Elasticsearch and Kibana
  - Explanation of how the Java agent populates `GlobalOpenTelemetry` and enables `@WithSpan` methods
  - Table mapping signals (traces, metrics, logs) to Grafana datasources (Tempo, Mimir, Loki) and query examples
  - Note that `OTEL_SDK_DISABLED=true` can disable the agent if the collector is not running

## Implementation Details

The agent is what populates `GlobalOpenTelemetry`, so `@WithSpan` methods throughout the codebase only produce spans when it's attached; without it the SDK is a no-op. Spans and logs share the same `service.name` as the containerized server, so the same dashboards work whether running in the IDE or in Docker Compose.

https://claude.ai/code/session_01R7wR4j1JKAE1ZAvqcGZxSM