### PR TITLE
Console: org Overview page and Dashboard naming

### DIFF
--- a/kinotic-frontend/apps/system/src/components/StatTile.vue
+++ b/kinotic-frontend/apps/system/src/components/StatTile.vue
@@ -1,0 +1,33 @@
+<template>
+  <component
+    :is="to ? RouterLink : 'div'"
+    :to="to"
+    class="flex flex-col gap-1 rounded-lg border border-surface p-4"
+    :class="to ? 'cursor-pointer text-color no-underline transition-colors hover:bg-emphasis' : ''"
+  >
+    <span class="text-xs font-medium uppercase tracking-wide text-muted-color">{{ label }}</span>
+    <span v-if="tag" class="py-1">
+      <Tag :value="value" :severity="tag" />
+    </span>
+    <span v-else class="text-3xl font-semibold">{{ value }}</span>
+    <span class="text-xs text-muted-color">{{ description }}</span>
+  </component>
+</template>
+
+<script setup lang="ts">
+import { RouterLink, type RouteLocationRaw } from 'vue-router'
+import Tag from 'primevue/tag'
+
+/**
+ * One dashboard statistic: a labeled value with a caption explaining what it measures.
+ * Given a route it becomes a link with hover affordance; given a tag severity the value
+ * renders as a Tag instead of a number.
+ */
+defineProps<{
+  label: string
+  value: string
+  description: string
+  tag?: string
+  to?: RouteLocationRaw
+}>()
+</script>

--- a/kinotic-frontend/apps/system/src/pages/Overview.vue
+++ b/kinotic-frontend/apps/system/src/pages/Overview.vue
@@ -5,21 +5,7 @@
     <Message v-if="clusterError" severity="error" :closable="false" class="mb-4">{{ clusterError }}</Message>
 
     <div class="grid grid-cols-2 gap-4 xl:grid-cols-4">
-      <component
-        :is="stat.to ? RouterLink : 'div'"
-        v-for="stat in stats"
-        :key="stat.label"
-        :to="stat.to"
-        class="flex flex-col gap-1 rounded-lg border border-surface p-4"
-        :class="stat.to ? 'cursor-pointer text-color no-underline transition-colors hover:bg-emphasis' : ''"
-      >
-        <span class="text-xs font-medium uppercase tracking-wide text-muted-color">{{ stat.label }}</span>
-        <span v-if="stat.tag" class="py-1">
-          <Tag :value="stat.value" :severity="stat.tag" />
-        </span>
-        <span v-else class="text-3xl font-semibold">{{ stat.value }}</span>
-        <span class="text-xs text-muted-color">{{ stat.description }}</span>
-      </component>
+      <StatTile v-for="stat in stats" :key="stat.label" v-bind="stat" />
     </div>
 
     <div class="mt-6 rounded-lg border border-surface">
@@ -67,7 +53,6 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { RouterLink } from 'vue-router'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import Tag from 'primevue/tag'
@@ -78,6 +63,7 @@ import type { KinoticClusterInfo } from '@kinotic-ai/os-api'
 import { PageHeader } from '@kinotic-ai/frontend-common'
 
 import LogLevelDialog from '@/components/LogLevelDialog.vue'
+import StatTile from '@/components/StatTile.vue'
 
 const clusterInfo = ref<KinoticClusterInfo | null>(null)
 const clusterError = ref<string | null>(null)

