### PR TITLE
Add live job progress watching for in-flight runs

### DIFF
--- a/kinotic-migration/src/main/resources/migrations/V1__init.sql
+++ b/kinotic-migration/src/main/resources/migrations/V1__init.sql
@@ -249,6 +249,7 @@ CREATE TABLE IF NOT EXISTS kinotic_job_run (
     status KEYWORD,
     error TEXT,
     resumedFrom KEYWORD,
+    nodeId KEYWORD,
     started DATE,
     finished DATE
 );

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/JobProgressEvent.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/JobProgressEvent.java
@@ -1,0 +1,48 @@
+package org.kinotic.orchestrator.api.model.grind;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.kinotic.orchestrator.api.services.JobService;
+
+/**
+ * One step lifecycle event of a running job, as delivered by {@link JobService#watch(String)}.
+ * Each event names the step it concerns by the same {@link TaskRecord#getStepPath()} the run's
+ * records use, so a live event and the record it corresponds to identify the same step.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+@NoArgsConstructor
+public class JobProgressEvent {
+
+    /**
+     * What this event reports about the step.
+     */
+    private JobProgressEventType type;
+
+    /**
+     * The position of the step within the run's step tree, as the {@code /} separated
+     * sequence numbers from the root {@code JobDefinition} down to the step.
+     */
+    private String stepPath;
+
+    /**
+     * The description of the step, carried by {@link JobProgressEventType#STEP_STARTED}.
+     */
+    private String description;
+
+    /**
+     * How far along the step is, from 0 to 100, carried by
+     * {@link JobProgressEventType#STEP_PROGRESS}.
+     */
+    private Integer percentageComplete;
+
+    /**
+     * The progress message for {@link JobProgressEventType#STEP_PROGRESS}, or the failure for
+     * {@link JobProgressEventType#STEP_FAILED}.
+     */
+    private String message;
+
+}

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/JobProgressEventType.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/JobProgressEventType.java
@@ -1,0 +1,29 @@
+package org.kinotic.orchestrator.api.model.grind;
+
+/**
+ * What a {@link JobProgressEvent} reports about the step it names.
+ */
+public enum JobProgressEventType {
+
+    /**
+     * The step began executing. {@link JobProgressEvent#getDescription()} carries its description.
+     */
+    STEP_STARTED,
+
+    /**
+     * The step reported how far along it is. {@link JobProgressEvent#getPercentageComplete()} and
+     * {@link JobProgressEvent#getMessage()} carry the reported progress.
+     */
+    STEP_PROGRESS,
+
+    /**
+     * The step finished successfully.
+     */
+    STEP_COMPLETED,
+
+    /**
+     * The step terminated with a failure. {@link JobProgressEvent#getMessage()} carries the failure.
+     */
+    STEP_FAILED
+
+}

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/JobRun.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/JobRun.java
@@ -73,6 +73,12 @@ public class JobRun implements Identifiable<String> {
     private String resumedFrom;
 
     /**
+     * The id of the cluster node executing this run, which is the node holding the run's live
+     * result stream. A live subscription must be routed to this node to reach that stream.
+     */
+    private String nodeId;
+
+    /**
      * When the run started executing.
      */
     private Date started;

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/StepInfo.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/model/grind/StepInfo.java
@@ -2,6 +2,10 @@
 
 package org.kinotic.orchestrator.api.model.grind;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.stream.Collectors;
+
 /**
  * The sequence of steps that have been executed to get to a specific {@link Result}
  *
@@ -38,5 +42,20 @@ public class StepInfo {
 
     public StepInfo getAncestor() {
         return ancestor;
+    }
+
+    /**
+     * The position of this step within the run's step tree, as the {@code /} separated
+     * sequence numbers from the root {@link JobDefinition} down to this step
+     * @return the step path, such as {@code 0/2/1}
+     */
+    public String path() {
+        Deque<Integer> sequences = new ArrayDeque<>();
+        for(StepInfo info = this; info != null; info = info.getAncestor()){
+            sequences.addFirst(info.getSequence());
+        }
+        return sequences.stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.joining("/"));
     }
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/JobService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/JobService.java
@@ -5,6 +5,7 @@ package org.kinotic.orchestrator.api.services;
 import org.kinotic.orchestrator.api.model.grind.JobDefinition;
 import org.kinotic.orchestrator.api.model.grind.JobExecution;
 import org.kinotic.orchestrator.api.model.grind.JobOwner;
