### PR TITLE
Console: organization Dashboard landing page and System wordmark

### DIFF
--- a/kinotic-frontend/apps/system/index.html
+++ b/kinotic-frontend/apps/system/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kinotic System Console</title>
+    <title>Kinotic System</title>
   </head>
   <body>
     <div id="app"></div>

--- a/kinotic-frontend/apps/system/src/layouts/Header.vue
+++ b/kinotic-frontend/apps/system/src/layouts/Header.vue
@@ -5,7 +5,7 @@
         <img src="@/assets/header-logo.svg" class="h-6 w-[27px]" alt="Kinotic" />
       </RouterLink>
       <span class="text-lg text-surface-600">/</span>
-      <span class="text-sm font-medium text-surface-300">System Console</span>
+      <span class="text-sm font-medium text-surface-300">System</span>
 
       <template v-if="isOrgDetailPage">
         <span class="text-lg text-surface-600">/</span>


### PR DESCRIPTION
## Per-organization Dashboard

Drilling into an organization now lands on a Dashboard — the first entry in the organization sidebar group:

```ts
// router.ts — the drill-in redirect lands on the dashboard
{ name: 'organization-detail', path: 'organizations/:organizationId',
  redirect: to => ({ name: 'org-dashboard', params: to.params }) },
{ name: 'org-dashboard', path: 'organizations/:organizationId/dashboard',
  component: () => import('./pages/org/OrgDashboard.vue'), props: true,
  meta: { sidebar: organizationSidebarItem('Dashboard', 'pi-objects-column', 5) } }
```

The page shows clickable count tiles — Applications, Projects, Members, Pending invites — each navigating to its section, plus a Details panel (id, description, created). Counts come from one-row pages (`totalElements` carries the full count):

```ts
const [org, apps, projects, members, invites] = await Promise.all([
  Kinotic.systemOrganizations.findOrganizationById(orgId),
  Kinotic.systemOrganizations.findApplications(orgId, firstPage),
  ...
```

The tile markup was about to appear a second time, so it extracted to `StatTile.vue`, now shared by the console Overview and the org Dashboard.

## Wordmark

Header wordmark and browser-tab title go from "System Console" to "System" / "Kinotic System".

## Verified

- Console `vue-tsc -b && vite build` clean
- Org reads still gated on publishing `@kinotic-ai/os-api@5.0.0-beta.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS