### PR TITLE
Console: full-height tab tables and header organization switcher

### DIFF
--- a/kinotic-frontend/apps/system/src/layouts/Header.vue
+++ b/kinotic-frontend/apps/system/src/layouts/Header.vue
@@ -6,6 +6,42 @@
       </RouterLink>
       <span class="text-lg text-surface-600">/</span>
       <span class="text-sm font-medium text-surface-300">System Console</span>
+
+      <template v-if="isOrgDetailPage">
+        <span class="text-lg text-surface-600">/</span>
+
+        <div ref="orgDropdownRef" class="relative inline-block">
+          <button @click="toggleOrgDropdown"
+            class="flex w-full items-center justify-between gap-2 text-sm font-medium text-surface-300 transition-opacity hover:opacity-80">
+            {{ currentOrgName }}
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div v-if="orgDropdownOpen"
+            :class="[
+              'absolute top-full left-0 z-50 mt-2 max-h-80 w-64 overflow-y-auto rounded-xl border p-2 shadow-lg',
+              isDark ? 'border-surface-800 bg-surface-900' : 'border-surface-200 bg-surface-0'
+            ]">
+            <div class="w-full mb-2">
+              <IconField class="w-full">
+                <InputIcon class="pi pi-search" />
+                <InputText v-model="searchTextOrg" placeholder="Search organizations" class="w-full" />
+              </IconField>
+            </div>
+            <div v-for="org in filteredOrganizations" :key="org.id ?? ''" @click="selectOrg(org)"
+              :class="[
+                'flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-sm',
+                currentOrgId === org.id
+                  ? 'bg-primary-50 text-primary-600 font-medium'
+                  : isDark ? 'text-surface-0 hover:bg-surface-800' : 'text-surface-950 hover:bg-surface-100'
+              ]">
+              <span>{{ org.name }}</span>
+              <i v-if="currentOrgId === org.id" class="pi pi-check text-primary-500"></i>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
 
     <div class="flex items-center gap-3">
@@ -48,22 +84,46 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import IconField from 'primevue/iconfield'
+import InputIcon from 'primevue/inputicon'
+import InputText from 'primevue/inputtext'
 
-import { Kinotic } from '@kinotic-ai/core'
-import type { UserParticipantIdentity } from '@kinotic-ai/os-api'
+import { Kinotic, Pageable } from '@kinotic-ai/core'
+import type { Organization, UserParticipantIdentity } from '@kinotic-ai/os-api'
 import { isDark as darkMode, toggleDark } from '@kinotic-ai/frontend-common'
 
 import { SYSTEM_USER_STATE } from '@/states/SystemUserState'
 
+const route = useRoute()
 const router = useRouter()
 
 const avatarDropdownOpen = ref(false)
 const avatarDropdownRef = ref<HTMLElement>()
 const profile = ref<UserParticipantIdentity | null>(null)
 
+const orgDropdownOpen = ref(false)
+const orgDropdownRef = ref<HTMLElement>()
+const organizations = ref<Organization[]>([])
+const searchTextOrg = ref('')
+
 const isDark = darkMode
+
+const isOrgDetailPage = computed(() => route.name === 'organization-detail')
+const currentOrgId = computed(() => route.params.organizationId as string | undefined)
+
+const currentOrgName = computed(() => {
+  const current = organizations.value.find(org => org.id === currentOrgId.value)
+  return current?.name ?? currentOrgId.value ?? ''
+})
+
+const filteredOrganizations = computed(() => {
+  const needle = searchTextOrg.value.trim().toLowerCase()
+  return needle
+      ? organizations.value.filter(org => org.name.toLowerCase().includes(needle) || (org.id ?? '').includes(needle))
+      : organizations.value
+})
 
 const profileName = computed(() => profile.value?.displayName ?? 'System operator')
 const profileDetail = computed(() => profile.value?.email ?? SYSTEM_USER_STATE.connectedInfo?.participant?.id ?? '')
@@ -72,6 +132,37 @@ const avatarMenuItemClass = computed(() => [
   'flex w-full items-center px-4 py-2 text-left text-sm',
   isDark.value ? 'text-surface-0 hover:bg-surface-800' : 'text-surface-700 hover:bg-surface-100'
 ])
