### PR TITLE
Make the CrudTable loading placeholder opt-in

### DIFF
--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -57,6 +57,9 @@ const props = withDefaults(defineProps<{
   enableRowHover?: boolean
   defaultPageSize?: number
   transparentDarkCards?: boolean
+  // Fills the first load with placeholder rows. Worth it only where the fetch is slow
+  // enough to be worth previewing — against a fast one the placeholder is a flash.
+  showLoadingSkeleton?: boolean
   // When set, each row gets an ellipsis button opening a popup menu with these
   // items. Rows for which the function returns an empty array get no button.
   rowActions?: (item: any) => MenuItem[]
@@ -80,6 +83,7 @@ const props = withDefaults(defineProps<{
   enableRowHover: true,
   defaultPageSize: 10,
   transparentDarkCards: false,
+  showLoadingSkeleton: false,
 });
 
 const emit = defineEmits<{
@@ -134,8 +138,12 @@ const hasRowMenu = computed<boolean>(() => {
 });
 
 /** True while a fetch is in flight and there are no rows to keep on screen. */
-const showSkeleton = computed<boolean>(() => {
+const isInitialLoad = computed<boolean>(() => {
   return loading.value && items.value.length === 0;
+});
+
+const showSkeleton = computed<boolean>(() => {
+  return props.showLoadingSkeleton && isInitialLoad.value;
 });
 
 // One placeholder per row the page holds, so the loading state occupies the same height a
@@ -152,7 +160,7 @@ const displayRows = computed<DescriptiveIdentifiable[]>(() => {
 // The paginator disables itself at a count of zero, so a real count would switch it out of
 // its greyed-out state on arrival. Standing in a full page keeps it enabled throughout.
 const displayTotal = computed<number>(() => {
-  return showSkeleton.value ? options.value.rows : totalItems.value;
+  return isInitialLoad.value ? options.value.rows : totalItems.value;
 });
 
 function rowMenuItems(item: DescriptiveIdentifiable): MenuItem[] {
@@ -506,7 +514,7 @@ defineExpose({ find, displayAlert });
           </Card>
         </div>
         <div
-          v-else
+          v-else-if="!loading"
           :class="['flex flex-1 flex-col items-center justify-center py-20', isDark ? 'text-surface-400' : 'text-surface-500']"
         >
           <p class="text-sm">{{ emptyStateText }}</p>


### PR DESCRIPTION
The placeholder rows added in #414 assume the fetch takes long enough to be worth previewing. Ours does not — they are on screen for a frame or two, which reads as a flash rather than a preview. No page takes them now.

```ts
// packages/common/src/components/CrudTable.vue:60
// Fills the first load with placeholder rows. Worth it only where the fetch is slow
// enough to be worth previewing — against a fast one the placeholder is a flash.
showLoadingSkeleton?: boolean   // default: false
```

Every existing table falls back to what it did before the placeholders: header row already in its final position, the indeterminate line running under it, rows filling in when they arrive.

## Keeping the earlier fixes working with it off

The placeholder had become load-bearing for two things it should not have owned. Both now key off the load itself:

```ts
// :141 — the load, independent of whether placeholders render
const isInitialLoad = computed<boolean>(() => loading.value && items.value.length === 0);
const showSkeleton  = computed<boolean>(() => props.showLoadingSkeleton && isInitialLoad.value);

// :162 — was showSkeleton, which would have brought back the grey-then-white select from #419
return isInitialLoad.value ? options.value.rows : totalItems.value;
```

The card view's empty state also has to wait for the fetch to settle, or "No items yet" flashes under every load once nothing is standing in:

```html
<!-- :523 -->
<div v-else-if="!loading" ...>
  <p class="text-sm">{{ emptyStateText }}</p>
</div>
```

## Verification

Driven with Playwright against `CrudTable` inside a copy of the `LayoutForPage` chain, sampled while the fetch is in flight and again once it settles:

```
                   loading state                              shifts (header / select / paginator)
default-off        skeletons=0  emptyText=false  bar=true     0px / 0px / 0px   -> 3 rows
opted-in           skeletons=60 emptyText=false  bar=true     0px / 0px / 0px   -> 3 rows
off, full page     skeletons=0  emptyText=false  bar=true     0px / 0px / 0px   -> 10 rows
off, empty result  skeletons=0  emptyText=false  bar=true     0px / 0px / 0px   -> 0 rows
```

`emptyText=false` while loading is the card-view guard; the paginator select stays enabled in every row. Internal scrolling with the sticky header still holds in both themes, and `vue-tsc -b` is clean for `apps/portal` and `apps/system`.

## Note

Nothing sets the prop — a toggle with no consumer is the kind of seam CLAUDE.md warns against, so the alternative was deleting the placeholder outright and re-adding it if a genuinely slow page turns up. Kept at the owner's request for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWX9G4EfekrvUZXqErZT4u


---
_Generated by [Claude Code](https://claude.ai/code/session_01HWX9G4EfekrvUZXqErZT4u)_