--- a/kinotic-frontend/apps/system/src/pages/org/OrgDashboard.vue
+++ b/kinotic-frontend/apps/system/src/pages/org/OrgDashboard.vue
@@ -1,0 +1,105 @@
+<template>
+  <div>
+    <PageHeader title="Dashboard" description="The organization at a glance." />
+
+    <Message v-if="error" severity="error" :closable="false" class="mb-4">{{ error }}</Message>
+
+    <div class="grid grid-cols-2 gap-4 xl:grid-cols-4">
+      <StatTile v-for="stat in stats" :key="stat.label" v-bind="stat" />
+    </div>
+
+    <div class="mt-6 flex flex-col gap-2 rounded-lg border border-surface p-4">
+      <h2 class="text-base font-semibold">Details</h2>
+      <dl class="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1 text-sm">
+        <dt class="text-muted-color">Id</dt>
+        <dd class="font-mono">{{ organizationId }}</dd>
+        <dt class="text-muted-color">Description</dt>
+        <dd>{{ organization?.description || '—' }}</dd>
+        <dt class="text-muted-color">Created</dt>
+        <dd>{{ formatEpochDate(organization?.created ?? null) }}</dd>
+      </dl>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import Message from 'primevue/message'
+
+import { Kinotic, Pageable } from '@kinotic-ai/core'
+import type { Organization } from '@kinotic-ai/os-api'
+import { DatetimeUtil, PageHeader } from '@kinotic-ai/frontend-common'
+
+import StatTile from '@/components/StatTile.vue'
+
+const props = defineProps<{
+  organizationId: string
+}>()
+
+const organization = ref<Organization | null>(null)
+const applicationCount = ref<number | null>(null)
+const projectCount = ref<number | null>(null)
+const memberCount = ref<number | null>(null)
+const inviteCount = ref<number | null>(null)
+const error = ref<string | null>(null)
+
+const formatEpochDate = DatetimeUtil.formatEpochDate
+
+const stats = computed(() => [
+  {
+    label: 'Applications',
+    value: applicationCount.value?.toString() ?? '—',
+    description: 'Applications owned by this organization',
+    to: { name: 'org-applications', params: { organizationId: props.organizationId } }
+  },
+  {
+    label: 'Projects',
+    value: projectCount.value?.toString() ?? '—',
+    description: 'Projects across all of its applications',
+    to: { name: 'org-projects', params: { organizationId: props.organizationId } }
+  },
+  {
+    label: 'Members',
+    value: memberCount.value?.toString() ?? '—',
+    description: 'People with access to this organization',
+    to: { name: 'org-members', params: { organizationId: props.organizationId } }
+  },
+  {
+    label: 'Pending invites',
+    value: inviteCount.value?.toString() ?? '—',
+    description: 'Invitations awaiting acceptance',
+    to: { name: 'org-members', params: { organizationId: props.organizationId } }
+  }
+])
+
+async function load() {
+  error.value = null
+  organization.value = null
+  applicationCount.value = projectCount.value = memberCount.value = inviteCount.value = null
+  const orgId = props.organizationId
+  // A one-row page carries the full count in totalElements
+  const firstPage = Pageable.create(0, 1)
+  try {
+    const [org, apps, projects, members, invites] = await Promise.all([
+      Kinotic.systemOrganizations.findOrganizationById(orgId),
+      Kinotic.systemOrganizations.findApplications(orgId, firstPage),
+      Kinotic.systemOrganizations.findProjects(orgId, firstPage),
+      Kinotic.systemOrganizations.findMembers(orgId, null, firstPage),
+      Kinotic.systemOrganizations.findPendingInvites(orgId, null, firstPage)
+    ])
+    organization.value = org
+    applicationCount.value = apps.totalElements ?? 0
+    projectCount.value = projects.totalElements ?? 0
+    memberCount.value = members.totalElements ?? 0
+    inviteCount.value = invites.totalElements ?? 0
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load organization dashboard'
+  }
+}
+
+// The header's organization switcher navigates in place, so the router reuses this
+// component instance; refetch when the target organization changes
+watch(() => props.organizationId, load)
+
+onMounted(load)
+</script>

--- a/kinotic-frontend/apps/system/src/router.ts
+++ b/kinotic-frontend/apps/system/src/router.ts
@@ -45,7 +45,14 @@ const routes: RouteRecordRaw[] = [
             {
                 name: 'organization-detail',
                 path: 'organizations/:organizationId',
-                redirect: to => ({ name: 'org-applications', params: to.params })
+                redirect: to => ({ name: 'org-dashboard', params: to.params })
+            },
+            {
+                name: 'org-dashboard',
+                path: 'organizations/:organizationId/dashboard',
+                component: () => import('./pages/org/OrgDashboard.vue'),
+                props: true,
+                meta: { sidebar: organizationSidebarItem('Dashboard', 'pi-objects-column', 5) }
             },
             {
                 name: 'org-applications',


### PR DESCRIPTION
Two commits: the per-organization landing page, then the naming pass that settled where "Dashboard" and "Overview" live.

## Final shape

- The system-level page is **Dashboard** at `/dashboard` (was Overview at `/overview`); login's fallback redirect follows.
- Drilling into an organization lands on the org's **Overview** (`organizations/:id/overview`): clickable count tiles for Applications, Projects, Members, and Pending invites, plus a Details panel (id, description, created). Counts ride one-row pages (`totalElements`).
- The organization sidebar shows a sectionless **Dashboard** entry above the Organization heading, leading back to the system dashboard — via a navigation-only route record, since the shared SideBar builds purely from route meta:

```ts
// router.ts
{ name: 'org-to-dashboard', path: 'organizations/:organizationId/dashboard',
  redirect: { name: 'dashboard' },
  meta: { sidebar: { group: 'organization', label: 'Dashboard', icon: 'pi-objects-column', order: 1 } } },
{ name: 'org-overview', path: 'organizations/:organizationId/overview',
  component: () => import('./pages/org/OrgOverview.vue'), props: true,
  meta: { sidebar: organizationSidebarItem('Overview', 'pi-chart-bar', 5) } }
```

The stat-tile markup extracted to `StatTile.vue`, shared by the system Dashboard and the org Overview. The org Overview watches `organizationId` so the header switcher reloads it in place.

## Verified

- Console `vue-tsc -b && vite build` clean
- Org reads still gated on publishing `@kinotic-ai/os-api@5.0.0-beta.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dmzjCqWFPEzkEpHYS7mjS