### PR TITLE
Handle event consumer unregistration gracefully

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConsumer.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConsumer.java
@@ -30,9 +30,9 @@ public interface EventConsumer {
     EventConsumer exceptionHandler(Handler<Throwable> handler);
 
     /**
-     * Sets a handler that is called when the event stream ends.
-     * Under normal operation this should not occur.
-     * @param handler the handler called on stream end
+     * Sets a handler that is called when this consumer is unregistered, whether by a call to {@link #unregister()}
+     * or by the underlying event bus closing.
+     * @param handler the handler called on unregistration
      * @return this for fluent usage
      */
     EventConsumer endHandler(Handler<Void> handler);

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -110,9 +110,14 @@ public class ServiceInvocationSupervisor {
                         return null;
                     }))
                     .exceptionHandler(throwable -> log.error("Event listener error", throwable))
+                    // Vert.x invokes the end handler on every unregistration, including the one stop() performs.
+                    // stop() clears active before unregistering, so a successful CAS here means something other
+                    // than stop() unregistered the consumer and this supervisor is no longer serving invocations.
                     .endHandler(_ -> {
-                        log.error("Should not happen! Event listener stopped for some reason!! Changing supervisor state to inactive");
-                        active.set(false);
+                        if(active.compareAndSet(true, false)){
+                            log.warn("Event listener for {} was unregistered without a call to stop(), supervisor is now inactive",
+                                     serviceDescriptor.serviceIdentifier().cri());
+                        }
                     });
 
             return methodInvocationEventConsumer.completion();

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
@@ -140,7 +140,15 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
                     }
                 })
                 .exceptionHandler(throwable -> log.error("Reply Event listener error", throwable))
-                .endHandler(v -> log.error("Should not happen! Reply Event listener stopped for some reason!!"));
+                // Vert.x invokes the end handler on every unregistration, including the one release() performs.
+                // release() sets released before unregistering, so reaching the log means something other than
+                // release() unregistered the consumer and no in-flight response can be correlated any more.
+                .endHandler(_ -> {
+                    if(!released.get()){
+                        log.warn("Reply event listener for {} was unregistered without a call to release()",
+                                 serviceClass.getName());
+                    }
+                });
     }
 
     @Override


### PR DESCRIPTION
## Summary

Improve error handling and logging for event consumer unregistration in RPC and service invocation contexts. Rather than treating all unregistrations as unexpected errors, distinguish between intentional cleanup (via `release()` or `stop()`) and unexpected unregistrations by the underlying event bus.

## Changes

- **DefaultRpcServiceProxyHandle.java**: Replace unconditional error log with conditional warning that only fires if the consumer was unregistered without calling `release()`. Uses the existing `released` atomic boolean to detect whether unregistration was intentional.

- **ServiceInvocationSupervisor.java**: Replace unconditional error log and forced state change with a compare-and-set operation. Only logs a warning and marks the supervisor inactive if the consumer was unregistered without calling `stop()`. This prevents spurious state changes when `stop()` itself triggers the end handler.

- **EventConsumer.java**: Update javadoc for `endHandler()` to clarify that it fires on any unregistration (intentional via `unregister()` or unexpected via event bus closure), not just stream end. This documents the actual Vert.x behavior.

## Implementation Details

Both changes follow the same pattern: the cleanup method (e.g., `release()`, `stop()`) sets a flag *before* unregistering the consumer, so the end handler can distinguish intentional cleanup from unexpected unregistration. This prevents false alarms when the handler itself triggers during normal shutdown while preserving detection of genuine resource leaks.

https://claude.ai/code/session_01DmFRZVhGuMXLkr7oxkxuo9