### PR TITLE
Settle the CrudTable paginator while a page loads

### DIFF
--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -612,7 +612,7 @@ defineExpose({ find, displayAlert });
           :totalRecords="displayTotal"
           :rowsPerPageOptions="paginationOptions"
           @page="onPaginatorPage"
-          class="justify-end border-0 bg-transparent px-0 pb-[0.875rem] pt-3 shadow-none"
+          class="border-0 bg-transparent px-0 pb-[0.875rem] pt-3 shadow-none"
         />
       </div>
     </div>
@@ -652,6 +652,13 @@ defineExpose({ find, displayAlert });
 .p-datatable-paginator-bottom {
   border: none !important;
   box-shadow: none !important;
+}
+
+/* Anchors the rows-per-page select to the table's right edge, so the page buttons grow
+   leftward as the record count arrives rather than pushing the select sideways. Two class
+   selectors to outweigh the theme's own centring on .p-paginator. */
+.crud-table .p-paginator {
+  justify-content: flex-end;
 }
 
 .crud-table--light .crud-table__view-switcher.p-selectbutton {

--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -149,6 +149,12 @@ const displayRows = computed<DescriptiveIdentifiable[]>(() => {
   return showSkeleton.value ? skeletonRows.value : items.value;
 });
 
+// The paginator disables itself at a count of zero, so a real count would switch it out of
+// its greyed-out state on arrival. Standing in a full page keeps it enabled throughout.
+const displayTotal = computed<number>(() => {
+  return showSkeleton.value ? options.value.rows : totalItems.value;
+});
+
 function rowMenuItems(item: DescriptiveIdentifiable): MenuItem[] {
   const menuItems = props.rowActions ? [...props.rowActions(item)] : [];
   if (props.isShowDelete) {
@@ -508,7 +514,7 @@ defineExpose({ find, displayAlert });
 
         <Paginator
           :rows="options.rows"
-          :totalRecords="totalItems"
+          :totalRecords="displayTotal"
           :rowsPerPageOptions="paginationOptions"
           @page="onPaginatorPage"
           class="mt-auto pt-4"
@@ -603,7 +609,7 @@ defineExpose({ find, displayAlert });
           v-if="showPagination"
           :rows="options.rows"
           :first="options.first"
-          :totalRecords="totalItems"
+          :totalRecords="displayTotal"
           :rowsPerPageOptions="paginationOptions"
           @page="onPaginatorPage"
           class="justify-end border-0 bg-transparent px-0 pb-[0.875rem] pt-3 shadow-none"


### PR DESCRIPTION
Follow-up to #417. The last visible artefact of the load on `/members`: the rows-per-page select sat greyed out while the placeholder showed, then turned white and shifted sideways when the data landed.

Two separate causes, one commit each.

## 1. The grey — no record count yet

The paginator disables itself at a record count of zero, and while the placeholder shows there is no count:

```html
<!-- packages/common/src/components/CrudTable.vue:612 (before) -->
<Paginator :rows="options.rows" :totalRecords="totalItems" ... />
```

```
loading: selectX=804  bg=rgb(229, 229, 231)  disabled=true   pageButtons=[]
loaded : selectX=824  bg=rgb(255, 255, 255)  disabled=false  pageButtons=["1"]
```

Stand in a full page while the placeholder shows, the same way the skeleton rows stand in for the rows:

```ts
// packages/common/src/components/CrudTable.vue:152
const displayTotal = computed<number>(() => {
  return showSkeleton.value ? options.value.rows : totalItems.value;
});
```

## 2. The shift — a centred cluster widening from the middle

Once the count arrives the page buttons appear, and a centred cluster grows outward in both directions, carrying the select with it. Anchoring the cluster to the right edge pins the select — the buttons then grow leftward into empty space:

```css
/* packages/common/src/components/CrudTable.vue:657 */
.crud-table .p-paginator {
  justify-content: flex-end;
}
```

The `Paginator` already carried a `justify-end` class that the theme's own `justify-content: center` on `.p-paginator` outweighed; this rule replaces it and wins on specificity. The select's right edge lands at the table's content edge, lining up with the row-menu column.

## Verification

Measured on the select element, before and after the rows arrive:

```
                        selectX loading -> loaded
one page  (3 records)      1256 -> 1256    0px
five pages (42 records)    1256 -> 1256    0px
five pages, dark           1256 -> 1256    0px
card view (42 records)     1256 -> 1256    0px
```

Enabled and white (`rgb(255, 255, 255)`) in both states throughout. Re-ran the #417 checks against these commits:

```
                   headerShift   paginatorShift   pagerVisible      rows
full-page-10          0px            0px          true  -> true    10 -> 10
partial-3             0px            0px          true  -> true    10 -> 3
empty-0               0px            0px          true  -> true    10 -> 1
partial-3-dark        0px            0px          true  -> true    10 -> 3
partial-3 @720h       0px            0px          true  -> true    10 -> 3
```

plus internal scrolling with a fixed header in both themes, a tall non-table page still scrolling, and the card grid. `vue-tsc -b` clean for `apps/portal` and `apps/system`.

## Note

The alignment change applies to every CrudTable, in both apps — it is a look change, not only a fix for the load. It was reviewed against a rendered before/after comparison before going in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWX9G4EfekrvUZXqErZT4u
