### PR TITLE
Redesign ProfilePage with enhanced identity card and PageHeader component

### DIFF
--- a/kinotic-frontend/apps/portal/components.d.ts
+++ b/kinotic-frontend/apps/portal/components.d.ts
@@ -32,6 +32,7 @@ declare module 'vue' {
     GlobalObjectNode: typeof import('./src/components/nodes/GlobalObjectNode.vue')['default']
     NewProjectSidebar: typeof import('./src/components/NewProjectSidebar.vue')['default']
     ObjectNode: typeof import('./src/components/nodes/ObjectNode.vue')['default']
+    PageHeader: typeof import('./src/components/PageHeader.vue')['default']
     ProjectEntityDefinitionsTable: typeof import('./src/components/ProjectEntityDefinitionsTable.vue')['default']
     ProjectList: typeof import('./src/components/ProjectList.vue')['default']
     PropertyType: typeof import('./src/components/entity-definitions/flow-components/PropertyType.vue')['default']

--- a/kinotic-frontend/apps/portal/src/components/PageHeader.vue
+++ b/kinotic-frontend/apps/portal/src/components/PageHeader.vue
@@ -12,7 +12,7 @@ defineProps<{
 </script>
 
 <template>
-  <header class="mb-8 flex flex-wrap items-start justify-between gap-4">
+  <header class="mb-6 flex flex-wrap items-start justify-between gap-4">
     <div class="min-w-0">
       <h1 class="text-2xl font-semibold tracking-tight text-surface-950 dark:text-surface-0">{{ title }}</h1>
       <p v-if="description" class="mt-2 max-w-[640px] text-sm text-surface-500 dark:text-surface-400">

--- a/kinotic-frontend/apps/portal/src/components/PageHeader.vue
+++ b/kinotic-frontend/apps/portal/src/components/PageHeader.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+/**
+ * The title block a page opens with: the page's name, an optional sentence saying what the
+ * page is for, and an {@code actions} slot for the controls that act on the whole page.
+ *
+ * The section a page belongs to is named by the sidebar, so the title stands alone here.
+ */
+defineProps<{
+  title: string
+  description?: string
+}>()
+</script>
+
+<template>
+  <header class="mb-8 flex flex-wrap items-start justify-between gap-4">
+    <div class="min-w-0">
+      <h1 class="text-2xl font-semibold tracking-tight text-surface-950 dark:text-surface-0">{{ title }}</h1>
+      <p v-if="description" class="mt-2 max-w-[640px] text-sm text-surface-500 dark:text-surface-400">
+        {{ description }}
+      </p>
+    </div>
+
+    <div v-if="$slots.actions" class="flex shrink-0 items-center gap-2">
+      <slot name="actions" />
+    </div>
+  </header>
+</template>

--- a/kinotic-frontend/apps/portal/src/pages/ApplicationDetails.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ApplicationDetails.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import ProjectList from '@/components/ProjectList.vue'
 import EntityDefinitionsList from '@/components/EntityDefinitionsList.vue'
+import PageHeader from '@/components/PageHeader.vue'
 import Tabs from 'primevue/tabs'
 import TabList from 'primevue/tablist'
 import Tab from 'primevue/tab'
@@ -75,12 +76,7 @@ isInitialized.value = true
   <!-- The flex column chain down through the tabs lets the CrudTable shell stretch to the
        bottom of the viewport, keeping its paginator in a fixed position. -->
   <div :class="['flex flex-col transition-colors', isDark ? 'text-surface-0' : 'text-surface-950']">
-    <div class="flex justify-between items-center mb-6 h-[58px]">
-      <div>
-        <h1 :class="['mb-3 text-2xl font-semibold', isDark ? 'text-white' : 'text-surface-950']">{{ applicationId }}</h1>
-        <span :class="[isDark ? 'text-surface-400' : 'text-surface-600']">{{ projectsCount }} projects, {{ entityDefinitionsCount }} entities</span>
-      </div>
-    </div>
+    <PageHeader :title="applicationId" :description="`${projectsCount} projects, ${entityDefinitionsCount} entities`" />
 
     <Tabs class="flex-1" :value="activeTab" @update:value="activeTab = $event">
       <TabList>

--- a/kinotic-frontend/apps/portal/src/pages/ApplicationList.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ApplicationList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { CrudTable } from "@kinotic-ai/frontend-common";
 import ApplicationSidebar from "@/components/ApplicationSidebar.vue";
+import PageHeader from "@/components/PageHeader.vue";
 import { Kinotic } from "@kinotic-ai/core";
 import {
   type IApplicationService,
@@ -134,7 +135,7 @@ async function deleteApplication(item: Application): Promise<void> {
 
 <template>
   <div :class="['application-list flex flex-col transition-colors', isDark ? 'application-list--dark text-surface-0' : 'text-surface-950']">
-    <h1 :class="['mb-5 text-2xl font-semibold', isDark ? 'text-white' : 'text-surface-950']">Applications</h1>
+    <PageHeader title="Applications" />
     <CrudTable
       ref="crudTable"
       createNewButtonText="New application"

--- a/kinotic-frontend/apps/portal/src/pages/ApplicationSettings.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ApplicationSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['application-settings', isDark ? 'application-settings--dark' : 'application-settings--light']">
-    <h1 class="application-settings__title">Application settings</h1>
+    <PageHeader title="Application settings" />
 
     <div class="application-settings__general-shell">
       <form @submit.prevent="saveSettings" class="application-settings__form">
@@ -52,6 +52,7 @@
 import { ref, defineProps, onMounted, watch } from 'vue'
 import { showErrorToast } from '@kinotic-ai/frontend-common'
 import { InputText, Textarea, Button, ToggleSwitch } from 'primevue'
+import PageHeader from '@/components/PageHeader.vue'
 import { APPLICATION_STATE } from '@/states/IApplicationState'
 import { USER_STATE } from '@/states/IUserState'
 import { Kinotic } from '@kinotic-ai/core'
@@ -140,19 +141,10 @@ const saveSettings = async () => {
   color: #101010;
 }
 
-.application-settings__title {
-  margin: 0 0 1.25rem;
-  font-size: 1.5rem;
-  font-weight: 600;
-  line-height: 1;
-}
-
-.application-settings--dark .application-settings__title,
 .application-settings--dark .application-settings__label {
   color: #ffffff;
 }
 
-.application-settings--light .application-settings__title,
 .application-settings--light .application-settings__label {
   color: #101010;
 }

--- a/kinotic-frontend/apps/portal/src/pages/ConnectedAppsPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ConnectedAppsPage.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="flex flex-col">
+    <PageHeader title="Connected apps"
+                description="Clients you have authorized to act on your behalf. Revoking one signs it out everywhere." />
+
     <CrudTable
       ref="crudTable"
       :headers="headers"
@@ -66,6 +69,7 @@ import type { CrudHeader } from '@kinotic-ai/frontend-common'
 import type { DescriptiveIdentifiable } from '@kinotic-ai/frontend-common'
 import { DatetimeUtil } from '@kinotic-ai/frontend-common'
 import { showErrorToast } from '@kinotic-ai/frontend-common'
+import PageHeader from '@/components/PageHeader.vue'
 
 /** One table row — a client authorized to act on the signed-in user's behalf. */
 interface DelegateRow extends DescriptiveIdentifiable {

--- a/kinotic-frontend/apps/portal/src/pages/Dashboards.vue
+++ b/kinotic-frontend/apps/portal/src/pages/Dashboards.vue
@@ -5,6 +5,7 @@ import { APPLICATION_STATE } from '@/states/IApplicationState'
 import { DashboardEntityRepository } from '@/services/DashboardEntityRepository'
 import { Dashboard } from '@/domain/Dashboard'
 import { CrudTable } from '@kinotic-ai/frontend-common'
+import PageHeader from '@/components/PageHeader.vue'
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import { useToast } from 'primevue/usetoast'
@@ -189,9 +190,7 @@ watch(() => router.currentRoute.value.query.refresh, () => {
 
 <template>
   <div :class="['transition-colors', isDark ? 'text-surface-0' : 'text-surface-950']">
-    <div :class="['mb-6 flex items-center justify-between border-b pb-6', isDark ? 'border-surface-800' : 'border-surface-200']">
-      <h1 :class="['text-2xl font-semibold', isDark ? 'text-surface-0' : 'text-surface-950']">{{ title }}</h1>
-    </div>
+    <PageHeader :title="title" />
     
     <div class="h-[calc(100vh-140px)]">
       <CrudTable

--- a/kinotic-frontend/apps/portal/src/pages/InviteEmailTemplatePage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/InviteEmailTemplatePage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="invite-email-page">
-    <h1 class="text-xl font-semibold mb-4">Invitation email</h1>
+    <PageHeader title="Invitation email" />
 
     <div v-if="loading" class="flex justify-center py-12">
       <i class="pi pi-spin pi-spinner text-3xl text-primary-500"></i>
@@ -67,6 +67,7 @@ import { useToast } from 'primevue/usetoast'
 
 import { Kinotic } from '@kinotic-ai/core'
 import { InviteEmailTemplate } from '@kinotic-ai/os-api'
+import PageHeader from '@/components/PageHeader.vue'
 import { showErrorToast } from '@kinotic-ai/frontend-common'
 
 /**

--- a/kinotic-frontend/apps/portal/src/pages/MachinesPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/MachinesPage.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="flex flex-col">
+    <PageHeader title="Machines"
+                description="Non-human callers that connect to this application's API with their own client id and secret." />
+
     <CrudTable
       ref="crudTable"
       :headers="headers"
@@ -91,6 +94,7 @@ import { Kinotic } from '@kinotic-ai/core'
 import type { MachineParticipantIdentity } from '@kinotic-ai/os-api'
 
 import { CrudTable } from '@kinotic-ai/frontend-common'
+import PageHeader from '@/components/PageHeader.vue'
 import { filteredPageLoader, statusSeverity, useCrudTablePage } from '@kinotic-ai/frontend-common'
 import type { CrudHeader } from '@kinotic-ai/frontend-common'
 import type { DescriptiveIdentifiable } from '@kinotic-ai/frontend-common'

--- a/kinotic-frontend/apps/portal/src/pages/MembersPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/MembersPage.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="flex flex-col">
+    <PageHeader title="Members" :description="membersDescription" />
+
     <CrudTable
       ref="crudTable"
       :headers="headers"
@@ -72,6 +74,7 @@ import {
 import type { PendingInviteSummary, UserParticipantIdentity } from '@kinotic-ai/os-api'
 
 import { CrudTable } from '@kinotic-ai/frontend-common'
+import PageHeader from '@/components/PageHeader.vue'
 import { statusSeverity, useCrudTablePage } from '@kinotic-ai/frontend-common'
 import type { CrudHeader } from '@kinotic-ai/frontend-common'
 import type { DescriptiveIdentifiable } from '@kinotic-ai/frontend-common'
@@ -126,6 +129,12 @@ const userState = KinoticStates.getUserState()
 const { crudTable, tableSearch, dataSource, refreshTable, run } = useCrudTablePage(load)
 
 const formatDate = DatetimeUtil.formatEpochDate
+
+const membersDescription = computed<string>(() => {
+  return props.applicationId !== null
+      ? 'Everyone with access to this application, including pending invitations.'
+      : 'Everyone in your organization, including pending invitations.'
+})
 
 const providersHint = computed<string>(() => {
   if (props.applicationId !== null) {

--- a/kinotic-frontend/apps/portal/src/pages/OrganizationSettings.vue
+++ b/kinotic-frontend/apps/portal/src/pages/OrganizationSettings.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import GitHubLinkStatus from '@/components/GitHubLinkStatus.vue'
+import PageHeader from '@/components/PageHeader.vue'
 </script>
 
 <template>
   <div>
-    <div class="mb-2 text-sm text-surface-500">Organization</div>
-    <h1 class="mb-6 text-2xl font-semibold text-surface-950 dark:text-surface-0">Organization settings</h1>
+    <PageHeader title="Organization settings" description="Settings that apply to everyone in your organization." />
 
     <section class="max-w-[720px]">
       <h2 class="mb-3 text-sm font-semibold text-surface-950 dark:text-surface-0">Integrations</h2>

--- a/kinotic-frontend/apps/portal/src/pages/OrganizationWorkspacePlaceholder.vue
+++ b/kinotic-frontend/apps/portal/src/pages/OrganizationWorkspacePlaceholder.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import PageHeader from '@/components/PageHeader.vue'
+
 defineProps<{
   title: string
   description?: string
@@ -6,11 +8,5 @@ defineProps<{
 </script>
 
 <template>
-  <div>
-    <div class="mb-2 text-sm text-surface-500">Organization</div>
-    <h1 class="mb-3 text-2xl font-semibold text-surface-950 dark:text-surface-0">{{ title }}</h1>
-    <p class="max-w-[560px] text-sm text-surface-500 dark:text-surface-400">
-      {{ description || 'This section is being prepared.' }}
-    </p>
-  </div>
+  <PageHeader :title="title" :description="description || 'This section is being prepared.'" />
 </template>

--- a/kinotic-frontend/apps/portal/src/pages/ProfilePage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ProfilePage.vue
@@ -1,67 +1,150 @@
 <template>
-  <div>
-    <div class="mb-2 text-sm text-surface-500">Account</div>
-    <h1 class="mb-6 text-2xl font-semibold text-surface-950 dark:text-surface-0">Profile</h1>
+  <div class="max-w-[860px]">
+    <PageHeader title="Profile" description="How you appear to everyone else in Kinotic." />
 
-    <section class="max-w-[560px]">
-      <div class="flex items-center gap-5 border-b border-surface-200 pb-6 dark:border-surface-700">
-        <Avatar :label="initials" shape="circle" size="xlarge" />
-        <div class="flex min-w-0 flex-col gap-1">
-          <span class="truncate text-lg font-semibold text-surface-950 dark:text-surface-0">
-            {{ savedDisplayName || 'Unnamed user' }}
+    <div class="flex flex-col gap-6">
+      <section class="relative overflow-hidden rounded-2xl border border-surface-200 bg-surface-0 dark:border-surface-700 dark:bg-surface-800/30">
+        <div class="pointer-events-none absolute -right-20 -top-28 h-72 w-72 rounded-full bg-primary-500/10 blur-[90px] dark:bg-primary-500/20"
+             aria-hidden="true" />
+
+        <div class="relative flex flex-wrap items-center gap-5 px-6 py-6">
+          <Skeleton v-if="loading" shape="circle" size="4.5rem" />
+          <div v-else aria-hidden="true"
+               class="grid h-18 w-18 shrink-0 place-items-center rounded-full bg-gradient-to-br from-primary-400 to-primary-600
+                      text-2xl font-semibold text-white shadow-lg shadow-primary-500/30 ring-4 ring-primary-500/10">
+            {{ initials || '?' }}
+          </div>
+
+          <div class="flex min-w-0 flex-1 flex-col gap-1.5">
+            <Skeleton v-if="loading" height="1.75rem" width="12rem" />
+            <h2 v-else class="truncate text-2xl font-semibold tracking-tight text-surface-950 dark:text-surface-0">
+              {{ savedDisplayName || 'Unnamed user' }}
+            </h2>
+
+            <Skeleton v-if="loading" height="1rem" width="16rem" />
+            <span v-else class="truncate text-sm text-muted-color">{{ email }}</span>
+          </div>
+
+          <Tag v-if="!loading" :value="statusLabel" :severity="statusSeverity(statusLabel)" rounded />
+        </div>
+
+        <dl class="relative grid gap-5 border-t border-surface-200 px-6 py-5 sm:grid-cols-3 dark:border-surface-700">
+          <div v-for="detail in details" :key="detail.label" class="flex min-w-0 flex-col gap-1.5">
+            <dt class="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-color">
+              <i :class="detail.icon" />
+              {{ detail.label }}
+            </dt>
+            <dd class="m-0 min-w-0">
+              <Skeleton v-if="loading" height="1rem" width="7rem" />
+              <button v-else-if="detail.copyable" type="button"
+                      class="group flex w-full min-w-0 items-center gap-2 text-left font-mono text-xs text-surface-700 dark:text-surface-300"
+                      :title="detail.value" :aria-label="`Copy ${detail.label.toLowerCase()}`"
+                      @click="copy(detail.label, detail.value)">
+                <span class="truncate">{{ detail.value }}</span>
+                <i :class="[copied === detail.label ? 'pi pi-check text-green-500' : 'pi pi-copy opacity-50 group-hover:opacity-100',
+                            'shrink-0 !text-xs transition-opacity']" />
+              </button>
+              <span v-else class="text-sm">{{ detail.value }}</span>
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="rounded-2xl border border-surface-200 bg-surface-0 dark:border-surface-700 dark:bg-surface-800/30">
+        <div class="flex flex-col gap-4 px-6 py-6">
+          <div class="flex flex-col gap-1">
+            <label for="profile-display-name" class="text-sm font-medium">Display name</label>
+            <small class="text-muted-color">Shown wherever you appear in the platform.</small>
+          </div>
+
+          <Skeleton v-if="loading" height="2.5rem" />
+          <InputText v-else id="profile-display-name" v-model="displayName" :invalid="emptyName"
+                     class="max-w-[26rem]" autocomplete="name" maxlength="80"
+                     @keyup.enter="save" @keyup.esc="reset" />
+
+          <small v-if="emptyName" class="text-red-500">A display name is required.</small>
+        </div>
+
+        <div class="flex flex-wrap items-center justify-between gap-3 border-t border-surface-200 px-6 py-4 dark:border-surface-700">
+          <span class="flex items-center gap-2 text-xs text-muted-color">
+            <template v-if="dirty">
+              <span class="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
+              Unsaved changes
+            </template>
           </span>
-          <span class="truncate text-sm text-muted-color">{{ email }}</span>
-          <span class="text-xs text-muted-color">Profile photos aren't supported yet.</span>
-        </div>
-      </div>
 
-      <div class="flex flex-col gap-5 pt-6">
-        <div class="flex flex-col gap-1">
-          <label for="profile-display-name" class="text-sm font-medium">Display name</label>
-          <InputText id="profile-display-name" v-model="displayName" :disabled="loading"
-                     autocomplete="name" @keyup.enter="save" />
-          <small class="text-muted-color">Shown wherever you appear in the platform.</small>
+          <div class="flex items-center gap-2">
+            <Button v-if="dirty" label="Reset" severity="secondary" text size="small"
+                    :disabled="saving" @click="reset" />
+            <Button label="Save changes" size="small" :loading="saving" :disabled="!canSave" @click="save" />
+          </div>
         </div>
-
-        <div class="flex flex-col gap-1">
-          <label for="profile-email" class="text-sm font-medium">Email</label>
-          <InputText id="profile-email" :model-value="email" disabled />
-          <small class="text-muted-color">Identifies your account within this organization.</small>
-        </div>
-
-        <div>
-          <Button label="Save changes" :loading="saving" :disabled="!canSave" @click="save" />
-        </div>
-      </div>
-    </section>
+      </section>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import Avatar from 'primevue/avatar'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import Button from 'primevue/button'
 import InputText from 'primevue/inputtext'
+import Skeleton from 'primevue/skeleton'
+import Tag from 'primevue/tag'
 import { useToast } from 'primevue/usetoast'
 
-import { showErrorToast } from '@kinotic-ai/frontend-common'
+import { AuthType } from '@kinotic-ai/os-api'
+import { DatetimeUtil, showErrorToast, statusSeverity } from '@kinotic-ai/frontend-common'
+import PageHeader from '@/components/PageHeader.vue'
 import { PROFILE_STATE } from '@/states/IProfileState'
+
+/** One read-only fact about the account, rendered as a column of the identity card's footer. */
+interface ProfileDetail {
+  label: string
+  value: string
+  icon: string
+  copyable?: boolean
+}
+
+/** How long the copy button shows its confirmation before returning to the copy icon. */
+const COPIED_FEEDBACK_MILLIS = 2000
 
 const toast = useToast()
 
 const displayName = ref('')
 const loading = ref(true)
 const saving = ref(false)
+const copied = ref<string | null>(null)
+
+let copiedTimer: ReturnType<typeof setTimeout> | null = null
 
 const email = computed(() => PROFILE_STATE.profile?.email ?? '')
 const savedDisplayName = computed(() => PROFILE_STATE.profile?.displayName ?? '')
 const initials = computed(() => PROFILE_STATE.initials)
+const statusLabel = computed(() => PROFILE_STATE.profile?.enabled ? 'Active' : 'Disabled')
 
-const canSave = computed(() => !loading.value
-                              && displayName.value.trim().length > 0
-                              && displayName.value.trim() !== savedDisplayName.value)
+const dirty = computed(() => !loading.value && displayName.value.trim() !== savedDisplayName.value)
+const emptyName = computed(() => !loading.value && displayName.value.trim().length === 0)
+const canSave = computed(() => dirty.value && !emptyName.value)
+
+const details = computed<ProfileDetail[]>(() => [
+  { label: 'Sign-in method', value: signInMethod(), icon: 'pi pi-shield' },
+  { label: 'Member since', value: DatetimeUtil.formatMonthDayYear(PROFILE_STATE.profile?.created ?? 0) || '—', icon: 'pi pi-calendar' },
+  { label: 'User ID', value: PROFILE_STATE.profile?.id ?? '—', icon: 'pi pi-hashtag', copyable: true }
+])
 
 onMounted(load)
+
+onBeforeUnmount(() => {
+  if (copiedTimer) clearTimeout(copiedTimer)
+})
+
+function signInMethod(): string {
+  switch (PROFILE_STATE.profile?.authType) {
+    case AuthType.LOCAL: return 'Password'
+    case AuthType.OIDC:  return 'Single sign-on'
+    default:             return '—'
+  }
+}
 
 async function load() {
   try {
@@ -72,6 +155,10 @@ async function load() {
   } finally {
     loading.value = false
   }
+}
+
+function reset() {
+  displayName.value = savedDisplayName.value
 }
 
 async function save() {
@@ -85,6 +172,17 @@ async function save() {
     showErrorToast(toast, 'Failed to save your profile', err, { life: 8000 })
   } finally {
     saving.value = false
+  }
+}
+
+async function copy(label: string, value: string) {
+  try {
+    await navigator.clipboard.writeText(value)
+    copied.value = label
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => { copied.value = null }, COPIED_FEEDBACK_MILLIS)
+  } catch (err) {
+    showErrorToast(toast, `Failed to copy the ${label.toLowerCase()}`, err)
   }
 }
 </script>

--- a/kinotic-frontend/apps/portal/src/pages/ProjectEntityDefinitionsPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ProjectEntityDefinitionsPage.vue
@@ -2,16 +2,15 @@
 import { useRoute } from 'vue-router'
 import { computed, watch } from 'vue'
 import ProjectEntityDefinitionsTable from '@/components/ProjectEntityDefinitionsTable.vue'
+import PageHeader from '@/components/PageHeader.vue'
 import { APPLICATION_STATE } from '@/states/IApplicationState'
 import { createDebug } from '@kinotic-ai/frontend-common'
-import { isDark as darkMode } from '@kinotic-ai/frontend-common'
 
 const debug = createDebug('project-entity-definitions-page')
 
 const route = useRoute()
 const projectId = computed(() => route.params.projectId as string)
 const applicationId = computed(() => APPLICATION_STATE.currentApplication?.id || '')
-const isDark = computed(() => darkMode.value)
 
 watch(() => APPLICATION_STATE.currentApplication, (newApp) => {
   debug('APPLICATION_STATE.currentApplication changed to: %s', newApp?.id)
@@ -24,9 +23,7 @@ watch(applicationId, (newId) => {
 
 <template>
   <div class="flex flex-col">
-    <h1 :class="['mb-4 text-2xl font-semibold', isDark ? 'text-white' : 'text-surface-950']">
-      {{ projectId }}
-    </h1>
+    <PageHeader :title="projectId" />
     <ProjectEntityDefinitionsTable :key="`${applicationId}-${projectId}`" :applicationId="applicationId" />
   </div>
 </template>

--- a/kinotic-frontend/apps/portal/src/pages/SavedWidgets.vue
+++ b/kinotic-frontend/apps/portal/src/pages/SavedWidgets.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['saved-widgets-page', isDark ? 'text-surface-0' : 'text-surface-950']">
-    <h1 :class="['text-2xl font-semibold mb-4', isDark ? 'text-surface-0' : 'text-surface-950']">Saved Widgets</h1>
+    <PageHeader title="Saved Widgets" />
 
     <!-- Loading state -->
     <div v-if="loadingWidgets" class="flex justify-center py-12">
@@ -103,6 +103,7 @@ import { useToast } from 'primevue/usetoast'
 import { DataInsightsWidgetEntityRepository } from '@/services/DataInsightsWidgetEntityRepository'
 import type { DataInsightsWidget } from '@/domain/DataInsightsWidget'
 import SavedWidgetItem from '@/components/SavedWidgetItem.vue'
+import PageHeader from '@/components/PageHeader.vue'
 import { createDebug } from '@kinotic-ai/frontend-common'
 import { isDark as darkMode } from '@kinotic-ai/frontend-common'
 

--- a/kinotic-frontend/apps/portal/src/pages/routes.ts
+++ b/kinotic-frontend/apps/portal/src/pages/routes.ts
@@ -6,6 +6,10 @@ function organizationSidebarItem(label: string, icon: string, order: number): Si
   return { group: 'organization', section: 'Organization', label, icon, order }
 }
 
+function accountSidebarItem(label: string, icon: string, order: number): SidebarItemMeta {
+  return { group: 'account', section: 'Account', label, icon, order }
+}
+
 function organizationPlaceholderRoute(path: string, name: string, title: string, description: string,
                                       icon: string, order: number): RouteRecordRaw {
   return {
@@ -101,7 +105,7 @@ const pageRoutes: RouteRecordRaw[] = [
         name: 'account-profile',
         path: 'profile',
         meta: {
-          sidebar: { group: 'account', label: 'Profile', icon: 'pi-user', order: 10 } as SidebarItemMeta
+          sidebar: accountSidebarItem('Profile', 'pi-user', 10)
         } as RouteMeta,
         component: () => import('@/pages/ProfilePage.vue')
       },
@@ -109,7 +113,7 @@ const pageRoutes: RouteRecordRaw[] = [
         name: 'account-connected-apps',
         path: 'connected-apps',
         meta: {
-          sidebar: { group: 'account', label: 'Connected apps', icon: 'pi-link', order: 20 } as SidebarItemMeta
+          sidebar: accountSidebarItem('Connected apps', 'pi-link', 20)
         } as RouteMeta,
         component: () => import('@/pages/ConnectedAppsPage.vue')
       }


### PR DESCRIPTION
Refactors the profile page with a modern identity card design and introduces a reusable `PageHeader` component for consistent page headers across the application.

## Summary

This change modernizes the ProfilePage UI with an enhanced identity card displaying user information, account status, and copyable details (sign-in method, member since, user ID). It also extracts the page header pattern into a reusable `PageHeader` component and applies it consistently across multiple pages.

## Key Changes

**ProfilePage.vue:**
- Redesigned identity card with gradient avatar, status tag, and account details (sign-in method, member since, user ID)
- Added copy-to-clipboard functionality for copyable fields with visual feedback
- Separated display name form into its own section with reset/save controls
- Added validation for empty display names with error messaging
- Introduced "unsaved changes" indicator and reset button
- Added loading skeletons for better perceived performance
- Integrated `PageHeader` component with description
- Added `statusSeverity()` utility and `AuthType` enum handling for sign-in method display

**PageHeader.vue (new):**
- Reusable component for consistent page headers with title, optional description, and actions slot
- Replaces inline header markup across multiple pages
- Follows established design patterns with proper typography and spacing

**Applied PageHeader to:**
- `ApplicationSettings.vue` — replaced inline title
- `OrganizationWorkspacePlaceholder.vue` — replaced inline header markup
- `MembersPage.vue` — added with dynamic description based on context
- `ApplicationDetails.vue` — replaced inline header with computed description
- `ProjectEntityDefinitionsPage.vue` — replaced inline title
- `Dashboards.vue` — replaced inline header
- `ConnectedAppsPage.vue` — added with descriptive text
- `MachinesPage.vue` — added with descriptive text
- `OrganizationSettings.vue` — replaced inline header
- `ApplicationList.vue` — imported for use
- `InviteEmailTemplatePage.vue` — replaced inline title
- `SavedWidgets.vue` — replaced inline title

**routes.ts:**
- Extracted `accountSidebarItem()` helper function for consistent account sidebar item creation

## Implementation Details

The ProfilePage redesign introduces:
- Copy feedback mechanism with 2-second timeout before reverting to copy icon
- Computed properties for dirty state, validation, and account details
- Proper cleanup of timers on component unmount
- Integration with `DatetimeUtil` for date formatting and `statusSeverity()` for tag styling
- Support for different authentication types (LOCAL, OIDC) with human-readable labels

The `PageHeader` component provides a flexible header pattern with optional description and actions slot, reducing duplication across pages while maintaining visual consistency.

https://claude.ai/code/session_01Ua5jTrfzZUbraFVMyjSe2M