### PR TITLE
Scroll CrudTable rows inside the shell so the paginator stays put

### DIFF
--- a/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
+++ b/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
@@ -32,10 +32,12 @@ const isFullWidth = computed(() => route.meta.fullWidth === true)
         >
             <div :class="['h-[calc(100vh-64px)] overflow-y-auto px-8 py-6 transition-colors', isDark ? 'bg-surface-900 text-surface-0' : 'bg-surface-0 text-surface-950']">
                 <router-view v-if="isFullWidth" />
-                <!-- flex + flex-1 (rather than min-h-full on the page root) so short pages still
-                     stretch to the bottom of the viewport inside this auto-height wrapper. -->
-                <div v-else class="mx-auto flex min-h-full w-full max-w-[1200px] flex-col">
-                    <router-view class="flex-1" />
+                <!-- h-full (not min-h-full) gives the page a definite height to divide up, so a
+                     page that scrolls a region internally — a table keeping its paginator in
+                     place — can size that region. min-h-0 lets the page shrink to it; taller
+                     pages overflow and scroll in the wrapper above as before. -->
+                <div v-else class="mx-auto flex h-full w-full max-w-[1200px] flex-col">
+                    <router-view class="min-h-0 flex-1" />
                 </div>
             </div>
         </div>

--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -210,10 +210,12 @@ const dataTablePt = computed(() => {
     header: {
       class: 'hidden'
     },
+    // The header row is sticky over the scrolling rows, so it carries the surface colour the
+    // shell sits on rather than being transparent — otherwise rows show through it.
     headerCell: {
       class: [
-        'bg-transparent px-[14px] pb-[0.9rem] pt-4 text-sm font-semibold',
-        isDark.value ? 'border-surface-700 text-surface-100' : 'border-surface-200 text-surface-950'
+        'px-[14px] pb-[0.9rem] pt-4 text-sm font-semibold',
+        isDark.value ? 'bg-surface-900 border-surface-700 text-surface-100' : 'bg-surface-0 border-surface-200 text-surface-950'
       ]
     },
     bodyRow: {
@@ -376,8 +378,10 @@ defineExpose({ find, displayAlert });
 
 <template>
   <!-- flex-1 lets the table fill the remaining height when a page provides a flex column
-       chain down to here; in a plain block parent the flex classes are inert. -->
-  <div class="crud-table flex flex-1 flex-col" :class="isDark ? 'crud-table--dark' : 'crud-table--light'" :style="{ '--row-hover-color': rowHoverColor }">
+       chain down to here; in a plain block parent the flex classes are inert. min-h-0 runs
+       down that chain so the rows scroll inside the shell instead of stretching it past the
+       viewport, which would carry the paginator off screen. -->
+  <div class="crud-table flex min-h-0 flex-1 flex-col" :class="isDark ? 'crud-table--dark' : 'crud-table--light'" :style="{ '--row-hover-color': rowHoverColor }">
     <div class="crud-table__toolbar flex items-center justify-between mb-6 gap-4">
       <IconField class="crud-table__search w-[236px] max-w-sm">
         <InputIcon class="pi pi-search" />
@@ -423,11 +427,11 @@ defineExpose({ find, displayAlert });
       </div>
     </div>
 
-    <div class="mb-6 flex flex-1 flex-col">
-      <div v-if="isColumnView" class="flex flex-1 flex-col">
+    <div class="mb-6 flex min-h-0 flex-1 flex-col">
+      <div v-if="isColumnView" class="flex min-h-0 flex-1 flex-col">
         <div
           v-if="displayRows.length > 0"
-          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+          class="grid min-h-0 flex-1 auto-rows-min grid-cols-1 gap-4 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3"
         >
           <Card
             v-for="(item, index) in displayRows"
@@ -510,18 +514,24 @@ defineExpose({ find, displayAlert });
         />
       </div>
 
-      <div v-if="isBurgerView" class="flex flex-1 flex-col">
+      <div v-if="isBurgerView" class="flex min-h-0 flex-1 flex-col">
         <div
           :class="[
-            'crud-table__table-shell flex flex-1 flex-col rounded-[14px] border px-4 py-2 transition-colors',
+            'crud-table__table-shell flex min-h-0 flex-1 flex-col rounded-[14px] border px-4 py-2 transition-colors',
             isDark ? 'border-surface-700 bg-transparent text-surface-0 shadow-[0_0_0_1px_rgba(58,58,64,0.15)]' : 'border-surface-200 bg-transparent text-surface-950'
           ]"
         >
           <DataTable
-            :class="['crud-table__datatable', { 'crud-table__datatable--loading': loading }]"
+            :class="[
+              'crud-table__datatable',
+              { 'crud-table__datatable--loading': loading },
+              displayRows.length > 0 ? 'min-h-0 flex-1' : ''
+            ]"
             :pt="dataTablePt"
             :value="displayRows"
             dataKey="id"
+            scrollable
+            scrollHeight="flex"
             @row-click="onRowClick"
             sortMode="multiple"
             :rowClass="getRowClass"
@@ -577,12 +587,13 @@ defineExpose({ find, displayAlert });
             </Column>
           </DataTable>
 
-          <!-- Filler between the rows and the bottom border: absorbs leftover shell height
-               so the shell can stretch, and hosts the centered empty state. -->
+          <!-- Centered in the space under the header row, which the table leaves free only
+               when it has no rows to scroll. -->
           <div
+            v-if="!loading && items.length === 0"
             :class="['flex flex-1 items-center justify-center', isDark ? 'text-surface-400' : 'text-surface-500']"
           >
-            <span v-if="!loading && items.length === 0" class="py-20">{{ emptyStateText }}</span>
+            <span class="py-20">{{ emptyStateText }}</span>
           </div>
         </div>
 


### PR DESCRIPTION
Follow-up to #414. That PR stopped the columns reflowing and added skeleton rows, but left a vertical version of the same problem: on `/members` the placeholder pushed the pagination buttons off screen, and they popped back once a short result arrived.

## Cause

The shell grows to fit its rows, and `LayoutForPage` never gave it a height to fit *into*:

```html
<!-- apps/portal/src/layouts/LayoutForPage.vue:37 (before) -->
<div v-else class="mx-auto flex min-h-full w-full max-w-[1200px] flex-col">
    <router-view class="flex-1" />
</div>
```

`min-h-full` leaves the height **auto**, which always resolves to content height — so no amount of `min-h-0` below it changes anything. A full-page placeholder made the page taller than the viewport; a 3-row result collapsed it again. Ten *real* rows already did the same thing.

## Change

```html
<!-- apps/portal/src/layouts/LayoutForPage.vue:39 (after) -->
<div v-else class="mx-auto flex h-full w-full max-w-[1200px] flex-col">
    <router-view class="min-h-0 flex-1" />
</div>
```

`h-full` is definite, `min-h-0` lets the chain divide it, and the table sizes to what is left and scrolls its own rows:

```html
<!-- packages/common/src/components/CrudTable.vue:520 -->
<DataTable
  :class="[..., displayRows.length > 0 ? 'min-h-0 flex-1' : '']"
  scrollable
  scrollHeight="flex"
```

Three things fell out of that:

- The sticky header needed an opaque fill — rows scrolled visibly through the transparent header cells. It now carries `bg-surface-0` / `bg-surface-900`, the surface the shell sits on, so it looks unchanged.
- The filler `div` under the rows only existed to absorb leftover shell height. The table absorbs it now, so it renders only for the empty state it also hosted.
- The card grid grew the same way and scrolls internally too.

## Verification

Driven with Playwright against `CrudTable` inside a copy of the `LayoutForPage` chain, sampling geometry mid-load and after the rows land:

```
                   headerShift   paginatorShift   pagerVisible      rows
full-page-10          0px            0px          true  -> true    10 -> 10
partial-3             0px            0px          true  -> true    10 -> 3
empty-0               0px            0px          true  -> true    10 -> 1
partial-3-dark        0px            0px          true  -> true    10 -> 3
partial-3 @720h       0px            0px          true  -> true    10 -> 3
```

`pagerVisible true -> true` is the line that read `false -> true` before this change, and it now also holds for a full ten-row page, which never fit previously. Also checked:

- rows scroll inside the table (`tableScrollsInternally=true`) while the page itself does not (`pageScrolls=false`), header fixed at the same y after scrolling to the bottom, in both themes
- a tall non-table page still scrolls normally under the new layout (scrollHeight 836 → 2968, last element reachable) — the risk in touching a shared layout
- the card view scrolls its grid with the paginator visible

`vue-tsc -b` is clean for both `apps/portal` and `apps/system`.

## Not included

`apps/system/src/layouts/ConsoleLayout.vue` is a copy of the same layout and shares this `CrudTable`, but its tables sit inside `Tabs`/`TabPanels`, which breaks the flex chain — the change would have no effect there, so I left it rather than make an unverifiable edit to the other app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWX9G4EfekrvUZXqErZT4u


---
_Generated by [Claude Code](https://claude.ai/code/session_01HWX9G4EfekrvUZXqErZT4u)_