### PR TITLE
Fix ToggleSwitch layout shift in ApplicationSettings

### DIFF
--- a/kinotic-frontend/apps/portal/src/pages/ApplicationSettings.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ApplicationSettings.vue
@@ -26,7 +26,7 @@
           <div class="application-settings__field">
             <label class="application-settings__label">Tenant per user</label>
             <div class="flex items-center gap-3">
-              <ToggleSwitch v-model="tenantPerUser" />
+              <ToggleSwitch v-model="tenantPerUser" class="shrink-0" />
               <span class="text-sm text-muted-color">
                 Each user of this application gets their own isolated tenant.
                 Applies to users created after enabling.


### PR DESCRIPTION
Prevent the ToggleSwitch component from causing layout shift when toggled by adding `shrink-0` class.

**Changes:**
- ApplicationSettings.vue:29 — Added `class="shrink-0"` to ToggleSwitch component for "Tenant per user" setting

The ToggleSwitch was allowing flex layout to shrink its width during state changes, causing the adjacent text label to reflow. The `shrink-0` utility class (Tailwind's `flex-shrink: 0`) locks the component's width, maintaining stable layout when toggled.

https://claude.ai/code/session_01UB9VmY5M6cD6RmzQPKcGxN