+import org.kinotic.orchestrator.api.model.grind.JobProgressEvent;
 import org.kinotic.orchestrator.api.model.grind.Result;
 import org.kinotic.orchestrator.api.model.grind.ResultOptions;
 import org.kinotic.orchestrator.api.model.grind.ResultType;
@@ -102,5 +103,21 @@ public interface JobService {
      * @return the prepared {@link JobExecution}
      */
     JobExecution resume(String jobRunId, JobDefinition jobDefinition, ResultOptions options);
+
+    /**
+     * Follows the live progress of a run executing on this node, for an observer that did not
+     * start it. Every subscriber receives the run's events from the beginning, so a subscription
+     * made mid-run still sees the steps that already finished, and the stream completes when the
+     * run reaches a terminal status.
+     *
+     * Only the node executing the run holds its result stream, recorded as
+     * {@link org.kinotic.orchestrator.api.model.grind.JobRun#getNodeId()}. A run that is not
+     * executing here - it finished, never started, or is running on another node - yields an
+     * empty stream, leaving the run's {@link org.kinotic.orchestrator.api.model.grind.TaskRecord}s
+     * as the account of what happened.
+     * @param jobRunId the id of the run to follow
+     * @return a {@link Flux} of the run's {@link JobProgressEvent}s
+     */
+    Flux<JobProgressEvent> watch(String jobRunId);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/model/grind/JobRunRecorder.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/model/grind/JobRunRecorder.java
@@ -11,17 +11,13 @@ import org.kinotic.orchestrator.api.model.grind.JobDefinition;
 import org.kinotic.orchestrator.api.model.grind.JobOwner;
 import org.kinotic.orchestrator.api.model.grind.Result;
 import org.kinotic.orchestrator.api.model.grind.StepCompletion;
-import org.kinotic.orchestrator.api.model.grind.StepInfo;
 import tools.jackson.databind.ObjectMapper;
 
-import java.util.ArrayDeque;
 import java.util.Date;
-import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Writes the {@link JobRun} and {@link TaskRecord}s for one job execution as its
@@ -41,6 +37,7 @@ public class JobRunRecorder {
     private CompletableFuture<Void> writeChain = CompletableFuture.completedFuture(null);
 
     public JobRunRecorder(String jobRunId,
+                          String nodeId,
                           JobDefinition jobDefinition,
                           JobOwner owner,
                           String resumedFrom,
@@ -55,7 +52,8 @@ public class JobRunRecorder {
                                   .setName(jobDefinition.getName())
                                   .setVersion(jobDefinition.getVersion())
                                   .setDescription(jobDefinition.getDescription())
-                                  .setResumedFrom(resumedFrom);
+                                  .setResumedFrom(resumedFrom)
+                                  .setNodeId(nodeId);
         if(owner != null){
             jobRun.setOrganizationId(owner.getOrganizationId())
                   .setApplicationId(owner.getApplicationId())
@@ -85,11 +83,12 @@ public class JobRunRecorder {
     }
 
     public void record(Result<?> result) {
+        String stepPath = result.getStepInfo().path();
         switch(result.getResultType()){
-            case STEP_STARTED -> stepStarted(pathOf(result), (String) result.getValue());
-            case STEP_COMPLETED -> stepCompleted(pathOf(result), (StepCompletion) result.getValue());
-            case STEP_FAILED -> stepFailed(pathOf(result), (Throwable) result.getValue());
-            case DYNAMIC_STEPS -> stepProducedDynamicSteps(pathOf(result));
+            case STEP_STARTED -> stepStarted(stepPath, (String) result.getValue());
+            case STEP_COMPLETED -> stepCompleted(stepPath, (StepCompletion) result.getValue());
+            case STEP_FAILED -> stepFailed(stepPath, (Throwable) result.getValue());
+            case DYNAMIC_STEPS -> stepProducedDynamicSteps(stepPath);
             default -> { }
         }
     }
@@ -217,16 +216,6 @@ public class JobRunRecorder {
                 enqueue(() -> taskRecordService.save(record));
             }
         }
-    }
-
-    private String pathOf(Result<?> result) {
-        Deque<Integer> sequences = new ArrayDeque<>();
-        for(StepInfo info = result.getStepInfo(); info != null; info = info.getAncestor()){
-            sequences.addFirst(info.getSequence());
-        }
-        return sequences.stream()
-                        .map(String::valueOf)
-                        .collect(Collectors.joining("/"));
     }
 
     private synchronized void enqueue(Supplier<CompletableFuture<?>> writeOperation) {

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobService.java
@@ -5,8 +5,12 @@ package org.kinotic.orchestrator.internal.api.services;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
+import org.kinotic.core.api.Kinotic;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.grind.ExecutionStatus;
+import org.kinotic.orchestrator.api.model.grind.JobProgressEvent;
+import org.kinotic.orchestrator.api.model.grind.JobProgressEventType;
+import org.kinotic.orchestrator.api.model.grind.Progress;
 import org.kinotic.orchestrator.api.model.grind.StoreType;
 import org.kinotic.orchestrator.api.model.grind.TaskRecord;
 import org.kinotic.orchestrator.api.services.JobRunService;
@@ -37,6 +41,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  *
@@ -52,6 +58,13 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
     private final JobRunService jobRunService;
     private final TaskRecordService taskRecordService;
     private final ObjectMapper objectMapper;
+    private final Kinotic kinotic;
+
+    /**
+     * The runs currently executing on this node, keyed by run id, which {@link #watch(String)}
+     * attaches observers to. A run is entered when it starts and removed when it terminates.
+     */
+    private final Map<String, JobExecution> executingRuns = new ConcurrentHashMap<>();
 
     private ConfigurableApplicationContext applicationContext;
 
@@ -71,7 +84,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
 
     @Override
     public JobExecution execute(JobDefinition jobDefinition) {
-        return execute(jobDefinition, null, new ResultOptions(DiagnosticLevel.NONE, false));
+        return execute(jobDefinition, null, recordedDefaults());
     }
 
     @Override
@@ -81,7 +94,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
 
     @Override
     public JobExecution execute(JobDefinition jobDefinition, JobOwner owner) {
-        return execute(jobDefinition, owner, new ResultOptions(DiagnosticLevel.NONE, false));
+        return execute(jobDefinition, owner, recordedDefaults());
     }
 
     @Override
@@ -91,6 +104,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
         Validate.notNull(options, "Options Must not be null");
 
         JobRunRecorder recorder = new JobRunRecorder(UUID.randomUUID().toString(),
+                                                     kinotic.serverInfo().getNodeId(),
                                                      jobDefinition,
                                                      owner,
                                                      null,
@@ -103,7 +117,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
 
     @Override
     public JobExecution resume(String jobRunId, JobDefinition jobDefinition) {
-        return resume(jobRunId, jobDefinition, new ResultOptions(DiagnosticLevel.NONE, false));
+        return resume(jobRunId, jobDefinition, recordedDefaults());
     }
 
     @Override
@@ -114,6 +128,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
         Validate.notNull(options, "Options Must not be null");
 
         JobRunRecorder recorder = new JobRunRecorder(UUID.randomUUID().toString(),
+                                                     kinotic.serverInfo().getNodeId(),
                                                      jobDefinition,
                                                      null,
                                                      jobRunId,
@@ -151,6 +166,25 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
     }
 
     @Override
+    public Flux<JobProgressEvent> watch(String jobRunId) {
+        Validate.notBlank(jobRunId, "jobRunId Must not be blank");
+        return Flux.defer(() -> {
+            JobExecution execution = executingRuns.get(jobRunId);
+            Flux<JobProgressEvent> ret;
+            if(execution == null){
+                ret = Flux.empty();
+            }else{
+                // An observer follows the run, it does not own its outcome: a failure ends the
+                // watch normally and is read from the run's terminal status and error instead
+                ret = execution.getResults()
+                               .mapNotNull(DefaultJobService::toProgressEvent)
+                               .onErrorResume(throwable -> Flux.empty());
+            }
+            return ret;
+        });
+    }
+
+    @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = (ConfigurableApplicationContext) applicationContext;
     }
@@ -168,14 +202,63 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
     }
 
     private JobExecution executeRecorded(JobRunRecorder recorder, Flux<Result<?>> results) {
-        Flux<Result<?>> recorded = results.doOnSubscribe(subscription -> recorder.runStarted())
+        String jobRunId = recorder.getJobRunId();
+        // The registration hooks need the JobExecution assembled from this very Flux. Nothing
+        // subscribes while JobExecution is being constructed, so the holder is always filled
+        // before the hooks can read it.
+        AtomicReference<JobExecution> registration = new AtomicReference<>();
+
+        Flux<Result<?>> recorded = results.doOnSubscribe(subscription -> {
+                                              // Entered only once the run starts, so an observer
+                                              // can never be the subscriber that starts it
+                                              executingRuns.put(jobRunId, registration.get());
+                                              recorder.runStarted();
+                                          })
                                           .doOnNext(recorder::record)
                                           .doOnError(recorder::runFailed)
                                           .doOnCancel(recorder::runCancelled)
-                                          .doOnComplete(recorder::runCompleted);
+                                          .doOnComplete(recorder::runCompleted)
+                                          .doFinally(signalType -> executingRuns.remove(jobRunId));
 
         // JobExecution multicasts, so these hooks see one subscription no matter how many subscribers attach
-        return new JobExecution(recorder.getJobRunId(), recorded);
+        JobExecution ret = new JobExecution(jobRunId, recorded);
+        registration.set(ret);
+        return ret;
+    }
+
+    /**
+     * Translates a {@link Result} into the event a watcher receives, or null for the result types
+     * that carry nothing a watcher can use: VALUE and NOOP hold the job's own domain objects, and
+     * DIAGNOSTIC and EXCEPTION repeat what the step lifecycle events already report.
+     */
+    private static JobProgressEvent toProgressEvent(Result<?> result) {
+        String stepPath = result.getStepInfo().path();
+        return switch(result.getResultType()){
+            case STEP_STARTED -> new JobProgressEvent().setType(JobProgressEventType.STEP_STARTED)
+                                                       .setStepPath(stepPath)
+                                                       .setDescription((String) result.getValue());
+            case STEP_COMPLETED -> new JobProgressEvent().setType(JobProgressEventType.STEP_COMPLETED)
+                                                         .setStepPath(stepPath);
+            case STEP_FAILED -> new JobProgressEvent().setType(JobProgressEventType.STEP_FAILED)
+                                                      .setStepPath(stepPath)
+                                                      .setMessage(String.valueOf(result.getValue()));
+            case PROGRESS -> {
+                Progress progress = (Progress) result.getValue();
+                yield new JobProgressEvent().setType(JobProgressEventType.STEP_PROGRESS)
+                                            .setStepPath(stepPath)
+                                            .setPercentageComplete(progress.getPercentageComplete())
+                                            .setMessage(progress.getMessage());
+            }
+            default -> null;
+        };
+    }
+
+    /**
+     * The options a recorded run uses when the caller names none. Progress results are on because
+     * {@link #watch(String)} exists to deliver them, and they are never written to a record.
+     */
+    private static ResultOptions recordedDefaults() {
+        return new ResultOptions(DiagnosticLevel.NONE, true);
     }
 
     /**

--- a/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/AbstractGrindTest.java
+++ b/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/AbstractGrindTest.java
@@ -2,6 +2,7 @@ package org.kinotic.orchestrator.internal.api.grind;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.kinotic.core.api.ServerInfo;
 import org.kinotic.orchestrator.api.model.grind.JobExecution;
 import org.kinotic.orchestrator.api.model.grind.ResultType;
 import org.kinotic.orchestrator.internal.api.services.DefaultJobService;
@@ -23,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public abstract class AbstractGrindTest {
 
+    /** The node these tests execute runs on, recorded on every {@code JobRun} they produce. */
+    protected static final String TEST_NODE_ID = "test-node-id";
+
     protected AnnotationConfigApplicationContext appCtx;
     protected StubJobRunService runs;
     protected StubTaskRecordService records;
@@ -36,7 +40,7 @@ public abstract class AbstractGrindTest {
         runs = new StubJobRunService();
         records = new StubTaskRecordService();
         objectMapper = new ObjectMapper();
-        jobService = new DefaultJobService(runs, records, objectMapper);
+        jobService = new DefaultJobService(runs, records, objectMapper, () -> new ServerInfo(TEST_NODE_ID, "test-node"));
         jobService.setApplicationContext(appCtx);
     }
 

--- a/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/JobWatchTest.java
+++ b/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/JobWatchTest.java
@@ -1,0 +1,166 @@
+package org.kinotic.orchestrator.internal.api.grind;
+
+import org.junit.jupiter.api.Test;
+import org.kinotic.orchestrator.api.model.grind.JobDefinition;
+import org.kinotic.orchestrator.api.model.grind.JobExecution;
+import org.kinotic.orchestrator.api.model.grind.JobProgressEvent;
+import org.kinotic.orchestrator.api.model.grind.JobProgressEventType;
+import org.kinotic.orchestrator.api.model.grind.JobRun;
+import org.kinotic.orchestrator.api.model.grind.Tasks;
+import reactor.core.Disposable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Behavior of watching a run in flight: what an observer that did not start the run receives,
+ * and the boundaries of what is watchable.
+ */
+public class JobWatchTest extends AbstractGrindTest {
+
+    private List<JobProgressEvent> eventsOf(String jobRunId) {
+        List<JobProgressEvent> events = Collections.synchronizedList(new ArrayList<>());
+        jobService.watch(jobRunId).subscribe(events::add);
+        return events;
+    }
+
+    private List<JobProgressEvent> eventsFor(List<JobProgressEvent> events, String stepPath) {
+        return events.stream().filter(event -> stepPath.equals(event.getStepPath())).toList();
+    }
+
+    /** The step's lifecycle alone, with the progress reports it interleaves them with removed. */
+    private List<JobProgressEventType> lifecycleOf(List<JobProgressEvent> events, String stepPath) {
+        return eventsFor(events, stepPath).stream()
+                                          .map(JobProgressEvent::getType)
+                                          .filter(type -> type != JobProgressEventType.STEP_PROGRESS)
+                                          .toList();
+    }
+
+    /**
+     * Runs the execution to termination on its own thread, so the calling test can attach a watch
+     * while it is in flight.
+     */
+    private Thread startOnItsOwnThread(JobExecution execution) {
+        Thread runner = new Thread(() -> execution.getResults().onErrorComplete().blockLast());
+        runner.start();
+        return runner;
+    }
+
+    @Test
+    public void watcherReceivesTheWholeRunIncludingWhatPrecededIt() throws Exception {
+        CountDownLatch firstStepEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstStep = new CountDownLatch(1);
+
+        JobDefinition def = JobDefinition.create("watched job").name("watched-job").version("1")
+            .task(Tasks.fromCallable("gated step", () -> {
+                firstStepEntered.countDown();
+                assertTrue(releaseFirstStep.await(15, TimeUnit.SECONDS), "step was never released");
+                return "gated";
+            }))
+            .task(Tasks.fromCallable("trailing step", () -> "trailing"));
+
+        JobExecution execution = jobService.execute(def);
+        Thread runner = startOnItsOwnThread(execution);
+        assertTrue(firstStepEntered.await(15, TimeUnit.SECONDS), "run never reached its first step");
+
+        List<JobProgressEvent> events = eventsOf(execution.getJobRunId());
+
+        releaseFirstStep.countDown();
+        runner.join(15_000);
+        assertFalse(runner.isAlive(), "run did not terminate within 15s");
+
+        // The gated step had already started when the watch attached, and its start still arrives
+        assertEquals(List.of(JobProgressEventType.STEP_STARTED, JobProgressEventType.STEP_COMPLETED),
+                     lifecycleOf(events, "0/1"));
+        assertEquals("gated step", eventsFor(events, "0/1").get(0).getDescription());
+
+        assertEquals(List.of(JobProgressEventType.STEP_STARTED, JobProgressEventType.STEP_COMPLETED),
+                     lifecycleOf(events, "0/2"));
+        assertEquals("trailing step", eventsFor(events, "0/2").get(0).getDescription());
+
+        // The root job aggregates its steps' progress, so it is what a UI shows for the run overall
+        JobProgressEvent finalProgress = eventsFor(events, "0").stream()
+                                                               .filter(event -> event.getType() == JobProgressEventType.STEP_PROGRESS)
+                                                               .reduce((first, second) -> second)
+                                                               .orElse(null);
+        assertNotNull(finalProgress, "the root job should report progress");
+        assertEquals(100, finalProgress.getPercentageComplete());
+    }
+
+    @Test
+    public void failedStepIsReportedWithItsFailure() throws Exception {
+        CountDownLatch firstStepEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstStep = new CountDownLatch(1);
+
+        JobDefinition def = JobDefinition.create("failing job").name("failing-job").version("1")
+            .task(Tasks.fromCallable("gated step", () -> {
+                firstStepEntered.countDown();
+                assertTrue(releaseFirstStep.await(15, TimeUnit.SECONDS), "step was never released");
+                return "gated";
+            }))
+            .task(Tasks.fromCallable("exploding step", () -> {
+                throw new IllegalStateException("boom");
+            }));
+
+        JobExecution execution = jobService.execute(def);
+        Thread runner = startOnItsOwnThread(execution);
+        assertTrue(firstStepEntered.await(15, TimeUnit.SECONDS), "run never reached its first step");
+
+        List<JobProgressEvent> events = eventsOf(execution.getJobRunId());
+
+        releaseFirstStep.countDown();
+        runner.join(15_000);
+        assertFalse(runner.isAlive(), "run did not terminate within 15s");
+
+        JobProgressEvent failure = events.stream()
+                                         .filter(event -> event.getType() == JobProgressEventType.STEP_FAILED)
+                                         .findFirst()
+                                         .orElse(null);
+        assertNotNull(failure, "the failed step should be reported");
+        assertEquals("0/2", failure.getStepPath());
+        assertTrue(failure.getMessage().contains("boom"), "the failure should carry its message");
+    }
+
+    @Test
+    public void watchingDoesNotStartTheRun() throws Exception {
+        JobDefinition def = JobDefinition.create("unstarted job").name("unstarted-job").version("1")
+            .task(Tasks.fromCallable("never runs", () -> "value"));
+
+        JobExecution execution = jobService.execute(def);
+
+        List<JobProgressEvent> events = eventsOf(execution.getJobRunId());
+
+        assertTrue(events.isEmpty(), "a run nobody has subscribed to is not executing yet");
+        assertTrue(runs.saved.isEmpty(), "no run should have been recorded");
+    }
+
+    @Test
+    public void finishedRunIsNoLongerWatchable() throws Exception {
+        JobDefinition def = JobDefinition.create("brief job").name("brief-job").version("1")
+            .task(Tasks.fromCallable("quick step", () -> "value"));
+
+        JobExecution execution = jobService.execute(def);
+        await(execution);
+
+        assertTrue(eventsOf(execution.getJobRunId()).isEmpty(),
+                   "a terminated run is read from its records, not watched");
+
+        JobRun run = runs.saved.get(execution.getJobRunId());
+        assertEquals(TEST_NODE_ID, run.getNodeId(), "the run records the node that can serve a watch");
+    }
+
+    @Test
+    public void unknownRunYieldsNothing() {
+        Disposable watch = jobService.watch("no-such-run").subscribe();
+        assertTrue(watch.isDisposed(), "an unknown run completes immediately");
+    }
+
+}


### PR DESCRIPTION
Adds the ability to observe progress events from a job run executing on the current node, enabling real-time monitoring of step lifecycle and progress without starting the run.

## Summary

Implements `JobService.watch(String jobRunId)` to stream `JobProgressEvent`s from running jobs. Observers receive the complete event history from run start through termination, even if they attach mid-execution. Runs that have finished, never started, or execute on another node yield empty streams, leaving their `TaskRecord`s as the authoritative record.

## Key Changes

- **New API**: `JobService.watch(String jobRunId)` returns `Flux<JobProgressEvent>` for live progress observation
- **Event types**: `JobProgressEventType` enum (STEP_STARTED, STEP_PROGRESS, STEP_COMPLETED, STEP_FAILED) with corresponding `JobProgressEvent` DTO carrying step path, description, progress percentage, and failure messages
- **Execution tracking**: `DefaultJobService` maintains `executingRuns` map keyed by run ID, populated on first subscription and cleared on termination via `doFinally`
- **Step path computation**: Moved `pathOf()` logic from `JobRunRecorder` to `StepInfo.path()` method for reuse in event translation
- **Node tracking**: `JobRun.nodeId` field records which cluster node executes the run, enabling routing of watch subscriptions to the correct node
- **Result filtering**: `toProgressEvent()` translates `Result` objects to events, filtering out VALUE/NOOP/DIAGNOSTIC/EXCEPTION types that carry no watcher-relevant data
- **Progress defaults**: Recorded runs now use `ResultOptions` with progress enabled (DiagnosticLevel.NONE, progress=true) since progress events are never persisted but delivered live

## Implementation Details

The watch mechanism uses `Flux.defer()` to defer execution lookup until subscription time, ensuring observers never trigger run execution. The `AtomicReference<JobExecution>` registration pattern allows the multicast `Flux` to be captured before any subscription occurs, so the `doOnSubscribe` hook can register the execution in `executingRuns` before the first subscriber receives events.

Observers see failures as terminal events (STEP_FAILED with message) rather than stream errors — the `onErrorResume(throwable -> Flux.empty())` converts exceptions to normal completion, leaving the run's terminal status and error fields as the authoritative failure record.

## Tests

`JobWatchTest` validates:
- Watchers receive complete event history including pre-attachment steps
- Failed steps report with their failure messages
- Watching alone does not start execution
- Finished runs are not watchable (read from records instead)
- Unknown runs complete immediately

https://claude.ai/code/session_01H7opuvATTABiit4ezwHs8d