### PR TITLE
Name the far end of client spans so traces are readable

### DIFF
--- a/.run/KinoticServerApplication.run.xml
+++ b/.run/KinoticServerApplication.run.xml
@@ -19,6 +19,7 @@
       <env name="OTEL_LOGS_EXPORTER" value="none" />
       <env name="OTEL_METRIC_EXPORT_INTERVAL" value="15000" />
       <env name="OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY" value="true" />
+      <env name="OTEL_INSTRUMENTATION_COMMON_PEER_SERVICE_MAPPING" value="localhost:9200=elasticsearch" />
     </envs>
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="true" />

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -178,6 +178,19 @@ nothing. The rules that matter:
   the `metrics_generator.processor` block alone does nothing.
 - **Loki** promotes `service.name` to the `service_name` index label and keeps `trace_id` /
   `span_id` as structured metadata, which is what the Tempo link on each log line matches.
+- **Span names come from semconv, not from the code**: `get` / `index` / `search` are
+  Elasticsearch endpoint ids, and a bare `GET` / `PUT` / `POST` is an HTTP span with no route
+  template. Each Elasticsearch call therefore appears twice — the client span and its transport
+  child. `peer.service` and `db.system` are what identify the far end, and Tempo resolves them
+  into virtual nodes on the service graph.
+
+`mimir.yml` and `tempo.yml` are bind-mounted, so editing them does not change the container
+spec and `docker compose up -d` leaves the old config running. Restart those services
+explicitly after a change:
+
+```bash
+docker compose -f compose-otel.yml restart mimir tempo
+```
 
 To see what's actually stored rather than what should be:
 

--- a/deployment/docker-compose/compose.kinotic-server.yml
+++ b/deployment/docker-compose/compose.kinotic-server.yml
@@ -46,6 +46,9 @@ services:
       # behind this flag. Direct buffers matter here — Vert.x and Netty allocate off-heap
       # against MaxDirectMemorySize.
       OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY: "true"
+      # Names the bare PUT/GET transport spans under each Elasticsearch call, which otherwise
+      # carry only an HTTP method in the waterfall.
+      OTEL_INSTRUMENTATION_COMMON_PEER_SERVICE_MAPPING: "kinotic-elasticsearch:9200=elasticsearch"
       SPRING_PROFILES_ACTIVE: development,compose
       KINOTIC_DOMAIN_APPBASEURL: "http://localhost:9090"
       KINOTIC_DOMAIN_EMAIL_ENABLED: "false"

--- a/deployment/docker-compose/tempo.yml
+++ b/deployment/docker-compose/tempo.yml
@@ -42,7 +42,11 @@ metrics_generator:
   traces_storage:
     path: /var/tempo/generator/traces
   processor:
-    service_graphs: {}
+    # Elasticsearch and other backends have no spans of their own, so they show up as virtual
+    # nodes resolved from peer.service/db.system on the client span. The label marks them as
+    # inferred rather than instrumented.
+    service_graphs:
+      enable_virtual_node_label: true
     span_metrics:
       # Attribute names from the stable HTTP semconv the 2.x agent emits — http.method and
       # http.status_code were the pre-1.0 names and produce empty labels against it.


### PR DESCRIPTION
Follow-up to #415. A trace of one Elasticsearch call currently renders as `get → index → PUT`, where the `PUT` says nothing about who it talked to:

```
kinotic-server  get (1.71ms)
                  index (563.66ms)     ← ES client span, named for the endpoint id
                  PUT (563.41ms)       ← its HTTP transport child, named for the method
```

Both names are semconv-correct — `ElasticsearchEndpointDefinition` names spans after the ES endpoint, and an HTTP span with no route template is named for its method — so the fix is to identify the peer rather than rename anything.

## Changes

**`peer.service` on the transport spans** — `.run/KinoticServerApplication.run.xml` and `compose.kinotic-server.yml`:

```
OTEL_INSTRUMENTATION_COMMON_PEER_SERVICE_MAPPING=localhost:9200=elasticsearch
                                                 kinotic-elasticsearch:9200=elasticsearch   # compose
```

**Virtual node labels** — `tempo.yml`:

```yaml
service_graphs:
  enable_virtual_node_label: true
```

Tempo's `peer_attributes` defaults to `["peer.service", "db.name", "db.system"]`. Elasticsearch has no spans of its own, so it resolves to a virtual node on the service graph; the label marks it as inferred rather than instrumented. `db.system=elasticsearch` was already on these spans, so the graph works off existing data.

**Documented the bind-mount reload trap** — `deployment/docker-compose/README.md`:

`mimir.yml` and `tempo.yml` are bind-mounted, so editing them leaves the container spec unchanged and `docker compose up -d` keeps running the old config — which silently leaves the metrics-generator off and metric names unsuffixed. Added the explicit restart, plus a note on where span names come from.

```bash
docker compose -f compose-otel.yml restart mimir tempo
```

## Verification

Property and attribute names were read out of the agent jar this repo builds against and the pinned Tempo 2.6.1 config reference, not from memory:

```
CommonConfig.class               → otel.instrumentation.common.peer-service-mapping
ElasticsearchDbAttributesGetter  → db.system = "elasticsearch"
tempo peer_attributes            → default ["peer.service", "db.name", "db.system"]
```

Config files parse; not run end to end (no Docker in the authoring environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7wR4j1JKAE1ZAvqcGZxSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7wR4j1JKAE1ZAvqcGZxSM)_