+
+// Load once when the org segment first shows, so the switcher and name resolve without a click
+watch(isOrgDetailPage, onOrgDetail => {
+  if (onOrgDetail && organizations.value.length === 0) {
+    loadOrganizations()
+  }
+}, { immediate: true })
+
+async function loadOrganizations() {
+  try {
+    const page = await Kinotic.systemOrganizations.findOrganizations(Pageable.create(0, 100))
+    organizations.value = page.content ?? []
+  } catch {
+    // The segment falls back to showing the route's organization id
+  }
+}
+
+function toggleOrgDropdown() {
+  orgDropdownOpen.value = !orgDropdownOpen.value
+  if (orgDropdownOpen.value && organizations.value.length === 0) {
+    loadOrganizations()
+  }
+}
+
+function selectOrg(org: Organization) {
+  orgDropdownOpen.value = false
+  searchTextOrg.value = ''
+  if (org.id && org.id !== currentOrgId.value) {
+    router.push({ name: 'organization-detail', params: { organizationId: org.id } })
+  }
+}
 
 onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
@@ -89,6 +180,9 @@ onBeforeUnmount(() => {
 function handleClickOutside(event: MouseEvent) {
   if (avatarDropdownOpen.value && avatarDropdownRef.value && !avatarDropdownRef.value.contains(event.target as Node)) {
     avatarDropdownOpen.value = false
+  }
+  if (orgDropdownOpen.value && orgDropdownRef.value && !orgDropdownRef.value.contains(event.target as Node)) {
+    orgDropdownOpen.value = false
   }
 }
 

--- a/kinotic-frontend/apps/system/src/pages/OrganizationDetailPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/OrganizationDetailPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="flex flex-col">
     <div class="flex items-center gap-3 mb-5">
       <Button icon="pi pi-arrow-left" severity="secondary" text aria-label="Back to organizations"
               @click="router.push({ name: 'organizations' })" />
@@ -14,20 +14,22 @@
 
     <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>
 
-    <Tabs v-else value="applications">
+    <!-- The flex chain from ConsoleLayout runs through the tabs so each table's flex-1
+         shell fills the viewport height regardless of row count, like every list page. -->
+    <Tabs v-else value="applications" class="flex flex-1 flex-col">
       <TabList>
         <Tab value="applications">Applications</Tab>
         <Tab value="projects">Projects</Tab>
         <Tab value="members">Members</Tab>
       </TabList>
-      <TabPanels>
-        <TabPanel value="applications">
+      <TabPanels class="flex flex-1 flex-col">
+        <TabPanel value="applications" class="flex flex-1 flex-col">
           <OrgApplicationsTable :organization-id="organizationId" />
         </TabPanel>
-        <TabPanel value="projects">
+        <TabPanel value="projects" class="flex flex-1 flex-col">
           <OrgProjectsTable :organization-id="organizationId" />
         </TabPanel>
-        <TabPanel value="members">
+        <TabPanel value="members" class="flex flex-1 flex-col">
           <OrgMembersTable :organization-id="organizationId" />
         </TabPanel>
       </TabPanels>


### PR DESCRIPTION
Two console refinements on top of #417/#418.

## Org-detail tab tables fill the viewport

#417 pins the CrudTable shell height and paginator, but inside the org-detail tabs the layout's flex chain stopped at the `Tabs` wrapper, so the shell had no height to fill and hugged its rows — a one-row Members tab rendered a short card while every list page filled the screen. The chain now runs through the tabs:

```html
<!-- OrganizationDetailPage.vue -->
<Tabs value="applications" class="flex flex-1 flex-col">
  <TabPanels class="flex flex-1 flex-col">
    <TabPanel value="members" class="flex flex-1 flex-col">   <!-- CrudTable's flex-1 now fills -->
      <OrgMembersTable :organization-id="organizationId" />
```

Inactive panels stay hidden: `TabPanel` hides via `v-show`, whose inline `display:none` outranks the `flex` class (checked in the installed PrimeVue source).

## Header grows an organization switcher when drilled in

Mirrors the portal header's application dropdown — on the `organization-detail` route the console header shows `… / System Console / <org> ▾` with a searchable organization list (loaded once via `Kinotic.systemOrganizations.findOrganizations`, current org checked, click switches org in place):

```html
<!-- apps/system/layouts/Header.vue -->
<template v-if="isOrgDetailPage">
  <span class="text-lg text-surface-600">/</span>
  <div ref="orgDropdownRef" class="relative inline-block">
    <button @click="toggleOrgDropdown" class="... text-surface-300 hover:opacity-80">
      {{ currentOrgName }}
```

The label falls back to the route's organization id until the list loads.

## Verified

- Both apps `vue-tsc -b && vite build` clean on top of develop's reworked CrudTable (skeleton loading, fixed column layout)
- Note: the org switcher calls `systemOrganizations.findOrganizations`, which ships in the still-unpublished `@kinotic-ai/os-api@5.0.0-beta.11` — same publish gate as the merged console org pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS

---
_Generated by [Claude Code](https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS)_