### PR TITLE
Console polish: clickable Organizations tile and CrudTable search icon fix

### DIFF
--- a/kinotic-frontend/apps/portal/components.d.ts
+++ b/kinotic-frontend/apps/portal/components.d.ts
@@ -30,8 +30,6 @@ declare module 'vue' {
     GitHubLinkStatus: typeof import('./src/components/GitHubLinkStatus.vue')['default']
     Glitch: typeof import('./src/components/Glitch.vue')['default']
     GlobalObjectNode: typeof import('./src/components/nodes/GlobalObjectNode.vue')['default']
-    IconField: typeof import('primevue/iconfield')['default']
-    InputIcon: typeof import('primevue/inputicon')['default']
     NewProjectSidebar: typeof import('./src/components/NewProjectSidebar.vue')['default']
     ObjectNode: typeof import('./src/components/nodes/ObjectNode.vue')['default']
     ProjectEntityDefinitionsTable: typeof import('./src/components/ProjectEntityDefinitionsTable.vue')['default']

--- a/kinotic-frontend/apps/system/src/pages/Overview.vue
+++ b/kinotic-frontend/apps/system/src/pages/Overview.vue
@@ -5,14 +5,21 @@
     <Message v-if="clusterError" severity="error" :closable="false" class="mb-4">{{ clusterError }}</Message>
 
     <div class="grid grid-cols-2 gap-4 xl:grid-cols-4">
-      <div v-for="stat in stats" :key="stat.label" class="flex flex-col gap-1 rounded-lg border border-surface p-4">
+      <component
+        :is="stat.to ? RouterLink : 'div'"
+        v-for="stat in stats"
+        :key="stat.label"
+        :to="stat.to"
+        class="flex flex-col gap-1 rounded-lg border border-surface p-4"
+        :class="stat.to ? 'cursor-pointer text-color no-underline transition-colors hover:bg-emphasis' : ''"
+      >
         <span class="text-xs font-medium uppercase tracking-wide text-muted-color">{{ stat.label }}</span>
         <span v-if="stat.tag" class="py-1">
           <Tag :value="stat.value" :severity="stat.tag" />
         </span>
         <span v-else class="text-3xl font-semibold">{{ stat.value }}</span>
         <span class="text-xs text-muted-color">{{ stat.description }}</span>
-      </div>
+      </component>
     </div>
 
     <div class="mt-6 rounded-lg border border-surface">
@@ -60,6 +67,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import Tag from 'primevue/tag'
@@ -81,6 +89,8 @@ interface Stat {
   value: string
   description: string
   tag?: string
+  /** Route the tile navigates to on click; unset renders a static tile. */
+  to?: string
 }
 
 const stats = computed<Stat[]>(() => [
@@ -103,7 +113,8 @@ const stats = computed<Stat[]>(() => [
   {
     label: 'Organizations',
     value: organizationCount.value?.toString() ?? '—',
-    description: 'Organizations registered on the platform'
+    description: 'Organizations registered on the platform',
+    to: '/organizations'
   }
 ])
 

--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -5,6 +5,8 @@ import { useRoute } from "vue-router";
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
 import Button from "primevue/button";
+import IconField from "primevue/iconfield";
+import InputIcon from "primevue/inputicon";
 import InputText from "primevue/inputtext";
 import ConfirmDialog from "primevue/confirmdialog";
 import Card from "primevue/card";


### PR DESCRIPTION
Two small follow-ups to the merged #404, found while trying the console against a live dev server.

## Organizations tile navigates

The Overview stat tiles accept an optional route; a routed tile renders as a `RouterLink` with hover affordance, and only Organizations sets one:

```ts
// Overview.vue
{ label: 'Organizations', value: ..., description: 'Organizations registered on the platform', to: '/organizations' }
```

```html
<component :is="stat.to ? RouterLink : 'div'" :to="stat.to"
           :class="stat.to ? 'cursor-pointer text-color no-underline transition-colors hover:bg-emphasis' : ''">
```

## CrudTable search icon rendered outside the input in the console

`CrudTable.vue` used `<IconField>`/`<InputIcon>` without importing them. The portal resolves them via `unplugin-vue-components`, but the system console has no component auto-import — the tags rendered as unknown elements and the `pi-search` glyph fell outside the field:

```ts
// CrudTable.vue — a shared component imports everything it uses
import IconField from "primevue/iconfield";
import InputIcon from "primevue/inputicon";
```

## Verified

- Both apps `vue-tsc -b && vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS

---
_Generated by [Claude Code](https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS)_