### PR TITLE
Replace CompletableFuture with Vert.x Future throughout codebase

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/api/utils/ApiGatewayUtil.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/api/utils/ApiGatewayUtil.java
@@ -17,7 +17,6 @@ import org.kinotic.gateway.api.config.CorsProperties;
 import org.kinotic.gateway.api.config.SslProperties;
 
 import java.util.Set;
-import java.util.concurrent.CompletionException;
 
 /**
  * Helpers for the Vert.x HTTP servers and routers fronted by the api-gateway: CORS handling,
@@ -101,12 +100,6 @@ public final class ApiGatewayUtil {
         int statusCode = context.statusCode();
 
         if(throwable != null){
-
-            if(throwable instanceof CompletionException){
-                if(throwable.getCause() != null) {
-                    throwable = throwable.getCause();
-                }
-            }
 
             errorMessage = throwable.getMessage();
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/crud/CrudService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/crud/CrudService.java
@@ -1,8 +1,7 @@
 package org.kinotic.core.api.crud;
 
+import io.vertx.core.Future;
 import org.kinotic.idl.api.annotations.McpToolInfo;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Generic CRUD service interface for domain objects.
@@ -14,61 +13,61 @@ public interface CrudService<T, ID> {
      * entity instance completely.
      *
      * @param entity must not be {@literal null}
-     * @return {@link CompletableFuture} emitting the saved entity
+     * @return {@link Future} emitting the saved entity
      * @throws IllegalArgumentException in case the given {@literal entity} is {@literal null}
      */
     @McpToolInfo(destructiveHint = true, idempotentHint = true)
-    CompletableFuture<T> save(T entity);
+    Future<T> save(T entity);
 
     /**
      * Saves a given entity and waits for the changes to be visible in search results before returning.
      * Use this when you need read-your-write consistency.
      *
      * @param entity must not be {@literal null}
-     * @return {@link CompletableFuture} emitting the saved entity after it is searchable
+     * @return {@link Future} emitting the saved entity after it is searchable
      * @throws IllegalArgumentException in case the given {@literal entity} is {@literal null}
      */
     @McpToolInfo(destructiveHint = true, idempotentHint = true)
-    CompletableFuture<T> saveSync(T entity);
+    Future<T> saveSync(T entity);
 
     /**
      * Retrieves an entity by its id.
      *
      * @param id must not be {@literal null}
-     * @return {@link CompletableFuture} emitting the entity with the given id or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} emitting the entity with the given id or {@link Future} emitting null if none found
      * @throws IllegalArgumentException in case the given {@literal id} is {@literal null}
      */
     @McpToolInfo(readOnlyHint = true)
-    CompletableFuture<T> findById(ID id);
+    Future<T> findById(ID id);
 
     /**
      * Returns the number of entities available.
      *
-     * @return {@link CompletableFuture} emitting the number of entities
+     * @return {@link Future} emitting the number of entities
      */
     @McpToolInfo(readOnlyHint = true)
-    CompletableFuture<Long> count();
+    Future<Long> count();
 
     /**
      * Deletes the entity with the given id.
      *
      * @param id must not be {@literal null}
-     * @return {@link CompletableFuture} signaling when operation has completed
+     * @return {@link Future} signaling when operation has completed
      * @throws IllegalArgumentException in case the given {@literal id} is {@literal null}
      */
     @McpToolInfo(destructiveHint = true, idempotentHint = true)
-    CompletableFuture<Void> deleteById(ID id);
+    Future<Void> deleteById(ID id);
 
     /**
      * Deletes the entity with the given id and waits for the deletion to be visible in search results
      * before returning. Use this when you need read-your-write consistency.
      *
      * @param id must not be {@literal null}
-     * @return {@link CompletableFuture} signaling when the deletion is visible to search
+     * @return {@link Future} signaling when the deletion is visible to search
      * @throws IllegalArgumentException in case the given {@literal id} is {@literal null}
      */
     @McpToolInfo(destructiveHint = true, idempotentHint = true)
-    CompletableFuture<Void> deleteByIdSync(ID id);
+    Future<Void> deleteByIdSync(ID id);
 
     /**
      * Returns a {@link Page} of entities meeting the paging restriction provided in the {@link Pageable} object.
@@ -77,7 +76,7 @@ public interface CrudService<T, ID> {
      * @return a page of entities
      */
     @McpToolInfo(readOnlyHint = true)
-    CompletableFuture<Page<T>> findAll(Pageable pageable);
+    Future<Page<T>> findAll(Pageable pageable);
 
     /**
      * Returns a {@link Page} of entities matching the search text and paging restriction provided in the {@link Pageable} object.
@@ -87,14 +86,14 @@ public interface CrudService<T, ID> {
      * @return a page of entities
      */
     @McpToolInfo(readOnlyHint = true)
-    CompletableFuture<Page<T>> search(String searchText, Pageable pageable);
+    Future<Page<T>> search(String searchText, Pageable pageable);
 
     /**
      * Forces a refresh of the underlying index, making all recent writes immediately available for search.
      * This should only be used in test or batch-load scenarios.
      *
-     * @return {@link CompletableFuture} signaling when the index has been refreshed
+     * @return {@link Future} signaling when the index has been refreshed
      */
     @McpToolInfo(idempotentHint = true)
-    CompletableFuture<Void> syncIndex();
+    Future<Void> syncIndex();
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/crud/IdentifiableCrudService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/crud/IdentifiableCrudService.java
@@ -1,6 +1,6 @@
 package org.kinotic.core.api.crud;
 
-import java.util.concurrent.CompletableFuture;
+import io.vertx.core.Future;
 
 /**
  * Extends {@link CrudService} to add a support for types that are {@link Identifiable}
@@ -14,11 +14,11 @@ public interface IdentifiableCrudService<T extends Identifiable<ID>, ID> extends
      * {@link org.kinotic.core.api.exceptions.AlreadyExistsException} on an id collision.
      *
      * @param entity to create, must not be {@literal null}
-     * @return a {@link CompletableFuture} containing the new entity, or failing with
+     * @return a {@link Future} containing the new entity, or failing with
      *         {@link org.kinotic.core.api.exceptions.AlreadyExistsException} if the id is
      *         already taken
      */
-    CompletableFuture<T> create(T entity);
+    Future<T> create(T entity);
 
     /**
      * Creates a new entity like {@link #create}, additionally waiting for it to be visible
@@ -26,10 +26,10 @@ public interface IdentifiableCrudService<T extends Identifiable<ID>, ID> extends
      * immediately after creation.
      *
      * @param entity to create, must not be {@literal null}
-     * @return a {@link CompletableFuture} containing the new entity after it is searchable,
+     * @return a {@link Future} containing the new entity after it is searchable,
      *         or failing with {@link org.kinotic.core.api.exceptions.AlreadyExistsException}
      *         if the id is already taken
      */
-    CompletableFuture<T> createSync(T entity);
+    Future<T> createSync(T entity);
 
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/secret/SecretReferenceResolver.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/secret/SecretReferenceResolver.java
@@ -1,6 +1,6 @@
 package org.kinotic.core.api.secret;
 
-import java.util.concurrent.CompletableFuture;
+import io.vertx.core.Future;
 
 /**
  * Resolves a named secret from external storage (typically Azure Key Vault) by its
@@ -16,5 +16,5 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface SecretReferenceResolver {
 
-    CompletableFuture<String> resolve(String secretName);
+    Future<String> resolve(String secretName);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/ApplicationScopedCrudService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/ApplicationScopedCrudService.java
@@ -1,11 +1,10 @@
 package org.kinotic.domain.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Identifiable;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Extends {@link IdentifiableCrudService} with queries scoped to an application.
@@ -21,17 +20,17 @@ public interface ApplicationScopedCrudService<T extends Identifiable<ID>, ID> ex
      * Returns the number of entities that belong to the given application.
      *
      * @param applicationId the application to count entities for
-     * @return a {@link CompletableFuture} emitting the count
+     * @return a {@link Future} emitting the count
      */
-    CompletableFuture<Long> countForApplication(String applicationId);
+    Future<Long> countForApplication(String applicationId);
 
     /**
      * Returns a {@link Page} of entities that belong to the given application.
      *
      * @param applicationId the application to find entities for
      * @param pageable      the paging parameters
-     * @return a {@link CompletableFuture} emitting a page of entities
+     * @return a {@link Future} emitting a page of entities
      */
-    CompletableFuture<Page<T>> findAllForApplication(String applicationId, Pageable pageable);
+    Future<Page<T>> findAllForApplication(String applicationId, Pageable pageable);
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/ProjectRepoProvisioner.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/ProjectRepoProvisioner.java
@@ -1,8 +1,7 @@
 package org.kinotic.domain.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.Project;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provisions the backing source-control repository for a {@link Project} during
@@ -20,7 +19,7 @@ public interface ProjectRepoProvisioner {
      *
      * @throws IllegalStateException when prerequisites aren't met (e.g. GitHub not linked)
      */
-    CompletableFuture<Project> provision(Project project);
+    Future<Project> provision(Project project);
 
     /**
      * Re-runs initialization against the already-created repository named by
@@ -31,5 +30,5 @@ public interface ProjectRepoProvisioner {
      * by {@link #provision(Project)}. The returned future fails when initialization
      * fails again, leaving the persisted status unchanged.
      */
-    CompletableFuture<Project> reinitialize(Project project);
+    Future<Project> reinitialize(Project project);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/ProjectScopedCrudService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/ProjectScopedCrudService.java
@@ -1,10 +1,9 @@
 package org.kinotic.domain.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Identifiable;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Extends {@link ApplicationScopedCrudService} with queries scoped to a project.
@@ -20,17 +19,17 @@ public interface ProjectScopedCrudService<T extends Identifiable<ID>, ID> extend
      * Returns the number of entities that belong to the given project.
      *
      * @param projectId the project to count entities for
-     * @return a {@link CompletableFuture} emitting the count
+     * @return a {@link Future} emitting the count
      */
-    CompletableFuture<Long> countForProject(String projectId);
+    Future<Long> countForProject(String projectId);
 
     /**
      * Returns a {@link Page} of entities that belong to the given project.
      *
      * @param projectId the project to find entities for
      * @param pageable  the paging parameters
-     * @return a {@link CompletableFuture} emitting a page of entities
+     * @return a {@link Future} emitting a page of entities
      */
-    CompletableFuture<Page<T>> findAllForProject(String projectId, Pageable pageable);
+    Future<Page<T>> findAllForProject(String projectId, Pageable pageable);
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/SecretStorageService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/SecretStorageService.java
@@ -1,8 +1,9 @@
 package org.kinotic.domain.api.services;
 
+import io.vertx.core.Future;
+
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provides secure secret storage with scope-based isolation.
@@ -19,7 +20,7 @@ public interface SecretStorageService {
      * @param value       the secret value to store
      * @return a future that completes when the secret has been persisted
      */
-    CompletableFuture<Void> setSecret(String secretScope, String key, String value);
+    Future<Void> setSecret(String secretScope, String key, String value);
 
     /**
      * Retrieves a secret value for the given scope and key.
@@ -28,7 +29,7 @@ public interface SecretStorageService {
      * @param key         the logical key identifying the secret within the scope
      * @return a future containing the secret value, or {@code null} if not found
      */
-    CompletableFuture<String> getSecret(String secretScope, String key);
+    Future<String> getSecret(String secretScope, String key);
 
     /**
      * Deletes a secret for the given scope and key.
@@ -37,7 +38,7 @@ public interface SecretStorageService {
      * @param key         the logical key identifying the secret within the scope
      * @return a future that completes when the secret has been deleted
      */
-    CompletableFuture<Void> deleteSecret(String secretScope, String key);
+    Future<Void> deleteSecret(String secretScope, String key);
 
     /**
      * Stores multiple secrets within a single scope.
@@ -46,7 +47,7 @@ public interface SecretStorageService {
      * @param secrets     a map of logical key to secret value
      * @return a future that completes when all secrets have been persisted
      */
-    CompletableFuture<Void> setSecrets(String secretScope, Map<String, String> secrets);
+    Future<Void> setSecrets(String secretScope, Map<String, String> secrets);
 
     /**
      * Retrieves multiple secrets within a single scope.
@@ -55,7 +56,7 @@ public interface SecretStorageService {
      * @param keys        the logical keys identifying the secrets within the scope
      * @return a future containing a map of logical key to secret value (keys not found are omitted)
      */
-    CompletableFuture<Map<String, String>> getSecrets(String secretScope, Set<String> keys);
+    Future<Map<String, String>> getSecrets(String secretScope, Set<String> keys);
 
     /**
      * Deletes multiple secrets within a single scope.
@@ -64,5 +65,5 @@ public interface SecretStorageService {
      * @param keys        the logical keys identifying the secrets to delete
      * @return a future that completes when all secrets have been deleted
      */
-    CompletableFuture<Void> deleteSecrets(String secretScope, Set<String> keys);
+    Future<Void> deleteSecrets(String secretScope, Set<String> keys);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/DeviceCodeGrantService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/DeviceCodeGrantService.java
@@ -1,10 +1,9 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.security.DeviceCodeGrantStart;
 import org.kinotic.domain.api.model.security.DeviceCodePollResult;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Drives the server side of the OAuth 2.0 Device Authorization Grant (RFC 8628) for CLI
@@ -20,7 +19,7 @@ public interface DeviceCodeGrantService {
      * @param deviceName optional name of the device starting the flow; becomes the label of
      *                   the token family issued when the grant is redeemed
      */
-    CompletableFuture<DeviceCodeGrantStart> start(String deviceName);
+    Future<DeviceCodeGrantStart> start(String deviceName);
 
     /**
      * Polls a pending grant by its {@code device_code}. Once the grant has been approved it
@@ -28,7 +27,7 @@ public interface DeviceCodeGrantService {
      *
      * @param deviceCode the plaintext device code issued by {@link #start()}
      */
-    CompletableFuture<DeviceCodePollResult> poll(String deviceCode);
+    Future<DeviceCodePollResult> poll(String deviceCode);
 
     /**
      * Binds an authenticated user to a pending grant identified by its {@code user_code}.
@@ -37,5 +36,5 @@ public interface DeviceCodeGrantService {
      * @param userCode the code the user entered in the browser
      * @param identityId   id of the authenticated {@link UserParticipantIdentity} approving the grant
      */
-    CompletableFuture<Void> approve(String userCode, String identityId);
+    Future<Void> approve(String userCode, String identityId);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/InviteService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/InviteService.java
@@ -1,11 +1,10 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
 import org.kinotic.domain.api.model.security.PendingInvite;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Manages member invitations into an existing Organization or Application scope: creating and
@@ -25,13 +24,13 @@ public interface InviteService {
      *               id, token, and expiry are assigned here
      * @return a future emitting the saved invitation
      */
-    CompletableFuture<PendingInvite> createInvite(PendingInvite invite);
+    Future<PendingInvite> createInvite(PendingInvite invite);
 
     /**
      * Finds the invitation for the given accept token, failing if the token is unknown or the
      * invitation has expired. Used to show invitation details on the accept page.
      */
-    CompletableFuture<PendingInvite> getValidInvite(String token);
+    Future<PendingInvite> getValidInvite(String token);
 
     /**
      * Accepts an invitation by setting a password. Creates the member in the invite's stored
@@ -42,7 +41,7 @@ public interface InviteService {
      * @param displayName optional display-name override; the invite's value is used when blank
      * @return a future emitting the created member
      */
-    CompletableFuture<UserParticipantIdentity> acceptLocalInvite(String token, String password, String displayName);
+    Future<UserParticipantIdentity> acceptLocalInvite(String token, String password, String displayName);
 
     /**
      * Accepts an invitation with a verified OIDC identity. The IdP-verified email must match the
@@ -55,18 +54,18 @@ public interface InviteService {
      * @param verifiedEmail the verified {@code email} claim from the IdP
      * @return a future emitting the created member
      */
-    CompletableFuture<UserParticipantIdentity> acceptOidcInvite(String token,
-                                                String oidcSubject,
-                                                String oidcConfigId,
-                                                String verifiedEmail);
+    Future<UserParticipantIdentity> acceptOidcInvite(String token,
+                                                     String oidcSubject,
+                                                     String oidcConfigId,
+                                                     String verifiedEmail);
 
     /**
      * Lists the live (unexpired) invitations for the given scope. {@code applicationId} null
      * lists org-member invites; set lists that application's invites.
      */
-    CompletableFuture<Page<PendingInvite>> findPendingInvites(String organizationId,
-                                                              String applicationId,
-                                                              Pageable pageable);
+    Future<Page<PendingInvite>> findPendingInvites(String organizationId,
+                                                   String applicationId,
+                                                   Pageable pageable);
 
     /**
      * Cancels (deletes) a pending invitation. Fails unless the invitation belongs to the given
@@ -75,5 +74,5 @@ public interface InviteService {
      * @param inviteId       id of the invitation to cancel
      * @param organizationId the organization the caller is acting for
      */
-    CompletableFuture<Void> cancelInvite(String inviteId, String organizationId);
+    Future<Void> cancelInvite(String inviteId, String organizationId);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/LocalAuthenticationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/LocalAuthenticationService.java
@@ -1,8 +1,7 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * In-process service for verifying email + password and resolving the matching
@@ -21,7 +20,7 @@ public interface LocalAuthenticationService {
      * <p>Used by the org-login token endpoint, which intentionally accepts both
      * ORGANIZATION-scope users and the SYSTEM-scope dev admin.
      */
-    CompletableFuture<UserParticipantIdentity> authenticateLocal(String email, String password);
+    Future<UserParticipantIdentity> authenticateLocal(String email, String password);
 
     /**
      * Scope-restricted variant of {@link #authenticateLocal(String, String)}: only
@@ -35,7 +34,7 @@ public interface LocalAuthenticationService {
      *   <li>both set → APPLICATION</li>
      * </ul>
      */
-    CompletableFuture<UserParticipantIdentity> authenticateLocal(String email, String password,
-                                                 String organizationId, String applicationId);
+    Future<UserParticipantIdentity> authenticateLocal(String email, String password,
+                                                      String organizationId, String applicationId);
 }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/OAuthAuthorizationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/OAuthAuthorizationService.java
@@ -1,9 +1,9 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.security.CodeExchangeResult;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
 import org.kinotic.domain.api.model.security.PendingOAuthAuthorization;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The OAuth 2.1 authorization-server logic behind the gateway's authorize and token endpoints and
@@ -25,42 +25,42 @@ public interface OAuthAuthorizationService {
      * @param scope         the requested scope, or {@code null}
      * @param resource      the RFC 8707 resource the request is bound to, or {@code null}
      * @param state         client CSRF value echoed on the redirect, or {@code null}
-     * @return a {@link CompletableFuture} emitting the request id the consent page approves or denies with
+     * @return a {@link Future} emitting the request id the consent page approves or denies with
      */
-    CompletableFuture<String> createAuthorizationRequest(String clientId,
-                                                         String redirectUri,
-                                                         String codeChallenge,
-                                                         String scope,
-                                                         String resource,
-                                                         String state);
+    Future<String> createAuthorizationRequest(String clientId,
+                                              String redirectUri,
+                                              String codeChallenge,
+                                              String scope,
+                                              String resource,
+                                              String state);
 
     /**
      * Describes a request awaiting consent, for display on the consent page.
      *
      * @param requestId the id returned by {@link #createAuthorizationRequest}
-     * @return a {@link CompletableFuture} emitting the pending request, failing when it is
+     * @return a {@link Future} emitting the pending request, failing when it is
      *         unknown, expired, or already decided
      */
-    CompletableFuture<PendingOAuthAuthorization> findPending(String requestId);
+    Future<PendingOAuthAuthorization> findPending(String requestId);
 
     /**
      * Binds the approving user to the request and mints its single-use authorization code.
      *
      * @param requestId the id returned by {@link #createAuthorizationRequest}
      * @param identityId    the approving {@link UserParticipantIdentity}'s id
-     * @return a {@link CompletableFuture} emitting the full redirect URL, carrying the code and
+     * @return a {@link Future} emitting the full redirect URL, carrying the code and
      *         the client's {@code state}, that the browser must navigate to
      */
-    CompletableFuture<String> approve(String requestId, String identityId);
+    Future<String> approve(String requestId, String identityId);
 
     /**
      * Rejects the request and consumes it.
      *
      * @param requestId the id returned by {@link #createAuthorizationRequest}
-     * @return a {@link CompletableFuture} emitting the full redirect URL carrying
+     * @return a {@link Future} emitting the full redirect URL carrying
      *         {@code error=access_denied} and the client's {@code state}
      */
-    CompletableFuture<String> deny(String requestId);
+    Future<String> deny(String requestId);
 
     /**
      * Exchanges an authorization code for its approving user, consuming the grant so the code
@@ -71,9 +71,9 @@ public interface OAuthAuthorizationService {
      * @param clientId     the client presenting the code
      * @param redirectUri  the redirect URI the code was issued for
      * @param codeVerifier the PKCE verifier whose S256 hash must equal the stored challenge
-     * @return a {@link CompletableFuture} emitting the enabled approving user
+     * @return a {@link Future} emitting the enabled approving user
      */
-    CompletableFuture<CodeExchangeResult> exchangeCode(String code,
+    Future<CodeExchangeResult> exchangeCode(String code,
                                             String clientId,
                                             String redirectUri,
                                             String codeVerifier);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/OidcConfigurationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/OidcConfigurationService.java
@@ -1,12 +1,12 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.domain.api.model.Organization;
 import org.kinotic.domain.api.model.security.BaseOidcConfiguration;
 import org.kinotic.domain.api.model.security.OidcConfiguration;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 // FIXME: add an OrganizationScopedServiceInterface
 public interface OidcConfigurationService extends IdentifiableCrudService<OidcConfiguration, String> {
@@ -20,7 +20,7 @@ public interface OidcConfigurationService extends IdentifiableCrudService<OidcCo
      * @param orgId the organization that owns the configurations
      * @return the enabled configurations
      */
-    CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId);
+    Future<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId);
 
     /**
      * Returns the {@link OidcConfiguration} the given organization uses as its SSO
@@ -28,7 +28,7 @@ public interface OidcConfigurationService extends IdentifiableCrudService<OidcCo
      * {@link Organization#getSsoConfigId()} — structurally
      * one-per-org, no scope flag needed on the config row itself.
      */
-    CompletableFuture<OidcConfiguration> findOrgLoginConfig(String organizationId);
+    Future<OidcConfiguration> findOrgLoginConfig(String organizationId);
 
     /**
      * The enabled OIDC configurations a login scope offers its users, in the order they should be
@@ -39,5 +39,5 @@ public interface OidcConfigurationService extends IdentifiableCrudService<OidcCo
      * @param organizationId the organization the scope belongs to
      * @param applicationId the application within it, or {@code null} for the organization scope
      */
-    CompletableFuture<List<BaseOidcConfiguration>> findEnabledForScope(String organizationId, String applicationId);
+    Future<List<BaseOidcConfiguration>> findEnabledForScope(String organizationId, String applicationId);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/OrgSignupOidcConfigurationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/OrgSignupOidcConfigurationService.java
@@ -1,11 +1,11 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.domain.api.model.security.OidcProviderKind;
 import org.kinotic.domain.api.model.security.OrgSignupOidcConfiguration;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 public interface OrgSignupOidcConfigurationService extends IdentifiableCrudService<OrgSignupOidcConfiguration, String> {
 
@@ -13,13 +13,13 @@ public interface OrgSignupOidcConfigurationService extends IdentifiableCrudServi
      * Returns every enabled signup config — the source of the social button list rendered
      * on signup and login pages.
      */
-    CompletableFuture<List<OrgSignupOidcConfiguration>> findAllEnabled();
+    Future<List<OrgSignupOidcConfiguration>> findAllEnabled();
 
     /**
      * Returns the single enabled config for the given provider kind, or {@code null} if
      * none is configured. Used by the social-button start endpoints to resolve the
      * correct config from the {@code :provider} path param.
      */
-    CompletableFuture<OrgSignupOidcConfiguration> findEnabledByProvider(OidcProviderKind provider);
+    Future<OrgSignupOidcConfiguration> findEnabledByProvider(OidcProviderKind provider);
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/ParticipantIdentityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/ParticipantIdentityService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -9,8 +10,6 @@ import org.kinotic.domain.api.model.security.MachineParticipantIdentity;
 import org.kinotic.domain.api.model.security.MachineProvisionResult;
 import org.kinotic.domain.api.model.security.ParticipantIdentity;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
-
-import java.util.concurrent.CompletableFuture;
 
 public interface ParticipantIdentityService extends IdentifiableCrudService<ParticipantIdentity, String> {
 
@@ -28,16 +27,16 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * @param email the email address to look up
      * @param organizationId the owning org id, or null for SYSTEM
      * @param applicationId the owning app id, or null for SYSTEM/ORGANIZATION
-     * @return {@link CompletableFuture} emitting the matching user, or {@code null} if no user matches
+     * @return {@link Future} emitting the matching user, or {@code null} if no user matches
      */
-    CompletableFuture<UserParticipantIdentity> findByEmail(String email, String organizationId, String applicationId);
+    Future<UserParticipantIdentity> findByEmail(String email, String organizationId, String applicationId);
 
     /**
      * Finds the first ORG-scope user with the given email across all organizations. Used by
      * the sign-up flow to enforce one user per email at organization-creation time, before
      * the new organization's id exists.
      */
-    CompletableFuture<UserParticipantIdentity> findFirstOrgUserByEmail(String email);
+    Future<UserParticipantIdentity> findFirstOrgUserByEmail(String email);
 
     /**
      * Finds the {@link UserParticipantIdentity} record for the given email, across all scopes. Returns
@@ -45,17 +44,17 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * SSO redirect — the service-layer uniqueness rule (one row per email + scope) makes
      * this an unambiguous lookup for the org-login flow.
      */
-    CompletableFuture<UserParticipantIdentity> findByEmail(String email);
+    Future<UserParticipantIdentity> findByEmail(String email);
 
     /**
      * Finds the {@link UserParticipantIdentity} (if any) with the given OIDC identity within a specific
      * scope. Scope is identified by {@code (organizationId, applicationId)} with the same
      * null conventions as {@link #findByEmail(String, String, String)}.
      */
-    CompletableFuture<UserParticipantIdentity> findByOidcIdentity(String oidcSubject,
-                                                  String oidcConfigId,
-                                                  String organizationId,
-                                                  String applicationId);
+    Future<UserParticipantIdentity> findByOidcIdentity(String oidcSubject,
+                                                       String oidcConfigId,
+                                                       String organizationId,
+                                                       String applicationId);
 
     /**
      * Finds the ORGANIZATION-scope user (if any) for the given OIDC identity, across all
@@ -63,24 +62,24 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * it is unambiguous because an email may belong to at most one organization, so a given
      * {@code (oidcSubject, oidcConfigId)} identity maps to at most one org-scope user.
      */
-    CompletableFuture<UserParticipantIdentity> findOrgUserByOidcIdentity(String oidcSubject, String oidcConfigId);
+    Future<UserParticipantIdentity> findOrgUserByOidcIdentity(String oidcSubject, String oidcConfigId);
 
     /**
      * Finds all users (never delegates) within the given scope, identified structurally by
      * {@code (organizationId, applicationId)} with the same null conventions as
      * {@link #findByEmail(String, String, String)}.
      */
-    CompletableFuture<Page<UserParticipantIdentity>> findUsersByScope(String organizationId, String applicationId, Pageable pageable);
+    Future<Page<UserParticipantIdentity>> findUsersByScope(String organizationId, String applicationId, Pageable pageable);
 
     /**
      * Searches users (never delegates) within the given scope by free text over email and
      * display name. A blank {@code searchText} returns every user in scope, equivalent to
      * {@link #findUsersByScope(String, String, Pageable)}.
      */
-    CompletableFuture<Page<UserParticipantIdentity>> searchUsersByScope(String searchText,
-                                                   String organizationId,
-                                                   String applicationId,
-                                                   Pageable pageable);
+    Future<Page<UserParticipantIdentity>> searchUsersByScope(String searchText,
+                                                             String organizationId,
+                                                             String applicationId,
+                                                             Pageable pageable);
 
     /**
      * Creates a user, assigning id and dates, enabling it, and detecting the auth type from
@@ -93,7 +92,7 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * @param password the password for a LOCAL user, or null for an OIDC user
      * @return a future emitting the created user
      */
-    CompletableFuture<UserParticipantIdentity> createUser(UserParticipantIdentity user, String password);
+    Future<UserParticipantIdentity> createUser(UserParticipantIdentity user, String password);
 
     /**
      * Resolves the delegate for {@code (owner, clientKey)}, creating it on first approval.
@@ -107,16 +106,16 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * @param displayName the client's display name, shown wherever the delegate is listed
      * @return a future emitting the enabled delegate
      */
-    CompletableFuture<DelegatingParticipantIdentity> findOrCreateDelegate(UserParticipantIdentity owner,
-                                                                          DelegateKind kind,
-                                                                          String clientKey,
-                                                                          String displayName);
+    Future<DelegatingParticipantIdentity> findOrCreateDelegate(UserParticipantIdentity owner,
+                                                               DelegateKind kind,
+                                                               String clientKey,
+                                                               String displayName);
 
     /**
      * Finds every delegate authorized on behalf of the given owner, revoked ones included —
      * the owner's view of which clients hold or held access.
      */
-    CompletableFuture<Page<DelegatingParticipantIdentity>> findDelegatesByOwner(String ownerId, Pageable pageable);
+    Future<Page<DelegatingParticipantIdentity>> findDelegatesByOwner(String ownerId, Pageable pageable);
 
     /**
      * Provisions a machine identity, assigning id and dates, enabling it, and generating the
@@ -126,14 +125,14 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * @param machine the unsaved machine carrying display name and scope
      * @return a future emitting the saved machine together with its one-time secret
      */
-    CompletableFuture<MachineProvisionResult> createMachine(MachineParticipantIdentity machine);
+    Future<MachineProvisionResult> createMachine(MachineParticipantIdentity machine);
 
     /**
      * Finds all machines within the given scope, identified structurally by
      * {@code (organizationId, applicationId)} with the same null conventions as
      * {@link #findByEmail(String, String, String)}.
      */
-    CompletableFuture<Page<MachineParticipantIdentity>> findMachinesByScope(String organizationId, String applicationId, Pageable pageable);
+    Future<Page<MachineParticipantIdentity>> findMachinesByScope(String organizationId, String applicationId, Pageable pageable);
 
     /**
      * Replaces a machine's client secret with a freshly generated one, invalidating the old
@@ -142,7 +141,7 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * @param machineId the machine whose secret to replace
      * @return a future emitting the new secret in plaintext, shown exactly once
      */
-    CompletableFuture<String> rotateMachineSecret(String machineId);
+    Future<String> rotateMachineSecret(String machineId);
 
     /**
      * Authenticates a machine by its credentials: the machine with the given id must exist,
@@ -154,7 +153,7 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
      * @param clientSecret the secret issued at provisioning
      * @return a future emitting the authenticated machine, failed for any invalid credential
      */
-    CompletableFuture<MachineParticipantIdentity> verifyMachineCredentials(String machineId, String clientSecret);
+    Future<MachineParticipantIdentity> verifyMachineCredentials(String machineId, String clientSecret);
 
 }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/RefreshTokenService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/RefreshTokenService.java
@@ -1,12 +1,12 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.security.DelegateSession;
 import org.kinotic.domain.api.model.security.ParticipantIdentity;
 import org.kinotic.domain.api.model.security.KinoticAudience;
 import org.kinotic.domain.api.model.security.RefreshTokenRotation;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Issues and rotates refresh tokens for OAuth client sessions. Tokens are stored only as hashes;
@@ -25,7 +25,7 @@ public interface RefreshTokenService {
      *                   shown wherever the identity's sessions are listed
      * @return the plaintext refresh token — available only here, the server stores only its hash
      */
-    CompletableFuture<String> issue(String identityId, KinoticAudience audience, String label);
+    Future<String> issue(String identityId, KinoticAudience audience, String label);
 
     /**
      * Validates and rotates a refresh token: the presented token is revoked and a fresh one
@@ -35,13 +35,13 @@ public interface RefreshTokenService {
      *
      * @param token the plaintext refresh token presented by the client
      */
-    CompletableFuture<RefreshTokenRotation> rotate(String token);
+    Future<RefreshTokenRotation> rotate(String token);
 
     /**
      * Lists the identity's live sessions — one per family whose current token is unrevoked
      * and unexpired.
      */
-    CompletableFuture<List<DelegateSession>> findActiveSessions(String identityId);
+    Future<List<DelegateSession>> findActiveSessions(String identityId);
 
     /**
      * Revokes every token in the given family, ending that session; future rotations of it
@@ -51,10 +51,10 @@ public interface RefreshTokenService {
      * @param identityId id of the identity the family authenticates
      * @param familyId   the family to revoke
      */
-    CompletableFuture<Void> revokeFamily(String identityId, String familyId);
+    Future<Void> revokeFamily(String identityId, String familyId);
 
     /**
      * Revokes every live family of the given identity, ending all of its sessions.
      */
-    CompletableFuture<Void> revokeAllFor(String identityId);
+    Future<Void> revokeAllFor(String identityId);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/SignUpService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/SignUpService.java
@@ -1,9 +1,8 @@
 package org.kinotic.domain.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
 import org.kinotic.domain.api.model.security.PendingSignUp;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Drives every sign-up through one short-lived {@link PendingSignUp} record. Two phases:
@@ -17,14 +16,14 @@ public interface SignUpService {
      * Starts an email/password sign-up: validates and stores a pending record and emails a
      * verification link. The organization name and password are collected later, at completion.
      */
-    CompletableFuture<Void> initiateLocalSignUp(String email, String displayName);
+    Future<Void> initiateLocalSignUp(String email, String displayName);
 
     /**
      * Stores a pending sign-up for an identity already verified by an OIDC provider, returning it
      * with its {@code id} and {@code verificationToken} populated. The caller supplies the verified
      * identity (and, for an existing-org registration, the {@code organizationId}).
      */
-    CompletableFuture<PendingSignUp> createOidcPending(PendingSignUp pending);
+    Future<PendingSignUp> createOidcPending(PendingSignUp pending);
 
     /**
      * Completes an email/password sign-up: validates the token, creates the organization with the
@@ -33,11 +32,11 @@ public interface SignUpService {
      *
      * @return the new organization's admin user
      */
-    CompletableFuture<UserParticipantIdentity> completeLocalSignUp(String token, String orgName, String orgDescription, String password);
+    Future<UserParticipantIdentity> completeLocalSignUp(String token, String orgName, String orgDescription, String password);
 
     /**
      * Completes an OIDC sign-up by creating a new organization with the given name (failing if it
      * is taken), making the verified identity its admin, then deleting the pending record.
      */
-    CompletableFuture<UserParticipantIdentity> completeOidcWithNewOrg(String token, String orgName, String orgDescription);
+    Future<UserParticipantIdentity> completeOidcWithNewOrg(String token, String orgName, String orgDescription);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/ElasticServiceDirectoryStrategy.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/ElasticServiceDirectoryStrategy.java
@@ -1,7 +1,6 @@
 package org.kinotic.domain.internal.api;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.crud.CursorPageable;
 import org.kinotic.core.api.crud.Page;
@@ -24,54 +23,46 @@ import java.util.Set;
 public class ElasticServiceDirectoryStrategy implements ServiceDirectoryStrategy {
 
     private final ServiceDirectoryEntryRepository repository;
-    private final Vertx vertx;
 
     @Override
     public Future<Void> upsertEntry(ServiceDirectoryEntry entry) {
-        return Future.fromCompletionStage(repository.upsertEntry(entry),
-                                          vertx.getOrCreateContext());
+        return repository.upsertEntry(entry);
     }
 
     @Override
     public Future<Void> setOnline(String entryId, boolean online, Instant when) {
-        return Future.fromCompletionStage(repository.setOnline(entryId, online, when),
-                                          vertx.getOrCreateContext());
+        return repository.setOnline(entryId, online, when);
     }
 
     @Override
     public Future<Void> setOnlineByAddress(String serviceAddress, boolean online, Instant when) {
-        return Future.fromCompletionStage(repository.setOnlineByAddress(serviceAddress, online, when),
-                                          vertx.getOrCreateContext());
+        return repository.setOnlineByAddress(serviceAddress, online, when);
     }
 
     @Override
     public Future<Void> reconcileLiveness(Set<String> activeAddresses, Instant when) {
-        return Future.fromCompletionStage(repository.reconcileLiveness(activeAddresses, when),
-                                          vertx.getOrCreateContext());
+        return repository.reconcileLiveness(activeAddresses, when);
     }
 
     @Override
     public Future<Page<ServiceDirectoryEntry>> findEntriesScopedTo(String organizationId,
                                                                    String applicationId,
                                                                    Pageable pageable) {
-        return Future.fromCompletionStage(repository.findEntriesScopedTo(organizationId, applicationId, pageable),
-                                          vertx.getOrCreateContext());
+        return repository.findEntriesScopedTo(organizationId, applicationId, pageable);
     }
 
     @Override
     public Future<McpToolDefinition> findMcpToolByName(String toolName,
                                                        String organizationId,
                                                        String applicationId) {
-        return Future.fromCompletionStage(repository.findMcpToolByName(toolName, organizationId, applicationId),
-                                          vertx.getOrCreateContext());
+        return repository.findMcpToolByName(toolName, organizationId, applicationId);
     }
 
     @Override
     public Future<McpToolDefinitionList> findMcpToolsCallableBy(String organizationId,
                                                                 String applicationId,
                                                                 CursorPageable pageable) {
-        return Future.fromCompletionStage(repository.findMcpToolsCallableBy(organizationId, applicationId, pageable),
-                                          vertx.getOrCreateContext());
+        return repository.findMcpToolsCallableBy(organizationId, applicationId, pageable);
     }
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractApplicationScopedRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractApplicationScopedRepository.java
@@ -1,13 +1,12 @@
 package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.ApplicationScoped;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Repository tier for entities that belong to an application within an organization.
@@ -24,12 +23,12 @@ public abstract class AbstractApplicationScopedRepository<T extends ApplicationS
         super(indexName, type, crudServiceTemplate);
     }
 
-    public CompletableFuture<Long> countForApplication(String applicationId, String orgId) {
+    public Future<Long> countForApplication(String applicationId, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return count(b -> b.routing(orgId).query(composeOrgFilter(orgId, applicationIdFilter(applicationId))));
     }
 
-    public CompletableFuture<Page<T>> findAllForApplication(String applicationId, String orgId, Pageable pageable) {
+    public Future<Page<T>> findAllForApplication(String applicationId, String orgId, Pageable pageable) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return findAll(pageable, b -> b.routing(orgId).query(composeOrgFilter(orgId, applicationIdFilter(applicationId))));
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
@@ -3,6 +3,7 @@ package org.kinotic.domain.internal.api.repositories;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import io.vertx.core.Future;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,6 @@ import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.OrganizationScoped;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -47,7 +47,7 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
         crudServiceTemplate.verifyIndexExists(indexName);
     }
 
-    public CompletableFuture<Long> count(String orgId) {
+    public Future<Long> count(String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return crudServiceTemplate.count(indexName, b -> b.routing(orgId).query(composeOrgFilter(orgId)));
     }
@@ -56,7 +56,7 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      * Returns the document with the given {@code id} that belongs to {@code orgId}, or
      * {@code null} if no such document exists.
      */
-    public CompletableFuture<T> findById(String id, String orgId) {
+    public Future<T> findById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return crudServiceTemplate.findById(indexName,
                                             composeDocumentId(id, orgId),
@@ -68,12 +68,12 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      * Deletes the document with the given {@code id} that belongs to {@code orgId}. No-op
      * if no such document exists.
      */
-    public CompletableFuture<Void> deleteById(String id, String orgId) {
+    public Future<Void> deleteById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return crudServiceTemplate.deleteById(indexName,
                                               composeDocumentId(id, orgId),
                                               b -> b.routing(orgId))
-                                  .thenApply(response -> null);
+                                  .mapEmpty();
     }
 
     /**
@@ -81,15 +81,15 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      * for the deletion to be visible in search results before returning. No-op if no such
      * document exists.
      */
-    public CompletableFuture<Void> deleteByIdSync(String id, String orgId) {
+    public Future<Void> deleteByIdSync(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return crudServiceTemplate.deleteByIdSync(indexName,
                                                   composeDocumentId(id, orgId),
                                                   b -> b.routing(orgId))
-                                  .thenApply(response -> null);
+                                  .mapEmpty();
     }
 
-    public CompletableFuture<Page<T>> findAll(String orgId, Pageable pageable) {
+    public Future<Page<T>> findAll(String orgId, Pageable pageable) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return crudServiceTemplate.search(indexName, pageable, type,
                                           b -> b.routing(orgId).query(composeOrgFilter(orgId)));
@@ -99,24 +99,24 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      * Saves {@code value} as belonging to {@code orgId}. Throws if the entity's own
      * {@code organizationId} disagrees with {@code orgId}.
      */
-    public CompletableFuture<T> save(T value, String orgId) {
+    public Future<T> save(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
         return crudServiceTemplate.save(indexName,
                                         composeDocumentId(value.getId(), orgId),
                                         value,
                                         b -> b.routing(orgId))
-                                  .thenApply(indexResponse -> value);
+                                  .map(value);
     }
 
-    public CompletableFuture<T> saveSync(T value, String orgId) {
+    public Future<T> saveSync(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
         return crudServiceTemplate.saveSync(indexName,
                                             composeDocumentId(value.getId(), orgId),
                                             value,
                                             b -> b.routing(orgId))
-                                  .thenApply(indexResponse -> value);
+                                  .map(value);
     }
 
     /**
@@ -124,31 +124,31 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      * {@link org.kinotic.core.api.exceptions.AlreadyExistsException} if the id is already
      * taken within that organization, instead of overwriting the way {@link #save} would.
      */
-    public CompletableFuture<T> create(T value, String orgId) {
+    public Future<T> create(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
         return crudServiceTemplate.create(indexName,
                                           composeDocumentId(value.getId(), orgId),
                                           value,
                                           b -> b.routing(orgId))
-                                  .thenApply(indexResponse -> value);
+                                  .map(value);
     }
 
     /**
      * Persists a new entity like {@link #create}, additionally waiting for it to be visible
      * in search results before returning.
      */
-    public CompletableFuture<T> createSync(T value, String orgId) {
+    public Future<T> createSync(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
         return crudServiceTemplate.createSync(indexName,
                                               composeDocumentId(value.getId(), orgId),
                                               value,
                                               b -> b.routing(orgId))
-                                  .thenApply(indexResponse -> value);
+                                  .map(value);
     }
 
-    public CompletableFuture<Page<T>> search(String searchText, String orgId, Pageable pageable) {
+    public Future<Page<T>> search(String searchText, String orgId, Pageable pageable) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         boolean hasText = searchText != null && !searchText.isEmpty();
         if (!hasText) {
@@ -160,19 +160,19 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
                                                   .filter(termFilter(ORGANIZATION_ID_FIELD, orgId))))));
     }
 
-    public CompletableFuture<Void> syncIndex() {
+    public Future<Void> syncIndex() {
         return crudServiceTemplate.syncIndex(indexName);
     }
 
-    protected CompletableFuture<Long> count(Consumer<CountRequest.Builder> builderConsumer) {
+    protected Future<Long> count(Consumer<CountRequest.Builder> builderConsumer) {
         return crudServiceTemplate.count(indexName, builderConsumer);
     }
 
-    protected CompletableFuture<Page<T>> findAll(Pageable pageable, Consumer<SearchRequest.Builder> builderConsumer) {
+    protected Future<Page<T>> findAll(Pageable pageable, Consumer<SearchRequest.Builder> builderConsumer) {
         return crudServiceTemplate.search(indexName, pageable, type, builderConsumer);
     }
 
-    protected CompletableFuture<T> findFirst(Consumer<SearchRequest.Builder> builderConsumer) {
+    protected Future<T> findFirst(Consumer<SearchRequest.Builder> builderConsumer) {
         return crudServiceTemplate.findFirst(indexName, type, builderConsumer);
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractProjectScopedRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractProjectScopedRepository.java
@@ -1,13 +1,12 @@
 package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.ProjectScoped;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Repository tier for entities that belong to a project within an application and organization.
@@ -22,12 +21,12 @@ public abstract class AbstractProjectScopedRepository<T extends ProjectScoped<St
         super(indexName, type, crudServiceTemplate);
     }
 
-    public CompletableFuture<Long> countForProject(String projectId, String orgId) {
+    public Future<Long> countForProject(String projectId, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return count(b -> b.routing(orgId).query(composeOrgFilter(orgId, projectIdFilter(projectId))));
     }
 
-    public CompletableFuture<Page<T>> findAllForProject(String projectId, String orgId, Pageable pageable) {
+    public Future<Page<T>> findAllForProject(String projectId, String orgId, Pageable pageable) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return findAll(pageable, b -> b.routing(orgId).query(composeOrgFilter(orgId, projectIdFilter(projectId))));
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractRepository.java
@@ -2,6 +2,7 @@ package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.*;
+import io.vertx.core.Future;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,6 @@ import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -37,7 +37,7 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
         crudServiceTemplate.verifyIndexExists(indexName);
     }
 
-    public CompletableFuture<Long> count() {
+    public Future<Long> count() {
         return count(null);
     }
 
@@ -45,37 +45,37 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
      * Counts documents with full builder access. Subclasses use this overload to issue
      * specialized count queries.
      */
-    protected CompletableFuture<Long> count(Consumer<CountRequest.Builder> builderConsumer) {
+    protected Future<Long> count(Consumer<CountRequest.Builder> builderConsumer) {
         return crudServiceTemplate.count(indexName, builderConsumer);
     }
 
-    public CompletableFuture<T> findById(String id) {
+    public Future<T> findById(String id) {
         return findById(id, null);
     }
 
-    protected CompletableFuture<T> findById(String id, Consumer<GetRequest.Builder> builderConsumer) {
+    protected Future<T> findById(String id, Consumer<GetRequest.Builder> builderConsumer) {
         return crudServiceTemplate.findById(indexName, id, type, builderConsumer);
     }
 
-    public CompletableFuture<Void> deleteById(String id) {
+    public Future<Void> deleteById(String id) {
         return deleteById(id, null);
     }
 
-    protected CompletableFuture<Void> deleteById(String id, Consumer<DeleteRequest.Builder> builderConsumer) {
+    protected Future<Void> deleteById(String id, Consumer<DeleteRequest.Builder> builderConsumer) {
         return crudServiceTemplate.deleteById(indexName, id, builderConsumer)
-                                  .thenApply(_ -> null);
+                                  .mapEmpty();
     }
 
-    public CompletableFuture<Void> deleteByIdSync(String id) {
+    public Future<Void> deleteByIdSync(String id) {
         return deleteByIdSync(id, null);
     }
 
-    protected CompletableFuture<Void> deleteByIdSync(String id, Consumer<DeleteRequest.Builder> builderConsumer) {
+    protected Future<Void> deleteByIdSync(String id, Consumer<DeleteRequest.Builder> builderConsumer) {
         return crudServiceTemplate.deleteByIdSync(indexName, id, builderConsumer)
-                                  .thenApply(_ -> null);
+                                  .mapEmpty();
     }
 
-    public CompletableFuture<Page<T>> findAll(Pageable pageable) {
+    public Future<Page<T>> findAll(Pageable pageable) {
         return findAll(pageable, null);
     }
 
@@ -83,26 +83,26 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
      * Issues a paginated search with full builder access. Subclasses use this overload to
      * issue specialized queries.
      */
-    protected CompletableFuture<Page<T>> findAll(Pageable pageable, Consumer<SearchRequest.Builder> builderConsumer) {
+    protected Future<Page<T>> findAll(Pageable pageable, Consumer<SearchRequest.Builder> builderConsumer) {
         return crudServiceTemplate.search(indexName, pageable, type, builderConsumer);
     }
 
-    public CompletableFuture<T> save(T value) {
+    public Future<T> save(T value) {
         return save(value, null);
     }
 
-    protected CompletableFuture<T> save(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
+    protected Future<T> save(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
         return crudServiceTemplate.save(indexName, value.getId(), value, builderConsumer)
-                                  .thenApply(_ -> value);
+                                  .map(value);
     }
 
-    public CompletableFuture<T> saveSync(T value) {
+    public Future<T> saveSync(T value) {
         return saveSync(value, null);
     }
 
-    protected CompletableFuture<T> saveSync(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
+    protected Future<T> saveSync(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
         return crudServiceTemplate.saveSync(indexName, value.getId(), value, builderConsumer)
-                                  .thenApply(_ -> value);
+                                  .map(value);
     }
 
     /**
@@ -110,32 +110,32 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
      * which overwrites, this fails with {@link org.kinotic.core.api.exceptions.AlreadyExistsException}
      * on an id collision — use it to enforce uniqueness on a caller-assigned id.
      */
-    public CompletableFuture<T> create(T value) {
+    public Future<T> create(T value) {
         return crudServiceTemplate.create(indexName, value.getId(), value)
-                                  .thenApply(_ -> value);
+                                  .map(value);
     }
 
     /**
      * Persists a new entity like {@link #create}, additionally waiting for it to be visible
      * in search results before returning.
      */
-    public CompletableFuture<T> createSync(T value) {
+    public Future<T> createSync(T value) {
         return createSync(value, null);
     }
 
-    protected CompletableFuture<T> createSync(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
+    protected Future<T> createSync(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
         return crudServiceTemplate.createSync(indexName, value.getId(), value, builderConsumer)
-                                  .thenApply(_ -> value);
+                                  .map(value);
     }
 
-    public CompletableFuture<Page<T>> search(String searchText, Pageable pageable) {
+    public Future<Page<T>> search(String searchText, Pageable pageable) {
         if (searchText == null || searchText.isEmpty()) {
             return findAll(pageable);
         }
         return findAll(pageable, b -> b.q(searchText));
     }
 
-    public CompletableFuture<Void> syncIndex() {
+    public Future<Void> syncIndex() {
         return crudServiceTemplate.syncIndex(indexName);
     }
 
@@ -167,7 +167,7 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
         return crudServiceTemplate.missingFilter(field);
     }
 
-    protected CompletableFuture<T> findFirst(Consumer<SearchRequest.Builder> builderConsumer) {
+    protected Future<T> findFirst(Consumer<SearchRequest.Builder> builderConsumer) {
         return crudServiceTemplate.findFirst(indexName, type, builderConsumer);
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractTokenVerificationRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractTokenVerificationRepository.java
@@ -1,10 +1,10 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.security.PendingVerification;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 
 import java.util.Date;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Persistence base for short-lived, single-use token records. Layers token lookup and
@@ -23,7 +23,7 @@ public abstract class AbstractTokenVerificationRepository<T extends PendingVerif
     }
 
     /** Finds a record by its verification token, or {@code null} if none matches. */
-    public CompletableFuture<T> findByVerificationToken(String verificationToken) {
+    public Future<T> findByVerificationToken(String verificationToken) {
         return findFirst(b -> b.query(termFilter("verificationToken", verificationToken)));
     }
 
@@ -32,17 +32,17 @@ public abstract class AbstractTokenVerificationRepository<T extends PendingVerif
      * has expired; fails if no record matches the token. Returns the live record otherwise —
      * callers consume it and delete it on success.
      */
-    public CompletableFuture<T> findValidByToken(String verificationToken) {
-        return findByVerificationToken(verificationToken).thenCompose(pending -> {
+    public Future<T> findValidByToken(String verificationToken) {
+        return findByVerificationToken(verificationToken).compose(pending -> {
             if (pending == null) {
-                return CompletableFuture.failedFuture(new IllegalArgumentException(
+                return Future.failedFuture(new IllegalArgumentException(
                         "Invalid or already consumed token."));
             }
             if (pending.getExpiresAt().before(new Date())) {
-                return deleteById(pending.getId()).thenCompose(v -> CompletableFuture.failedFuture(
+                return deleteById(pending.getId()).compose(v -> Future.failedFuture(
                         new IllegalArgumentException("This link has expired. Please start over.")));
             }
-            return CompletableFuture.completedFuture(pending);
+            return Future.succeededFuture(pending);
         });
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ApplicationRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ApplicationRepository.java
@@ -1,11 +1,10 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.domain.api.model.Application;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class ApplicationRepository extends AbstractOrganizationScopedRepository<Application> {
@@ -23,10 +22,10 @@ public class ApplicationRepository extends AbstractOrganizationScopedRepository<
      * @param organizationId the organization it must belong to
      * @return a future emitting the application, failed when it is not in the organization
      */
-    public CompletableFuture<Application> requireById(String applicationId, String organizationId) {
+    public Future<Application> requireById(String applicationId, String organizationId) {
         Validate.notBlank(applicationId, "applicationId cannot be blank");
         return findById(applicationId, organizationId)
-                .thenApply(app -> {
+                .map(app -> {
                     if (app == null) {
                         throw new IllegalArgumentException("Application not found: " + applicationId);
                     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/DeviceCodeGrantRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/DeviceCodeGrantRepository.java
@@ -1,10 +1,9 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.internal.api.model.DeviceCodeGrant;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DeviceCodeGrantRepository extends AbstractRepository<DeviceCodeGrant> {
@@ -14,12 +13,12 @@ public class DeviceCodeGrantRepository extends AbstractRepository<DeviceCodeGran
     }
 
     /** Finds the grant whose device code hashes to {@code deviceCodeHash}, or {@code null} if none matches. */
-    public CompletableFuture<DeviceCodeGrant> findByDeviceCodeHash(String deviceCodeHash) {
+    public Future<DeviceCodeGrant> findByDeviceCodeHash(String deviceCodeHash) {
         return findFirst(b -> b.query(termFilter("deviceCodeHash", deviceCodeHash)));
     }
 
     /** Finds the grant with the given {@code userCode}, or {@code null} if none matches. */
-    public CompletableFuture<DeviceCodeGrant> findByUserCode(String userCode) {
+    public Future<DeviceCodeGrant> findByUserCode(String userCode) {
         return findFirst(b -> b.query(termFilter("userCode", userCode)));
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/InviteEmailTemplateRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/InviteEmailTemplateRepository.java
@@ -1,11 +1,10 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.domain.api.model.InviteEmailTemplate;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class InviteEmailTemplateRepository extends AbstractApplicationScopedRepository<InviteEmailTemplate> {
@@ -15,7 +14,7 @@ public class InviteEmailTemplateRepository extends AbstractApplicationScopedRepo
     }
 
     /** Finds the application's invitation template, or {@code null} if none exists. */
-    public CompletableFuture<InviteEmailTemplate> findByApplication(String applicationId, String orgId) {
+    public Future<InviteEmailTemplate> findByApplication(String applicationId, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return findFirst(b -> b.routing(orgId).query(composeOrgFilter(orgId,
                 applicationIdFilter(applicationId))));

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OAuthAuthorizationGrantRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OAuthAuthorizationGrantRepository.java
@@ -1,10 +1,9 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.internal.api.model.OAuthAuthorizationGrant;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class OAuthAuthorizationGrantRepository extends AbstractRepository<OAuthAuthorizationGrant> {
@@ -14,7 +13,7 @@ public class OAuthAuthorizationGrantRepository extends AbstractRepository<OAuthA
     }
 
     /** Finds the grant whose authorization code hashes to {@code codeHash}, or {@code null} if none matches. */
-    public CompletableFuture<OAuthAuthorizationGrant> findByCodeHash(String codeHash) {
+    public Future<OAuthAuthorizationGrant> findByCodeHash(String codeHash) {
         return findFirst(b -> b.query(termFilter("codeHash", codeHash)));
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OidcConfigurationRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OidcConfigurationRepository.java
@@ -2,6 +2,7 @@ package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.IdsQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -10,7 +11,6 @@ import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class OidcConfigurationRepository extends AbstractOrganizationScopedRepository<OidcConfiguration> {
@@ -23,7 +23,7 @@ public class OidcConfigurationRepository extends AbstractOrganizationScopedRepos
      * Returns the configurations among {@code ids} that belong to {@code orgId} and whose
      * {@code enabled} flag is true.
      */
-    public CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId) {
+    public Future<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         Validate.notEmpty(ids, "ids cannot be null or empty");
         List<String> documentIds = ids.stream()
@@ -33,6 +33,6 @@ public class OidcConfigurationRepository extends AbstractOrganizationScopedRepos
                                        IdsQuery.of(i -> i.values(documentIds))._toQuery(),
                                        termFilter("enabled", true));
         return findAll(Pageable.ofSize(ids.size()), b -> b.routing(orgId).query(query))
-                .thenApply(Page::getContent);
+                .map(Page::getContent);
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OrgSignupOidcConfigurationRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OrgSignupOidcConfigurationRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.security.OidcProviderKind;
@@ -8,7 +9,6 @@ import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class OrgSignupOidcConfigurationRepository extends AbstractRepository<OrgSignupOidcConfiguration> {
@@ -17,12 +17,12 @@ public class OrgSignupOidcConfigurationRepository extends AbstractRepository<Org
         super("kinotic_org_signup_oidc_configuration", OrgSignupOidcConfiguration.class, crudServiceTemplate);
     }
 
-    public CompletableFuture<List<OrgSignupOidcConfiguration>> findAllEnabled() {
+    public Future<List<OrgSignupOidcConfiguration>> findAllEnabled() {
         return findAll(Pageable.ofSize(100), b -> b.query(termFilter("enabled", true)))
-                .thenApply(Page::getContent);
+                .map(Page::getContent);
     }
 
-    public CompletableFuture<OrgSignupOidcConfiguration> findEnabledByProvider(OidcProviderKind provider) {
+    public Future<OrgSignupOidcConfiguration> findEnabledByProvider(OidcProviderKind provider) {
         return findFirst(b -> b.query(composeFilter(
                 termFilter("provider", provider.key()),
                 termFilter("enabled", true))));

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ParticipantIdentityRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ParticipantIdentityRepository.java
@@ -1,6 +1,7 @@
 package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -13,8 +14,6 @@ import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Component
 public class ParticipantIdentityRepository extends AbstractRepository<ParticipantIdentity> {
 
@@ -22,7 +21,7 @@ public class ParticipantIdentityRepository extends AbstractRepository<Participan
         super("kinotic_participant_identity", ParticipantIdentity.class, crudServiceTemplate);
     }
 
-    public CompletableFuture<UserParticipantIdentity> findByEmail(String email, String organizationId, String applicationId) {
+    public Future<UserParticipantIdentity> findByEmail(String email, String organizationId, String applicationId) {
         Validate.notBlank(email, "email cannot be blank");
         if (applicationId != null) {
             Validate.notBlank(organizationId,
@@ -31,35 +30,35 @@ public class ParticipantIdentityRepository extends AbstractRepository<Participan
         return findFirst(b -> b.query(composeFilter(
                 termFilter("email", DomainUtil.normalizeEmail(email)),
                 scopeFilter(organizationId, applicationId))))
-                .thenApply(UserParticipantIdentity.class::cast);
+                .map(UserParticipantIdentity.class::cast);
     }
 
-    public CompletableFuture<UserParticipantIdentity> findFirstOrgUserByEmail(String email) {
+    public Future<UserParticipantIdentity> findFirstOrgUserByEmail(String email) {
         return findFirst(b -> b.query(composeFilter(
                 termFilter("email", DomainUtil.normalizeEmail(email)),
                 existsFilter("organizationId"),
                 missingFilter("applicationId"))))
-                .thenApply(UserParticipantIdentity.class::cast);
+                .map(UserParticipantIdentity.class::cast);
     }
 
-    public CompletableFuture<UserParticipantIdentity> findByEmail(String email) {
+    public Future<UserParticipantIdentity> findByEmail(String email) {
         return findFirst(b -> b.query(termFilter("email", DomainUtil.normalizeEmail(email))))
-                .thenApply(UserParticipantIdentity.class::cast);
+                .map(UserParticipantIdentity.class::cast);
     }
 
     /** Users only — delegates share their owner's scope and must not appear in member listings. */
-    public CompletableFuture<Page<UserParticipantIdentity>> findUsersByScope(String organizationId, String applicationId, Pageable pageable) {
+    public Future<Page<UserParticipantIdentity>> findUsersByScope(String organizationId, String applicationId, Pageable pageable) {
         return findAll(pageable, b -> b.query(composeFilter(
                 termFilter("type", ParticipantIdentityType.USER.name()),
                 scopeFilter(organizationId, applicationId))))
-                .thenApply(page -> page.map(UserParticipantIdentity.class::cast));
+                .map(page -> page.map(UserParticipantIdentity.class::cast));
     }
 
     /** Users only — delegates share their owner's scope and must not appear in member listings. */
-    public CompletableFuture<Page<UserParticipantIdentity>> searchUsersByScope(String searchText,
-                                                          String organizationId,
-                                                          String applicationId,
-                                                          Pageable pageable) {
+    public Future<Page<UserParticipantIdentity>> searchUsersByScope(String searchText,
+                                                                    String organizationId,
+                                                                    String applicationId,
+                                                                    Pageable pageable) {
         if (searchText == null || searchText.isEmpty()) {
             return findUsersByScope(organizationId, applicationId, pageable);
         }
@@ -70,49 +69,49 @@ public class ParticipantIdentityRepository extends AbstractRepository<Participan
                 .filter(composeFilter(
                         termFilter("type", ParticipantIdentityType.USER.name()),
                         scopeFilter(organizationId, applicationId)))))))
-                .thenApply(page -> page.map(UserParticipantIdentity.class::cast));
+                .map(page -> page.map(UserParticipantIdentity.class::cast));
     }
 
-    public CompletableFuture<Page<MachineParticipantIdentity>> findMachinesByScope(String organizationId, String applicationId, Pageable pageable) {
+    public Future<Page<MachineParticipantIdentity>> findMachinesByScope(String organizationId, String applicationId, Pageable pageable) {
         return findAll(pageable, b -> b.query(composeFilter(
                 termFilter("type", ParticipantIdentityType.MACHINE.name()),
                 scopeFilter(organizationId, applicationId))))
-                .thenApply(page -> page.map(MachineParticipantIdentity.class::cast));
+                .map(page -> page.map(MachineParticipantIdentity.class::cast));
     }
 
-    public CompletableFuture<Page<DelegatingParticipantIdentity>> findDelegatesByOwner(String ownerId, Pageable pageable) {
+    public Future<Page<DelegatingParticipantIdentity>> findDelegatesByOwner(String ownerId, Pageable pageable) {
         Validate.notBlank(ownerId, "ownerId cannot be blank");
         return findAll(pageable, b -> b.query(termFilter("ownerId", ownerId)))
-                .thenApply(page -> page.map(DelegatingParticipantIdentity.class::cast));
+                .map(page -> page.map(DelegatingParticipantIdentity.class::cast));
     }
 
-    public CompletableFuture<DelegatingParticipantIdentity> findByOwnerAndClientKey(String ownerId, String clientKey) {
+    public Future<DelegatingParticipantIdentity> findByOwnerAndClientKey(String ownerId, String clientKey) {
         Validate.notBlank(ownerId, "ownerId cannot be blank");
         Validate.notBlank(clientKey, "clientKey cannot be blank");
         return findFirst(b -> b.query(composeFilter(
                 termFilter("ownerId", ownerId),
                 termFilter("clientKey", clientKey))))
-                .thenApply(DelegatingParticipantIdentity.class::cast);
+                .map(DelegatingParticipantIdentity.class::cast);
     }
 
-    public CompletableFuture<UserParticipantIdentity> findByOidcIdentity(String oidcSubject,
-                                                         String oidcConfigId,
-                                                         String organizationId,
-                                                         String applicationId) {
+    public Future<UserParticipantIdentity> findByOidcIdentity(String oidcSubject,
+                                                              String oidcConfigId,
+                                                              String organizationId,
+                                                              String applicationId) {
         return findFirst(b -> b.query(composeFilter(
                 termFilter("oidcSubject", oidcSubject),
                 termFilter("oidcConfigId", oidcConfigId),
                 scopeFilter(organizationId, applicationId))))
-                .thenApply(UserParticipantIdentity.class::cast);
+                .map(UserParticipantIdentity.class::cast);
     }
 
-    public CompletableFuture<UserParticipantIdentity> findOrgUserByOidcIdentity(String oidcSubject, String oidcConfigId) {
+    public Future<UserParticipantIdentity> findOrgUserByOidcIdentity(String oidcSubject, String oidcConfigId) {
         return findFirst(b -> b.query(composeFilter(
                 termFilter("oidcSubject", oidcSubject),
                 termFilter("oidcConfigId", oidcConfigId),
                 existsFilter("organizationId"),
                 missingFilter("applicationId"))))
-                .thenApply(UserParticipantIdentity.class::cast);
+                .map(UserParticipantIdentity.class::cast);
     }
 
     /**

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/PendingInviteRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/PendingInviteRepository.java
@@ -1,14 +1,13 @@
 package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.security.PendingInvite;
 import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class PendingInviteRepository extends AbstractTokenVerificationRepository<PendingInvite> {
@@ -17,9 +16,9 @@ public class PendingInviteRepository extends AbstractTokenVerificationRepository
         super("kinotic_pending_invite", PendingInvite.class, crudServiceTemplate);
     }
 
-    public CompletableFuture<PendingInvite> findByEmailAndScope(String email,
-                                                                String organizationId,
-                                                                String applicationId) {
+    public Future<PendingInvite> findByEmailAndScope(String email,
+                                                     String organizationId,
+                                                     String applicationId) {
         return findFirst(b -> b.query(composeFilter(
                 termFilter("email", DomainUtil.normalizeEmail(email)),
                 scopeFilter(organizationId, applicationId))));
@@ -30,9 +29,9 @@ public class PendingInviteRepository extends AbstractTokenVerificationRepository
      * here rather than deleted — physical cleanup still happens on consumption via
      * {@link #findValidByToken}.
      */
-    public CompletableFuture<Page<PendingInvite>> findByScope(String organizationId,
-                                                              String applicationId,
-                                                              Pageable pageable) {
+    public Future<Page<PendingInvite>> findByScope(String organizationId,
+                                                   String applicationId,
+                                                   Pageable pageable) {
         return findAll(pageable, b -> b.query(composeFilter(
                 scopeFilter(organizationId, applicationId),
                 notExpiredFilter())));

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/PendingSignUpRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/PendingSignUpRepository.java
@@ -1,10 +1,9 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.security.PendingSignUp;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Persistence for {@link PendingSignUp} records: email lookup plus the token-based, single-use,
@@ -19,7 +18,7 @@ public class PendingSignUpRepository extends AbstractTokenVerificationRepository
     }
 
     /** Finds a pending sign-up by email, or {@code null} — used to block duplicate submissions. */
-    public CompletableFuture<PendingSignUp> findByEmail(String email) {
+    public Future<PendingSignUp> findByEmail(String email) {
         return findFirst(b -> b.query(termFilter("email", email)));
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ProjectRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ProjectRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -8,7 +9,6 @@ import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class ProjectRepository extends AbstractApplicationScopedRepository<Project> {
@@ -17,16 +17,16 @@ public class ProjectRepository extends AbstractApplicationScopedRepository<Proje
         super("kinotic_project", Project.class, crudServiceTemplate);
     }
 
-    public CompletableFuture<List<Project>> findByRepoFullName(String repoFullName) {
+    public Future<List<Project>> findByRepoFullName(String repoFullName) {
         return findAll(Pageable.ofSize(50),
                        b -> b.query(termFilter("repoFullName", repoFullName)))
-                .thenApply(Page::getContent);
+                .map(Page::getContent);
     }
 
-    public CompletableFuture<List<Project>> findByRepoFullName(String repoFullName, String orgId) {
+    public Future<List<Project>> findByRepoFullName(String repoFullName, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return findAll(Pageable.ofSize(50),
                        b -> b.routing(orgId).query(composeOrgFilter(orgId, termFilter("repoFullName", repoFullName))))
-                .thenApply(Page::getContent);
+                .map(Page::getContent);
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/RefreshTokenRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/RefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.internal.api.model.RefreshToken;
@@ -7,7 +8,6 @@ import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class RefreshTokenRepository extends AbstractRepository<RefreshToken> {
@@ -17,21 +17,21 @@ public class RefreshTokenRepository extends AbstractRepository<RefreshToken> {
     }
 
     /** Finds the token whose plaintext hashes to {@code tokenHash}, or {@code null} if none matches. */
-    public CompletableFuture<RefreshToken> findByTokenHash(String tokenHash) {
+    public Future<RefreshToken> findByTokenHash(String tokenHash) {
         return findFirst(b -> b.query(termFilter("tokenHash", tokenHash)));
     }
 
     /** Finds every unrevoked token of the given identity — one per live family. */
-    public CompletableFuture<List<RefreshToken>> findActiveByIdentityId(String identityId) {
+    public Future<List<RefreshToken>> findActiveByIdentityId(String identityId) {
         return findAll(Pageable.ofSize(1000), b -> b.query(composeFilter(
                 termFilter("identityId", identityId),
                 termFilter("revoked", false))))
-                .thenApply(Page::getContent);
+                .map(Page::getContent);
     }
 
     /** Finds every token in the given rotation lineage. Used to revoke a family on reuse detection. */
-    public CompletableFuture<List<RefreshToken>> findByFamilyId(String familyId) {
+    public Future<List<RefreshToken>> findByFamilyId(String familyId) {
         return findAll(Pageable.ofSize(1000), b -> b.query(termFilter("familyId", familyId)))
-                .thenApply(Page::getContent);
+                .map(Page::getContent);
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ServiceDirectoryEntryRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ServiceDirectoryEntryRepository.java
@@ -1,6 +1,7 @@
 package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.crud.CursorPage;
 import org.kinotic.core.api.crud.CursorPageable;
@@ -19,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Elasticsearch repository for {@link ServiceDirectoryEntry}s over the {@code kinotic_service_directory} index.
@@ -49,7 +49,7 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
      * Upserts an entry as a partial update, leaving the liveness fields untouched so a re-registration never
      * clobbers the {@code online} state the liveness owner maintains.
      */
-    public CompletableFuture<Void> upsertEntry(ServiceDirectoryEntry entry) {
+    public Future<Void> upsertEntry(ServiceDirectoryEntry entry) {
         @SuppressWarnings("unchecked")
         Map<String, Object> partial = objectMapper.convertValue(entry, Map.class);
         partial.remove("online");
@@ -63,7 +63,7 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
      * Sets the liveness fields of an existing entry via a partial update touching only {@code online} and
      * {@code lastStatusChange}.
      */
-    public CompletableFuture<Void> setOnline(String entryId, boolean online, Instant when) {
+    public Future<Void> setOnline(String entryId, boolean online, Instant when) {
         return crudServiceTemplate.partialUpdate(indexName,
                                                  entryId,
                                                  Map.of("online", online, "lastStatusChange", when),
@@ -73,23 +73,23 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
     /**
      * Resolves the entry for a service address and sets its liveness. Addresses matching no entry are ignored.
      */
-    public CompletableFuture<Void> setOnlineByAddress(String serviceAddress, boolean online, Instant when) {
+    public Future<Void> setOnlineByAddress(String serviceAddress, boolean online, Instant when) {
         return findFirst(b -> {
             b.query(termFilter("serviceAddress", serviceAddress));
             b.source(sc -> sc.filter(f -> f.includes("id")));
-        }).thenCompose(entry -> entry == null
-                ? CompletableFuture.completedFuture(null)
+        }).compose(entry -> entry == null
+                ? Future.succeededFuture()
                 : setOnline(entry.getId(), online, when));
     }
 
     /**
      * Corrects the liveness of every entry to match the given snapshot of active service addresses.
      */
-    public CompletableFuture<Void> reconcileLiveness(Set<String> activeAddresses, Instant when) {
+    public Future<Void> reconcileLiveness(Set<String> activeAddresses, Instant when) {
         return findAll(Pageable.ofSize(RECONCILE_PAGE_SIZE),
                        b -> b.source(sc -> sc.filter(f -> f.includes("id", "serviceAddress", "online"))))
-                .thenCompose(page -> {
-                    List<CompletableFuture<Void>> updates = new ArrayList<>();
+                .compose(page -> {
+                    List<Future<Void>> updates = new ArrayList<>();
                     for (ServiceDirectoryEntry entry : page.getContent()) {
                         boolean desired = entry.getServiceAddress() != null
                                 && activeAddresses.contains(entry.getServiceAddress());
@@ -97,7 +97,7 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
                             updates.add(setOnline(entry.getId(), desired, when));
                         }
                     }
-                    return CompletableFuture.allOf(updates.toArray(new CompletableFuture[0]));
+                    return Future.all(updates).mapEmpty();
                 });
     }
 
@@ -105,9 +105,9 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
      * Returns the entries in the given scope. A system scope (organizationId null) returns all entries; otherwise the
      * organization (and application, when given) is filtered on, so system entries never match a non-null scope.
      */
-    public CompletableFuture<Page<ServiceDirectoryEntry>> findEntriesScopedTo(String organizationId,
-                                                                              String applicationId,
-                                                                              Pageable pageable) {
+    public Future<Page<ServiceDirectoryEntry>> findEntriesScopedTo(String organizationId,
+                                                                   String applicationId,
+                                                                   Pageable pageable) {
         Query scopeFilter = scopeFilter(organizationId, applicationId);
         return findAll(pageable, b -> {
             if (scopeFilter != null) {
@@ -120,9 +120,9 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
      * Returns the online MCP tools a caller in the given scope may call, flattened from the matching entries. The
      * search {@code _source}-filters to the {@code mcpTools} field so contracts never leave Elasticsearch.
      */
-    public CompletableFuture<McpToolDefinitionList> findMcpToolsCallableBy(String organizationId,
-                                                                           String applicationId,
-                                                                           CursorPageable pageable) {
+    public Future<McpToolDefinitionList> findMcpToolsCallableBy(String organizationId,
+                                                                String applicationId,
+                                                                CursorPageable pageable) {
         // a service exposing MCP tools is callable whether or not it also is "advertised" see @Publish
         Query filter = composeFilter(termFilter("mcpExposed", true),
                                      termFilter("online", true),
@@ -132,7 +132,7 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
             b.query(filter);
             // cri is used for service invocation, must never be served in a listing, so we filter it
             b.source(sc -> sc.filter(f -> f.includes("mcpTools").excludes("mcpTools.cri")));
-        }).thenApply(page -> {
+        }).map(page -> {
             List<McpToolDefinition> tools = new ArrayList<>();
             for (ServiceDirectoryEntry entry : page.getContent()) {
                 if (entry.getMcpTools() != null) {
@@ -153,9 +153,9 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
      * when no callable tool carries the name. The term on {@code mcpTools.name} narrows to entries carrying
      * the name; the entry may hold other tools, so the flattening keeps only the matching ones.
      */
-    public CompletableFuture<McpToolDefinition> findMcpToolByName(String toolName,
-                                                                  String organizationId,
-                                                                  String applicationId) {
+    public Future<McpToolDefinition> findMcpToolByName(String toolName,
+                                                       String organizationId,
+                                                       String applicationId) {
         Query filter = composeFilter(termFilter("mcpTools.name", toolName),
                                      termFilter("mcpExposed", true),
                                      termFilter("online", true),
@@ -163,7 +163,7 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
         return findAll(Pageable.ofSize(RESOLUTION_PAGE_SIZE), b -> {
             b.query(filter);
             b.source(sc -> sc.filter(f -> f.includes("mcpTools")));
-        }).thenCompose(page -> {
+        }).compose(page -> {
             List<McpToolDefinition> tools = new ArrayList<>();
             for (ServiceDirectoryEntry entry : page.getContent()) {
                 if (entry.getMcpTools() != null) {
@@ -174,7 +174,7 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
                     }
                 }
             }
-            CompletableFuture<McpToolDefinition> ret;
+            Future<McpToolDefinition> ret;
             if (tools.size() > 1) {
                 // minted names are unique system wide, so duplicates mean this index holds corrupted data
                 // needing manual repair; the detail stays in this log and the caller gets a generic failure
@@ -184,9 +184,9 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
                           organizationId,
                           applicationId,
                           tools.stream().map(McpToolDefinition::getCri).toList());
-                ret = CompletableFuture.failedFuture(new IllegalStateException("MCP tool resolution failed for '" + toolName + "'"));
+                ret = Future.failedFuture(new IllegalStateException("MCP tool resolution failed for '" + toolName + "'"));
             } else {
-                ret = CompletableFuture.completedFuture(tools.isEmpty() ? null : tools.getFirst());
+                ret = Future.succeededFuture(tools.isEmpty() ? null : tools.getFirst());
             }
             return ret;
         });

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/ApplicationLoginHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/ApplicationLoginHandler.java
@@ -57,13 +57,10 @@ public class ApplicationLoginHandler implements SuppliesGatewayRoutes {
         String orgId = ctx.pathParam("orgId");
         String appId = ctx.pathParam("appId");
         oidcConfigurationService.findEnabledForScope(orgId, appId)
-              .whenComplete((configs, err) -> {
-                  if (err != null) {
-                      log.warn("Failed to list app providers for {}/{}: {}", orgId, appId, err.getMessage());
-                      authEndpointSupport.respondError(ctx, 500, "Failed to list providers");
-                      return;
-                  }
-                  authEndpointSupport.respondProvidersList(ctx, configs);
+              .onSuccess(configs -> authEndpointSupport.respondProvidersList(ctx, configs))
+              .onFailure(err -> {
+                  log.warn("Failed to list app providers for {}/{}: {}", orgId, appId, err.getMessage());
+                  authEndpointSupport.respondError(ctx, 500, "Failed to list providers");
               });
     }
 
@@ -82,7 +79,7 @@ public class ApplicationLoginHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(identityService.findByEmail(email, orgId, appId))
+        identityService.findByEmail(email, orgId, appId)
               .compose(user -> resolveSsoOrPassword(ctx, orgId, appId, user))
               .onFailure(err -> {
                   log.warn("App login lookup failed for {}/{}/{}: {}", orgId, appId, email, err.getMessage());
@@ -98,7 +95,7 @@ public class ApplicationLoginHandler implements SuppliesGatewayRoutes {
         }
 
         String configId = user.getOidcConfigId();
-        return Future.fromCompletionStage(oidcConfigurationRepository.findById(configId, orgId))
+        return oidcConfigurationRepository.findById(configId, orgId)
                      .compose(match -> {
                          if (match == null || !match.isEnabled()) {
                              return authEndpointSupport.respondPasswordPath(ctx);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
@@ -68,7 +68,7 @@ public class InviteHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(inviteService.getValidInvite(token))
+        inviteService.getValidInvite(token)
               .compose(invite -> {
                   Future<String> orgName = organizationService.findById(invite.getOrganizationId())
                           .map(org -> org == null ? null : org.getName());
@@ -106,7 +106,7 @@ public class InviteHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(inviteService.acceptLocalInvite(token, password, displayName))
+        inviteService.acceptLocalInvite(token, password, displayName)
               .onSuccess(user -> {
                   if (user.getApplicationId() != null) {
                       // Session established like any login (ApplicationParticipant); the payload
@@ -138,13 +138,12 @@ public class InviteHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(inviteService.getValidInvite(token))
+        inviteService.getValidInvite(token)
               .compose(invite -> startFlowForInvite(ctx, invite, configId, token))
               .onSuccess(url -> ctx.response().setStatusCode(302).putHeader("Location", url).end())
               .onFailure(err -> {
-                  Throwable cause = err.getCause() != null ? err.getCause() : err;
-                  log.warn("Invite OIDC start failed for config {}: {}", configId, cause.getMessage());
-                  String code = cause instanceof OidcCallbackException oce
+                  log.warn("Invite OIDC start failed for config {}: {}", configId, err.getMessage());
+                  String code = err instanceof OidcCallbackException oce
                           ? oce.getErrorCode() : OidcErrorCodes.INVITE_INVALID;
                   redirectInviteError(ctx, code, token);
               });
@@ -162,8 +161,7 @@ public class InviteHandler implements SuppliesGatewayRoutes {
                 orgId -> resolveCallbackConfig(pathConfigId, orgId))
                 .onSuccess(result -> completeOidcAccept(ctx, result))
                 .onFailure(ex -> {
-                    Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-                    String code = cause instanceof OidcCallbackException oce
+                    String code = ex instanceof OidcCallbackException oce
                             ? oce.getErrorCode() : OidcErrorCodes.EXCHANGE_FAILED;
                     redirectInviteError(ctx, code, null);
                 });
@@ -205,7 +203,7 @@ public class InviteHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(inviteService.acceptOidcInvite(token, sub, result.config().getId(), email))
+        inviteService.acceptOidcInvite(token, sub, result.config().getId(), email)
               .onSuccess(user -> {
                   if (user.getApplicationId() != null) {
                       // Session established like any login (ApplicationParticipant); the redirect
@@ -221,13 +219,12 @@ public class InviteHandler implements SuppliesGatewayRoutes {
                   }
               })
               .onFailure(err -> {
-                  Throwable cause = err.getCause() != null ? err.getCause() : err;
-                  if (cause instanceof InviteEmailMismatchException) {
+                  if (err instanceof InviteEmailMismatchException) {
                       // The invite is NOT consumed on mismatch — keep the token so the
                       // invitee can retry with another provider or a password.
                       redirectInviteError(ctx, OidcErrorCodes.EMAIL_MISMATCH, token);
                   } else {
-                      log.warn("Invite acceptance failed: {}", cause.getMessage());
+                      log.warn("Invite acceptance failed: {}", err.getMessage());
                       redirectInviteError(ctx, OidcErrorCodes.INVITE_INVALID, null);
                   }
               });
@@ -309,11 +306,10 @@ public class InviteHandler implements SuppliesGatewayRoutes {
      * surface those as 400s and keep everything else generic.
      */
     private void respondInviteFailure(RoutingContext ctx, Throwable err, String genericMessage) {
-        Throwable cause = err.getCause() != null ? err.getCause() : err;
-        if (cause instanceof IllegalArgumentException) {
-            authEndpointSupport.respondError(ctx, 400, cause.getMessage());
+        if (err instanceof IllegalArgumentException) {
+            authEndpointSupport.respondError(ctx, 400, err.getMessage());
         } else {
-            log.warn("{}: {}", genericMessage, cause.getMessage());
+            log.warn("{}: {}", genericMessage, err.getMessage());
             authEndpointSupport.respondError(ctx, 500, genericMessage);
         }
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
@@ -26,7 +26,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Unauthenticated invitation-accept routes — the complete invite flow, self-contained. The
@@ -71,12 +70,11 @@ public class InviteHandler implements SuppliesGatewayRoutes {
 
         Future.fromCompletionStage(inviteService.getValidInvite(token))
               .compose(invite -> {
-                  Future<String> orgName = Future.fromCompletionStage(
-                          organizationService.findById(invite.getOrganizationId()))
+                  Future<String> orgName = organizationService.findById(invite.getOrganizationId())
                           .map(org -> org == null ? null : org.getName());
-                  Future<List<BaseOidcConfiguration>> providers = Future.fromCompletionStage(
+                  Future<List<BaseOidcConfiguration>> providers =
                           oidcConfigurationService.findEnabledForScope(invite.getOrganizationId(),
-                                                                      invite.getApplicationId()));
+                                                                      invite.getApplicationId());
                   return Future.all(orgName, providers)
                                .map(v -> new JsonObject()
                                        .put("email", invite.getEmail())
@@ -242,9 +240,8 @@ public class InviteHandler implements SuppliesGatewayRoutes {
      * carries the accept token on the session and returns to {@link #handleOidcCallback}.
      */
     private Future<String> startFlowForInvite(RoutingContext ctx, PendingInvite invite, String configId, String token) {
-        return Future.fromCompletionStage(
-                             oidcConfigurationService.findEnabledForScope(invite.getOrganizationId(),
-                                                                         invite.getApplicationId()))
+        return oidcConfigurationService.findEnabledForScope(invite.getOrganizationId(),
+                                                            invite.getApplicationId())
                      .compose(offered -> {
                          BaseOidcConfiguration chosen = offered.stream()
                                                               .filter(c -> configId.equals(c.getId()))
@@ -265,25 +262,27 @@ public class InviteHandler implements SuppliesGatewayRoutes {
      * Resolves the callback's config, which may live in either table: platform social
      * configs (unscoped) or org SSO / app configs (org-scoped by the flow session's orgId).
      */
-    private CompletableFuture<BaseOidcConfiguration> resolveCallbackConfig(String configId, String orgId) {
+    private Future<BaseOidcConfiguration> resolveCallbackConfig(String configId, String orgId) {
         // Searching both tables by bare id is safe: we only get here after the orchestrator
         // matched the path's configId against the flow session, and that session value was
         // written by handleOidcStart, which only accepts configs the invite's target scope
         // offers. So whatever this finds is a config the start leg already approved (ids
         // are per-row UUIDs, so the same id cannot exist in both tables).
         return orgSignupOidcConfigurationService.findById(configId)
-                .thenCompose(social -> {
+                .compose(social -> {
+                    Future<BaseOidcConfiguration> ret;
                     if (social != null) {
-                        return CompletableFuture.<BaseOidcConfiguration>completedFuture(social);
+                        ret = Future.succeededFuture(social);
+                    } else if (orgId == null) {
+                        // Invite flows always stash an orgId; this guard only turns a corrupted
+                        // session into config_not_found instead of a repository exception.
+                        ret = Future.succeededFuture(null);
+                    } else {
+                        // The cast widens the future's element type — Future is invariant.
+                        ret = oidcConfigurationRepository.findById(configId, orgId)
+                                                         .map(c -> (BaseOidcConfiguration) c);
                     }
-                    // Invite flows always stash an orgId; this guard only turns a corrupted
-                    // session into config_not_found instead of a repository exception.
-                    if (orgId == null) {
-                        return CompletableFuture.completedFuture(null);
-                    }
-                    // The cast widens the future's element type — CompletableFuture is invariant.
-                    return oidcConfigurationRepository.findById(configId, orgId)
-                                                      .thenApply(c -> (BaseOidcConfiguration) c);
+                    return ret;
                 });
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OAuthServerHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OAuthServerHandler.java
@@ -244,8 +244,7 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
                                              String clientKey,
                                              String clientName,
                                              String sessionLabel) {
-        return Future.fromCompletionStage(
-                identityService.findOrCreateDelegate(approver, kind, clientKey, clientName))
+        return identityService.findOrCreateDelegate(approver, kind, clientKey, clientName)
                 .compose(delegate -> Future.fromCompletionStage(
                                 refreshTokenService.issue(delegate.getId(),
                                                           delegate.getDelegateKind().getAudience(),

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OAuthServerHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OAuthServerHandler.java
@@ -128,9 +128,8 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
             authEndpointSupport.respondError(ctx, 400, "invalid_request");
             return;
         }
-        Future.fromCompletionStage(
-                      oauthAuthorizationService.createAuthorizationRequest(clientId, redirectUri, codeChallenge,
-                                                                           scope, resource, state))
+        oauthAuthorizationService.createAuthorizationRequest(clientId, redirectUri, codeChallenge,
+                                                             scope, resource, state)
               .onSuccess(requestId -> ctx.response()
                                          .setStatusCode(302)
                                          .putHeader("Location", authEndpointSupport.appUrl("/oauth/consent?request_id="
@@ -153,7 +152,7 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
             authEndpointSupport.respondError(ctx, 400, "invalid_client");
             return;
         }
-        Future.fromCompletionStage(deviceCodeGrantService.start(ctx.request().getFormAttribute("device_name")))
+        deviceCodeGrantService.start(ctx.request().getFormAttribute("device_name"))
               .onSuccess(start -> {
                   // /device is a kinotic-frontend SPA route (DeviceVerification.vue), not a gateway
                   // route — hence appBaseUrl (SPA origin), not apiBaseUrl. The signed-in browser
@@ -198,7 +197,7 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
             authEndpointSupport.respondError(ctx, 400, "invalid_request");
             return;
         }
-        Future.fromCompletionStage(deviceCodeGrantService.poll(deviceCode))
+        deviceCodeGrantService.poll(deviceCode)
               .onSuccess(result -> {
                   switch (result.status()) {
                       case AUTHORIZATION_PENDING -> authEndpointSupport.respondError(ctx, 400, "authorization_pending");
@@ -224,7 +223,7 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
         String clientId = ctx.request().getFormAttribute("client_id");
         String redirectUri = ctx.request().getFormAttribute("redirect_uri");
         String codeVerifier = ctx.request().getFormAttribute("code_verifier");
-        Future.fromCompletionStage(oauthAuthorizationService.exchangeCode(code, clientId, redirectUri, codeVerifier))
+        oauthAuthorizationService.exchangeCode(code, clientId, redirectUri, codeVerifier)
               .compose(exchange -> issueDelegateTokens(ctx, exchange.approver(), DelegateKind.MCP_CLIENT,
                                                        exchange.clientId(), exchange.clientName(), null))
               .onFailure(err -> {
@@ -245,10 +244,9 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
                                              String clientName,
                                              String sessionLabel) {
         return identityService.findOrCreateDelegate(approver, kind, clientKey, clientName)
-                .compose(delegate -> Future.fromCompletionStage(
-                                refreshTokenService.issue(delegate.getId(),
-                                                          delegate.getDelegateKind().getAudience(),
-                                                          sessionLabel))
+                .compose(delegate -> refreshTokenService.issue(delegate.getId(),
+                                                               delegate.getDelegateKind().getAudience(),
+                                                               sessionLabel)
                         .onSuccess(refreshToken -> authEndpointSupport.respondTokenPair(
                                 ctx, delegate, refreshToken, delegate.getDelegateKind().getAudience())))
                 .mapEmpty();
@@ -260,7 +258,7 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
             authEndpointSupport.respondError(ctx, 400, "invalid_request");
             return;
         }
-        Future.fromCompletionStage(refreshTokenService.rotate(refreshToken))
+        refreshTokenService.rotate(refreshToken)
               .onSuccess(rotation -> authEndpointSupport.respondTokenPair(
                       ctx, rotation.identity(), rotation.refreshToken(), rotation.audience()))
               .onFailure(err -> {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationLoginHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationLoginHandler.java
@@ -66,7 +66,7 @@ public class OrganizationLoginHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(identityService.findByEmail(email))
+        identityService.findByEmail(email)
               .compose(user -> resolveSsoOrPassword(ctx, user))
               .onFailure(err -> {
                   log.warn("Login lookup failed for {}: {}", email, err.getMessage());
@@ -80,7 +80,7 @@ public class OrganizationLoginHandler implements SuppliesGatewayRoutes {
      * even when several configs share a kind.
      */
     private void handleProviders(RoutingContext ctx) {
-        Future.fromCompletionStage(orgSignupOidcConfigurationService.findAllEnabled())
+        orgSignupOidcConfigurationService.findAllEnabled()
               .onSuccess(configs -> {
                   JsonArray providers = new JsonArray();
                   Set<String> seen = new LinkedHashSet<>();
@@ -171,7 +171,7 @@ public class OrganizationLoginHandler implements SuppliesGatewayRoutes {
         }
 
         String orgId = user.getOrganizationId();
-        return Future.fromCompletionStage(oidcConfigurationService.findOrgLoginConfig(orgId))
+        return oidcConfigurationService.findOrgLoginConfig(orgId)
                      .compose(match -> {
                          if (match == null) {
                              // Org has no enabled SSO config — fall back to password (which will

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
@@ -60,18 +60,16 @@ public class OrganizationSignupHandler implements SuppliesGatewayRoutes {
             String displayName = body.getString("displayName");
 
             signUpService.initiateLocalSignUp(email, displayName)
-                    .thenAccept(v -> ctx.response()
+                    .onSuccess(v -> ctx.response()
                             .setStatusCode(200)
                             .putHeader("Content-Type", "application/json")
                             .end(new JsonObject().put("message", "Verification email sent. Please check your inbox.").encode()))
-                    .exceptionally(ex -> {
-                        Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-                        log.warn("Sign-up failed: {}", cause.getMessage());
+                    .onFailure(ex -> {
+                        log.warn("Sign-up failed: {}", ex.getMessage());
                         ctx.response()
                            .setStatusCode(400)
                            .putHeader("Content-Type", "application/json")
-                           .end(new JsonObject().put("error", cause.getMessage()).encode());
-                        return null;
+                           .end(new JsonObject().put("error", ex.getMessage()).encode());
                     });
         } catch (Exception e) {
             log.error("Failed to parse sign-up request", e);
@@ -97,15 +95,13 @@ public class OrganizationSignupHandler implements SuppliesGatewayRoutes {
             String password = body.getString("password");
 
             signUpService.completeLocalSignUp(token, orgName, orgDescription, password)
-                    .thenAccept(user -> authEndpointSupport.respondSuccess(ctx, user))
-                    .exceptionally(ex -> {
-                        Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-                        log.warn("Sign-up completion failed: {}", cause.getMessage());
+                    .onSuccess(user -> authEndpointSupport.respondSuccess(ctx, user))
+                    .onFailure(ex -> {
+                        log.warn("Sign-up completion failed: {}", ex.getMessage());
                         ctx.response()
                            .setStatusCode(400)
                            .putHeader("Content-Type", "application/json")
-                           .end(new JsonObject().put("error", cause.getMessage()).encode());
-                        return null;
+                           .end(new JsonObject().put("error", ex.getMessage()).encode());
                     });
         } catch (Exception e) {
             log.error("Failed to parse sign-up completion request", e);
@@ -173,15 +169,14 @@ public class OrganizationSignupHandler implements SuppliesGatewayRoutes {
                   pending.setOidcConfigId(config.getId());
                   pending.setEmail(email);
                   pending.setDisplayName(displayName);
-                  return Future.fromCompletionStage(signUpService.createOidcPending(pending));
+                  return signUpService.createOidcPending(pending);
               })
               .onSuccess(pending -> redirectToCompleteOrg(ctx, pending.getVerificationToken()))
               .onFailure(ex -> {
-                  Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-                  if (cause instanceof AccountExistsException) {
+                  if (ex instanceof AccountExistsException) {
                       authEndpointSupport.redirectError(ctx, OidcErrorCodes.ACCOUNT_EXISTS);
                   } else {
-                      log.warn("Signup resolution failed: {}", cause.getMessage());
+                      log.warn("Signup resolution failed: {}", ex.getMessage());
                       authEndpointSupport.redirectError(ctx, OidcErrorCodes.SIGNUP_FAILED);
                   }
               });
@@ -207,12 +202,9 @@ public class OrganizationSignupHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(signUpService.completeOidcWithNewOrg(token, orgName, orgDescription))
+        signUpService.completeOidcWithNewOrg(token, orgName, orgDescription)
               .onSuccess(user -> authEndpointSupport.respondSuccess(ctx, user))
-              .onFailure(ex -> {
-                  Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-                  authEndpointSupport.respondError(ctx, 400, cause.getMessage());
-              });
+              .onFailure(ex -> authEndpointSupport.respondError(ctx, 400, ex.getMessage()));
     }
 
     private String callbackUrl(String configId) {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
@@ -162,7 +162,7 @@ public class OrganizationSignupHandler implements SuppliesGatewayRoutes {
             return;
         }
 
-        Future.fromCompletionStage(identityService.findOrgUserByOidcIdentity(sub, config.getId()))
+        identityService.findOrgUserByOidcIdentity(sub, config.getId())
               .compose(existing -> {
                   if (existing != null) {
                       // Already have an account for this identity — push them to log in instead.

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/mcp/McpJsonRpcHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/mcp/McpJsonRpcHandler.java
@@ -198,13 +198,11 @@ public class McpJsonRpcHandler implements SuppliesGatewayRoutes {
             ret = mcpToolInvoker.invoke(params.get("name").asString(), arguments, participant)
                                 .map(toolResult -> JsonRpcResponse.result(id, toolResult))
                                 .otherwise(throwable -> {
-                                    // a repository failure crosses the strategy's fromCompletionStage wrapped in CompletionException
-                                    Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
                                     JsonRpcResponse response;
-                                    if (cause instanceof IllegalArgumentException) {
-                                        response = JsonRpcResponse.error(id, INVALID_PARAMS, cause.getMessage());
+                                    if (throwable instanceof IllegalArgumentException) {
+                                        response = JsonRpcResponse.error(id, INVALID_PARAMS, throwable.getMessage());
                                     } else {
-                                        log.error("tools/call failed", cause);
+                                        log.error("tools/call failed", throwable);
                                         response = JsonRpcResponse.error(id, INTERNAL_ERROR, "Internal error");
                                     }
                                     return response;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
@@ -4,7 +4,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -340,7 +339,7 @@ public class AuthEndpointSupport {
      * the authenticate call (already scope-aware where appropriate).
      */
     public void handlePasswordLogin(RoutingContext ctx,
-                                    BiFunction<String, String, CompletionStage<UserParticipantIdentity>> authenticate) {
+                                    BiFunction<String, String, Future<UserParticipantIdentity>> authenticate) {
         JsonObject body = readJsonBody(ctx);
         String email = body.getString("email");
         String password = body.getString("password");
@@ -348,7 +347,7 @@ public class AuthEndpointSupport {
             respondError(ctx, 400, "email and password are required");
             return;
         }
-        Future.fromCompletionStage(authenticate.apply(email, password))
+        authenticate.apply(email, password)
               .onSuccess(user -> {
                   if (user == null) {
                       // Generic 401 — covers unknown email, wrong password, OIDC user, disabled.

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
@@ -305,7 +305,7 @@ public class AuthEndpointSupport {
 
         String returnPath = safeReturnPath(ctx.request().getParam("referer"));
 
-        Future.fromCompletionStage(orgSignupOidcConfigurationService.findEnabledByProvider(providerKind))
+        orgSignupOidcConfigurationService.findEnabledByProvider(providerKind)
               .compose(config -> {
                   if (config == null) {
                       respondError(ctx, 400, "Unknown or disabled platform provider: " + provider);
@@ -374,7 +374,7 @@ public class AuthEndpointSupport {
     public void completeOidcLogin(RoutingContext ctx,
                                   BaseOidcConfiguration config,
                                   Map<String, Object> claims,
-                                  Function<String, CompletionStage<UserParticipantIdentity>> userLookup) {
+                                  Function<String, Future<UserParticipantIdentity>> userLookup) {
         String sub = OAuth2Util.stringClaim(claims, "sub");
         if (sub == null) {
             redirectError(ctx, OidcErrorCodes.INVALID_TOKEN);
@@ -384,7 +384,7 @@ public class AuthEndpointSupport {
             redirectError(ctx, OidcErrorCodes.EMAIL_NOT_VERIFIED);
             return;
         }
-        Future.fromCompletionStage(userLookup.apply(sub))
+        userLookup.apply(sub)
               .onSuccess(user -> {
                   if (user == null) {
                       redirectError(ctx, OidcErrorCodes.NO_ACCOUNT);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -439,8 +439,9 @@ public class OidcFlowOrchestrator {
         CompletableFuture<OAuth2Auth> cached =
                 oauth2AuthCache.get(key,
                                     (id, executor) -> secretReferenceResolver.resolve(config.getSecretNameRef())
-                                                                             .thenCompose(secret -> createOAuth2Auth(config, secret)
-                                                                                     .toCompletionStage()));
+                                                                             .compose(secret -> createOAuth2Auth(config, secret))
+                                                                             .toCompletionStage()
+                                                                             .toCompletableFuture());
         return Future.fromCompletionStage(cached, vertx.getOrCreateContext())
                      .onFailure(err -> log.error("Failed to initialize OAuth2Auth for config {}", config.getId(), err));
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -83,7 +83,7 @@ public class OidcFlowOrchestrator {
      * @param configResolver loads the config for this route, scoped by the {@code orgId}
      *                       recovered from the flow session (or {@code null} when the flow
      *                       stashed none — non-org-scoped routes ignore the argument). Must
-     *                       return a {@link CompletableFuture} resolving to {@code null} when
+     *                       return a {@link Future} resolving to {@code null} when
      *                       the config is unknown; a config that is no longer enabled is
      *                       rejected here, so the resolver need not check it.
      */
@@ -91,7 +91,7 @@ public class OidcFlowOrchestrator {
             RoutingContext ctx,
             String pathConfigId,
             String callbackUrl,
-            Function<String, CompletableFuture<C>> configResolver) {
+            Function<String, Future<C>> configResolver) {
 
         String code = ctx.request().getParam("code");
         String state = ctx.request().getParam("state");
@@ -114,7 +114,7 @@ public class OidcFlowOrchestrator {
             return Future.failedFuture(new OidcCallbackException(OidcErrorCodes.STATE_MISMATCH));
         }
 
-        return Future.fromCompletionStage(configResolver.apply(flowSession.orgId()))
+        return configResolver.apply(flowSession.orgId())
                      .compose(config -> {
                          // Re-checked here rather than in each resolver: a config disabled while the
                          // user was at the IdP must not complete the flow it started.

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractApplicationScopedService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractApplicationScopedService.java
@@ -1,13 +1,12 @@
 package org.kinotic.domain.internal.api.services;
 
-import org.kinotic.domain.api.services.ApplicationScopedCrudService;
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.domain.api.model.ApplicationScoped;
+import org.kinotic.domain.api.services.ApplicationScopedCrudService;
 import org.kinotic.domain.internal.api.repositories.AbstractApplicationScopedRepository;
-
-import java.util.concurrent.CompletableFuture;
 
 public abstract class AbstractApplicationScopedService<T extends ApplicationScoped<String>>
         extends AbstractOrganizationScopedService<T>
@@ -22,12 +21,12 @@ public abstract class AbstractApplicationScopedService<T extends ApplicationScop
     }
 
     @Override
-    public CompletableFuture<Long> countForApplication(String applicationId) {
+    public Future<Long> countForApplication(String applicationId) {
         return applicationRepository.countForApplication(applicationId, requireOrganizationId());
     }
 
     @Override
-    public CompletableFuture<Page<T>> findAllForApplication(String applicationId, Pageable pageable) {
+    public Future<Page<T>> findAllForApplication(String applicationId, Pageable pageable) {
         return applicationRepository.findAllForApplication(applicationId, requireOrganizationId(), pageable);
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractCrudService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractCrudService.java
@@ -1,13 +1,12 @@
 package org.kinotic.domain.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.crud.Identifiable;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.internal.api.repositories.AbstractRepository;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Thin {@link IdentifiableCrudService} delegating to an {@link AbstractRepository}. Use this as
@@ -23,23 +22,23 @@ public abstract class AbstractCrudService<T extends Identifiable<String>> implem
     protected final AbstractRepository<T> repository;
 
     @Override
-    public CompletableFuture<Long> count() {
+    public Future<Long> count() {
         return repository.count();
     }
 
     @Override
-    public CompletableFuture<T> findById(String id) {
+    public Future<T> findById(String id) {
         return repository.findById(id);
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String id) {
-        return beforeDelete(id).thenCompose(v -> repository.deleteById(id));
+    public Future<Void> deleteById(String id) {
+        return beforeDelete(id).compose(v -> repository.deleteById(id));
     }
 
     @Override
-    public CompletableFuture<Void> deleteByIdSync(String id) {
-        return beforeDelete(id).thenCompose(v -> repository.deleteByIdSync(id));
+    public Future<Void> deleteByIdSync(String id) {
+        return beforeDelete(id).compose(v -> repository.deleteByIdSync(id));
     }
 
     /**
@@ -48,33 +47,33 @@ public abstract class AbstractCrudService<T extends Identifiable<String>> implem
      * Override to validate the delete or cascade dependent data; the delete proceeds when
      * the returned future completes.
      */
-    protected CompletableFuture<Void> beforeDelete(String id) {
-        return CompletableFuture.completedFuture(null);
+    protected Future<Void> beforeDelete(String id) {
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Page<T>> findAll(Pageable pageable) {
+    public Future<Page<T>> findAll(Pageable pageable) {
         return repository.findAll(pageable);
     }
 
     @Override
-    public CompletableFuture<T> save(T value) {
-        return beforeSave(value).thenCompose(v -> repository.save(value));
+    public Future<T> save(T value) {
+        return beforeSave(value).compose(v -> repository.save(value));
     }
 
     @Override
-    public CompletableFuture<T> saveSync(T value) {
-        return beforeSave(value).thenCompose(v -> repository.saveSync(value));
+    public Future<T> saveSync(T value) {
+        return beforeSave(value).compose(v -> repository.saveSync(value));
     }
 
     @Override
-    public CompletableFuture<T> create(T value) {
-        return beforeSave(value).thenCompose(v -> repository.create(value));
+    public Future<T> create(T value) {
+        return beforeSave(value).compose(v -> repository.create(value));
     }
 
     @Override
-    public CompletableFuture<T> createSync(T value) {
-        return beforeSave(value).thenCompose(v -> repository.createSync(value));
+    public Future<T> createSync(T value) {
+        return beforeSave(value).compose(v -> repository.createSync(value));
     }
 
     /**
@@ -83,17 +82,17 @@ public abstract class AbstractCrudService<T extends Identifiable<String>> implem
      * path and not the others. Override to validate and prepare the entity (defaults, ids,
      * timestamps); the write proceeds when the returned future completes.
      */
-    protected CompletableFuture<Void> beforeSave(T entity) {
-        return CompletableFuture.completedFuture(null);
+    protected Future<Void> beforeSave(T entity) {
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Page<T>> search(String searchText, Pageable pageable) {
+    public Future<Page<T>> search(String searchText, Pageable pageable) {
         return repository.search(searchText, pageable);
     }
 
     @Override
-    public CompletableFuture<Void> syncIndex() {
+    public Future<Void> syncIndex() {
         return repository.syncIndex();
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.core.api.crud.Page;
@@ -10,8 +11,6 @@ import org.kinotic.domain.api.model.OrganizationScoped;
 import org.kinotic.domain.api.model.security.ApplicationParticipant;
 import org.kinotic.domain.api.model.security.OrganizationParticipant;
 import org.kinotic.domain.internal.api.repositories.AbstractOrganizationScopedRepository;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service base that adds organization-scope enforcement on top of an
@@ -33,23 +32,23 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
     }
 
     @Override
-    public CompletableFuture<Long> count() {
+    public Future<Long> count() {
         return scopedRepository.count(requireOrganizationId());
     }
 
     @Override
-    public CompletableFuture<T> findById(String id) {
+    public Future<T> findById(String id) {
         return scopedRepository.findById(id, requireOrganizationId());
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String id) {
-        return beforeDelete(id).thenCompose(v -> scopedRepository.deleteById(id, requireOrganizationId()));
+    public Future<Void> deleteById(String id) {
+        return beforeDelete(id).compose(v -> scopedRepository.deleteById(id, requireOrganizationId()));
     }
 
     @Override
-    public CompletableFuture<Void> deleteByIdSync(String id) {
-        return beforeDelete(id).thenCompose(v -> scopedRepository.deleteByIdSync(id, requireOrganizationId()));
+    public Future<Void> deleteByIdSync(String id) {
+        return beforeDelete(id).compose(v -> scopedRepository.deleteByIdSync(id, requireOrganizationId()));
     }
 
     /**
@@ -58,42 +57,42 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
      * Override to validate the delete or cascade dependent data; the org-scoped delete
      * proceeds when the returned future completes.
      */
-    protected CompletableFuture<Void> beforeDelete(String id) {
-        return CompletableFuture.completedFuture(null);
+    protected Future<Void> beforeDelete(String id) {
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Page<T>> findAll(Pageable pageable) {
+    public Future<Page<T>> findAll(Pageable pageable) {
         return scopedRepository.findAll(requireOrganizationId(), pageable);
     }
 
     @Override
-    public CompletableFuture<T> save(T value) {
-        return beforeSave(value).thenCompose(v -> {
+    public Future<T> save(T value) {
+        return beforeSave(value).compose(v -> {
             enforceOrgOnSave(value);
             return scopedRepository.save(value, resolveWriteOrgId(value));
         });
     }
 
     @Override
-    public CompletableFuture<T> saveSync(T value) {
-        return beforeSave(value).thenCompose(v -> {
+    public Future<T> saveSync(T value) {
+        return beforeSave(value).compose(v -> {
             enforceOrgOnSave(value);
             return scopedRepository.saveSync(value, resolveWriteOrgId(value));
         });
     }
 
     @Override
-    public CompletableFuture<T> create(T value) {
-        return beforeSave(value).thenCompose(v -> {
+    public Future<T> create(T value) {
+        return beforeSave(value).compose(v -> {
             enforceOrgOnSave(value);
             return scopedRepository.create(value, resolveWriteOrgId(value));
         });
     }
 
     @Override
-    public CompletableFuture<T> createSync(T value) {
-        return beforeSave(value).thenCompose(v -> {
+    public Future<T> createSync(T value) {
+        return beforeSave(value).compose(v -> {
             enforceOrgOnSave(value);
             return scopedRepository.createSync(value, resolveWriteOrgId(value));
         });
@@ -105,17 +104,17 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
      * path and not the others. Override to validate and prepare the entity (defaults, ids,
      * timestamps); org enforcement and the write proceed when the returned future completes.
      */
-    protected CompletableFuture<Void> beforeSave(T entity) {
-        return CompletableFuture.completedFuture(null);
+    protected Future<Void> beforeSave(T entity) {
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Page<T>> search(String searchText, Pageable pageable) {
+    public Future<Page<T>> search(String searchText, Pageable pageable) {
         return scopedRepository.search(searchText, requireOrganizationId(), pageable);
     }
 
     @Override
-    public CompletableFuture<Void> syncIndex() {
+    public Future<Void> syncIndex() {
         return scopedRepository.syncIndex();
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractProjectScopedService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractProjectScopedService.java
@@ -1,13 +1,12 @@
 package org.kinotic.domain.internal.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
-import org.kinotic.domain.api.services.ProjectScopedCrudService;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.domain.api.model.ProjectScoped;
+import org.kinotic.domain.api.services.ProjectScopedCrudService;
 import org.kinotic.domain.internal.api.repositories.AbstractProjectScopedRepository;
-
-import java.util.concurrent.CompletableFuture;
 
 public abstract class AbstractProjectScopedService<T extends ProjectScoped<String>>
         extends AbstractApplicationScopedService<T>
@@ -22,12 +21,12 @@ public abstract class AbstractProjectScopedService<T extends ProjectScoped<Strin
     }
 
     @Override
-    public CompletableFuture<Long> countForProject(String projectId) {
+    public Future<Long> countForProject(String projectId) {
         return projectRepository.countForProject(projectId, requireOrganizationId());
     }
 
     @Override
-    public CompletableFuture<Page<T>> findAllForProject(String projectId, Pageable pageable) {
+    public Future<Page<T>> findAllForProject(String projectId, Pageable pageable) {
         return projectRepository.findAllForProject(projectId, requireOrganizationId(), pageable);
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
@@ -24,6 +24,7 @@ import co.elastic.clients.json.JsonpMapperBase;
 import co.elastic.clients.transport.JsonEndpoint;
 import co.elastic.clients.transport.endpoints.EndpointWithResponseMapperAttr;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.*;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -93,9 +95,9 @@ public class CrudServiceTemplate {
      *
      * @param dataStreamName name of the data stream to append to
      * @param document       the document to append
-     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     * @return a {@link Future} that will complete with the {@link IndexResponse}
      */
-    public <T> CompletableFuture<IndexResponse> appendToDataStream(String dataStreamName, T document) {
+    public <T> Future<IndexResponse> appendToDataStream(String dataStreamName, T document) {
         return appendToDataStream(dataStreamName, document, null);
     }
 
@@ -107,12 +109,12 @@ public class CrudServiceTemplate {
      * @param dataStreamName  name of the data stream to append to
      * @param document        the document to append
      * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     * @return a {@link Future} that will complete with the {@link IndexResponse}
      */
-    public <T> CompletableFuture<IndexResponse> appendToDataStream(String dataStreamName,
+    public <T> Future<IndexResponse> appendToDataStream(String dataStreamName,
                                                                    T document,
                                                                    Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return bindToContext(esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
+        return toFuture(esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
             builder.index(dataStreamName).opType(OpType.Create).document(document);
             if (builderConsumer != null) {
                 builderConsumer.accept(builder);
@@ -139,11 +141,11 @@ public class CrudServiceTemplate {
      *
      * @param indexName       name of the index to count
      * @param builderConsumer to customize the {@link CountRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the number of documents in the index
+     * @return a {@link Future} that will complete with the number of documents in the index
      */
-    public CompletableFuture<Long> count(String indexName,
+    public Future<Long> count(String indexName,
                                          Consumer<CountRequest.Builder> builderConsumer) {
-        return bindToContext(esAsyncClient.count(builder -> {
+        return toFuture(esAsyncClient.count(builder -> {
                                                 builder.index(indexName);
                                                 if (builderConsumer != null) {
                                                     builderConsumer.accept(builder);
@@ -161,10 +163,10 @@ public class CrudServiceTemplate {
      * @param indexName name of the index
      * @param id        id the document must be created under
      * @param document  the document to index
-     * @return a {@link CompletableFuture} completing with the {@link IndexResponse}, or failing
+     * @return a {@link Future} completing with the {@link IndexResponse}, or failing
      *         with {@link AlreadyExistsException} if the id is already taken
      */
-    public <T> CompletableFuture<IndexResponse> create(String indexName,
+    public <T> Future<IndexResponse> create(String indexName,
                                                        String id,
                                                        T document) {
         return create(indexName, id, document, null);
@@ -179,31 +181,31 @@ public class CrudServiceTemplate {
      * @param id              id the document must be created under
      * @param document        the document to index
      * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} completing with the {@link IndexResponse}, or failing
+     * @return a {@link Future} completing with the {@link IndexResponse}, or failing
      *         with {@link AlreadyExistsException} if the id is already taken
      */
-    public <T> CompletableFuture<IndexResponse> create(String indexName,
+    public <T> Future<IndexResponse> create(String indexName,
                                                        String id,
                                                        T document,
                                                        Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return bindToContext(esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
+        return toFuture(esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
                     builder.index(indexName).id(id).document(document).opType(OpType.Create);
                     if (builderConsumer != null) {
                         builderConsumer.accept(builder);
                     }
                     return builder;
                 }))
-                .exceptionallyCompose(throwable -> isVersionConflict(throwable)
-                        ? CompletableFuture.failedFuture(new AlreadyExistsException(
+                .recover(throwable -> isVersionConflict(throwable)
+                        ? Future.failedFuture(new AlreadyExistsException(
                                 "A document with id '" + id + "' already exists in index '" + indexName + "'"))
-                        : CompletableFuture.<IndexResponse>failedFuture(throwable));
+                        : Future.failedFuture(throwable));
     }
 
     /**
      * Creates a data stream
      */
-    public CompletableFuture<Void> createDataStream(String dataStreamName) {
-        return bindToContext(esAsyncClient.indices().createDataStream(builder -> builder.name(dataStreamName))
+    public Future<Void> createDataStream(String dataStreamName) {
+        return toFuture(esAsyncClient.indices().createDataStream(builder -> builder.name(dataStreamName))
                                           .thenApply(response -> null));
     }
 
@@ -213,12 +215,12 @@ public class CrudServiceTemplate {
      * @param indexName       name of the index to create
      * @param failIfExists    if true will fail with an exception if the index already exists
      * @param mappings        the mappings to use for the index, or null if no mappings are needed
-     * @return a {@link CompletableFuture} that will complete when the index has been created
+     * @return a {@link Future} that will complete when the index has been created
      */
-    public CompletableFuture<Void> createIndex(String indexName,
+    public Future<Void> createIndex(String indexName,
                                                boolean failIfExists,
                                                Map<String, Property> mappings) {
-        return bindToContext(esAsyncClient.indices().exists(builder -> builder.index(indexName))
+        return toFuture(esAsyncClient.indices().exists(builder -> builder.index(indexName))
                             .thenCompose(exists -> {
                                 if (!exists.value()) {
                                     return esAsyncClient.indices()
@@ -254,9 +256,9 @@ public class CrudServiceTemplate {
      * @param indexPattern the pattern to match the index names
      * @param dataStreamVisibility the visibility of the data stream or null if not a data stream
      * @param mappings the mappings to use for the index, or null if no mappings are needed
-     * @return a {@link CompletableFuture} that will complete when the index template has been created
+     * @return a {@link Future} that will complete when the index template has been created
      */
-    public CompletableFuture<Void> createIndexTemplate(String templateName,
+    public Future<Void> createIndexTemplate(String templateName,
                                                        String indexPattern,
                                                        DataStreamVisibility dataStreamVisibility,
                                                        Map<String, Property> mappings) {
@@ -272,9 +274,9 @@ public class CrudServiceTemplate {
      * @param dataRetention the data stream lifecycle retention period, or null for no managed lifecycle;
      *                      Elasticsearch deletes data older than this from the stream's backing indices
      * @param mappings the mappings to use for the index, or null if no mappings are needed
-     * @return a {@link CompletableFuture} that will complete when the index template has been created
+     * @return a {@link Future} that will complete when the index template has been created
      */
-    public CompletableFuture<Void> createIndexTemplate(String templateName,
+    public Future<Void> createIndexTemplate(String templateName,
                                                        String indexPattern,
                                                        DataStreamVisibility dataStreamVisibility,
                                                        Duration dataRetention,
@@ -286,7 +288,7 @@ public class CrudServiceTemplate {
             throw new IllegalArgumentException(
                     "dataRetention can only be set for data stream templates (dataStreamVisibility must be non-null)");
         }
-        return bindToContext(esAsyncClient.indices().putIndexTemplate(builder -> {
+        return toFuture(esAsyncClient.indices().putIndexTemplate(builder -> {
             builder.name(templateName)
                    .indexPatterns(List.of(indexPattern))
                    .priority(DEFAULT_PRIORITY)
@@ -323,11 +325,11 @@ public class CrudServiceTemplate {
      * @param id              id the document must be created under
      * @param document        the document to index
      * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} completing with the {@link IndexResponse} after the
+     * @return a {@link Future} completing with the {@link IndexResponse} after the
      *         document is searchable, or failing with {@link AlreadyExistsException} if the id
      *         is already taken
      */
-    public <T> CompletableFuture<IndexResponse> createSync(String indexName,
+    public <T> Future<IndexResponse> createSync(String indexName,
                                                            String id,
                                                            T document,
                                                            Consumer<IndexRequest.Builder<T>> builderConsumer) {
@@ -345,12 +347,12 @@ public class CrudServiceTemplate {
      * @param indexName       name of the index to delete from
      * @param id              of the document to delete
      * @param builderConsumer to customize the {@link DeleteRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the {@link DeleteResponse}
+     * @return a {@link Future} that will complete with the {@link DeleteResponse}
      */
-    public CompletableFuture<DeleteResponse> deleteById(String indexName,
+    public Future<DeleteResponse> deleteById(String indexName,
                                                         String id,
                                                         Consumer<DeleteRequest.Builder> builderConsumer) {
-        return bindToContext(esAsyncClient.delete(builder -> {
+        return toFuture(esAsyncClient.delete(builder -> {
             builder.index(indexName).id(id);
             if (builderConsumer != null) {
                 builderConsumer.accept(builder);
@@ -366,9 +368,9 @@ public class CrudServiceTemplate {
      * @param indexName       name of the index to delete from
      * @param id              of the document to delete
      * @param builderConsumer to customize the {@link DeleteRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the {@link DeleteResponse}
+     * @return a {@link Future} that will complete with the {@link DeleteResponse}
      */
-    public CompletableFuture<DeleteResponse> deleteByIdSync(String indexName,
+    public Future<DeleteResponse> deleteByIdSync(String indexName,
                                                             String id,
                                                             Consumer<DeleteRequest.Builder> builderConsumer) {
         return deleteById(indexName, id, builder -> {
@@ -384,11 +386,11 @@ public class CrudServiceTemplate {
      *
      * @param indexName       name of the index to delete from
      * @param builderConsumer to customize the {@link DeleteRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the {@link DeleteResponse}
+     * @return a {@link Future} that will complete with the {@link DeleteResponse}
      */
-    public CompletableFuture<DeleteByQueryResponse> deleteByQuery(String indexName,
+    public Future<DeleteByQueryResponse> deleteByQuery(String indexName,
                                                                   Consumer<DeleteByQueryRequest.Builder> builderConsumer) {
-        return bindToContext(esAsyncClient.deleteByQuery(builder -> {
+        return toFuture(esAsyncClient.deleteByQuery(builder -> {
             builder.index(indexName);
             if (builderConsumer != null) {
                 builderConsumer.accept(builder);
@@ -400,8 +402,8 @@ public class CrudServiceTemplate {
     /**
      * Deletes a data stream
      */
-    public CompletableFuture<Void> deleteDataStream(String dataStreamName) {
-        return bindToContext(esAsyncClient.indices()
+    public Future<Void> deleteDataStream(String dataStreamName) {
+        return toFuture(esAsyncClient.indices()
                                           .deleteDataStream(builder -> builder.name(dataStreamName))
                                           .thenApply(response -> null));
     }
@@ -410,10 +412,10 @@ public class CrudServiceTemplate {
      * Deletes an index.
      *
      * @param indexName name of the index to delete
-     * @return a {@link CompletableFuture} that will complete when the index has been deleted
+     * @return a {@link Future} that will complete when the index has been deleted
      */
-    public CompletableFuture<Void> deleteIndex(String indexName) {
-        return bindToContext(esAsyncClient.indices()
+    public Future<Void> deleteIndex(String indexName) {
+        return toFuture(esAsyncClient.indices()
                                           .delete(builder -> builder.index(indexName))
                                           .thenApply(response -> null));
     }
@@ -421,8 +423,8 @@ public class CrudServiceTemplate {
     /**
      * Deletes an index template
      */
-    public CompletableFuture<Void> deleteIndexTemplate(String templateName) {
-        return bindToContext(esAsyncClient.indices()
+    public Future<Void> deleteIndexTemplate(String templateName) {
+        return toFuture(esAsyncClient.indices()
                                           .deleteIndexTemplate(builder -> builder.name(templateName))
                                           .thenApply(response -> null));
     }
@@ -439,9 +441,9 @@ public class CrudServiceTemplate {
      * @param id              of the document to return
      * @param type            of the document to return
      * @param builderConsumer to customize the {@link GetRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the document
+     * @return a {@link Future} that will complete with the document
      */
-    public <T> CompletableFuture<T> findById(String indexName,
+    public <T> Future<T> findById(String indexName,
                                              String id,
                                              Class<T> type,
                                              Consumer<GetRequest.Builder> builderConsumer){
@@ -456,9 +458,9 @@ public class CrudServiceTemplate {
      * @param type            of the document to return
      * @param builderConsumer to customize the {@link GetRequest}, or null if no customization is needed
      * @param resultMapper to map the {@link GetResult} to the desired type or null if the source should be returned directly
-     * @return a {@link CompletableFuture} that will complete with the document
+     * @return a {@link Future} that will complete with the document
      */
-    public <T, R> CompletableFuture<R> findById(String indexName,
+    public <T, R> Future<R> findById(String indexName,
                                                 String id,
                                                 Class<T> type,
                                                 Consumer<GetRequest.Builder> builderConsumer,
@@ -479,7 +481,7 @@ public class CrudServiceTemplate {
             builderConsumer.accept(builder);
         }
 
-        return bindToContext(esAsyncClient._transport()
+        return toFuture(esAsyncClient._transport()
                                           .performRequestAsync(builder.build(),
                                                                endpoint,
                                                                esAsyncClient._transportOptions())
@@ -498,11 +500,11 @@ public class CrudServiceTemplate {
      * Issues a search with {@code size=1} and returns the single hit, or {@code null} if none.
      * Convenience for "find by unique key" lookups.
      */
-    public <T> CompletableFuture<T> findFirst(String indexName,
+    public <T> Future<T> findFirst(String indexName,
                                               Class<T> type,
                                               Consumer<SearchRequest.Builder> builderConsumer) {
         return search(indexName, Pageable.create(0, 1, Sort.unsorted()), type, builderConsumer)
-                .thenApply(page -> page.getContent().isEmpty() ? null : page.getContent().getFirst());
+                .map(page -> page.getContent().isEmpty() ? null : page.getContent().getFirst());
     }
 
     /** Matches documents where {@code field} is absent (the inverse of {@link #existsFilter}). */
@@ -516,9 +518,9 @@ public class CrudServiceTemplate {
      * @param type of the document to return
      * @param builderConsumer to customize the {@link MgetRequest}, or null if no customization is needed
      * @param resultMapper to map the {@link GetResult} to the desired type or null if the source should be returned directly
-     * @return a {@link CompletableFuture} that will complete with the documents requested
+     * @return a {@link Future} that will complete with the documents requested
      */
-    public <T, R> CompletableFuture<List<R>> multiGet(List<MultiGetOperation> getOperations,
+    public <T, R> Future<List<R>> multiGet(List<MultiGetOperation> getOperations,
                                                       Class<T> type,
                                                       Consumer<MgetRequest.Builder> builderConsumer,
                                                       Function<GetResult<T>, R> resultMapper){
@@ -537,7 +539,7 @@ public class CrudServiceTemplate {
             builderConsumer.accept(builder);
         }
 
-        return bindToContext(esAsyncClient._transport()
+        return toFuture(esAsyncClient._transport()
                                           .performRequestAsync(builder.build(),
                                                                endpoint,
                                                                esAsyncClient._transportOptions())
@@ -575,15 +577,15 @@ public class CrudServiceTemplate {
      * @param id        of the document to update
      * @param partial   the fields to merge into the document
      * @param upsert    true to create the document from {@code partial} when it does not exist
-     * @return a {@link CompletableFuture} that will complete when the update is applied
+     * @return a {@link Future} that will complete when the update is applied
      */
-    public CompletableFuture<Void> partialUpdate(String indexName,
+    public Future<Void> partialUpdate(String indexName,
                                                  String id,
                                                  Map<String, Object> partial,
                                                  boolean upsert) {
         // a doc merge carries no compare-and-set semantics, so retrying re-applies the same fields
         // against the newest version and never loses a concurrent writer's fields
-        return bindToContext(esAsyncClient.update(u -> u.index(indexName)
+        return toFuture(esAsyncClient.update(u -> u.index(indexName)
                                                         .id(id)
                                                         .doc(partial)
                                                         .docAsUpsert(upsert)
@@ -601,13 +603,13 @@ public class CrudServiceTemplate {
      * @param id        of the document to update
      * @param partial   the fields to merge into the document
      * @param upsert    true to create the document from {@code partial} when it does not exist
-     * @return a {@link CompletableFuture} that will complete when the update is applied
+     * @return a {@link Future} that will complete when the update is applied
      */
-    public CompletableFuture<Void> partialUpdateSync(String indexName,
+    public Future<Void> partialUpdateSync(String indexName,
                                                      String id,
                                                      Map<String, Object> partial,
                                                      boolean upsert) {
-        return bindToContext(esAsyncClient.update(u -> u.index(indexName)
+        return toFuture(esAsyncClient.update(u -> u.index(indexName)
                                                         .id(id)
                                                         .doc(partial)
                                                         .docAsUpsert(upsert)
@@ -624,13 +626,13 @@ public class CrudServiceTemplate {
      * @param id              of the document to index
      * @param document        to index
      * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     * @return a {@link Future} that will complete with the {@link IndexResponse}
      */
-    public <T> CompletableFuture<IndexResponse> save(String indexName,
+    public <T> Future<IndexResponse> save(String indexName,
                                                      String id,
                                                      T document,
                                                      Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return bindToContext(esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
+        return toFuture(esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
             builder.index(indexName).id(id).document(document);
             if (builderConsumer != null) {
                 builderConsumer.accept(builder);
@@ -647,9 +649,9 @@ public class CrudServiceTemplate {
      * @param id              of the document to index
      * @param document        to index
      * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     * @return a {@link Future} that will complete with the {@link IndexResponse}
      */
-    public <T> CompletableFuture<IndexResponse> saveSync(String indexName,
+    public <T> Future<IndexResponse> saveSync(String indexName,
                                                          String id,
                                                          T document,
                                                          Consumer<IndexRequest.Builder<T>> builderConsumer) {
@@ -671,9 +673,9 @@ public class CrudServiceTemplate {
      * @param pageable        to use for the search
      * @param type            of the documents to return
      * @param builderConsumer to customize the {@link SearchRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with a {@link Page} of documents
+     * @return a {@link Future} that will complete with a {@link Page} of documents
      */
-    public <T> CompletableFuture<Page<T>> search(String indexName,
+    public <T> Future<Page<T>> search(String indexName,
                                                  Pageable pageable,
                                                  Class<T> type,
                                                  Consumer<SearchRequest.Builder> builderConsumer){
@@ -691,15 +693,15 @@ public class CrudServiceTemplate {
      * @param type            of the documents to return
      * @param builderConsumer to customize the {@link SearchRequest}, or null if no customization is needed
      * @param hitMapper       to map the {@link Hit} to the desired type or null if the source should be returned directly
-     * @return a {@link CompletableFuture} that will complete with a {@link Page} of documents
+     * @return a {@link Future} that will complete with a {@link Page} of documents
      */
-    public <T,R> CompletableFuture<Page<R>> search(String indexName,
+    public <T,R> Future<Page<R>> search(String indexName,
                                                    Pageable pageable,
                                                    Class<T> type,
                                                    Consumer<SearchRequest.Builder> builderConsumer,
                                                    Function<Hit<T>, R> hitMapper) {
 
-        return bindToContext(searchFullResponse(indexName, pageable, type, builderConsumer)
+        return toFuture(searchFullResponse(indexName, pageable, type, builderConsumer)
                 .thenApply(response -> {
 
                     HitsMetadata<T> hitsMetadata = response.hits();
@@ -741,10 +743,10 @@ public class CrudServiceTemplate {
                 }));
     }
 
-    public CompletableFuture<Void> syncIndex(String indexName) {
-        return esAsyncClient.indices()
-                            .refresh(b -> b.index(indexName))
-                            .thenApply(_ -> null);
+    public Future<Void> syncIndex(String indexName) {
+        return toFuture(esAsyncClient.indices()
+                                     .refresh(b -> b.index(indexName)))
+                .mapEmpty();
     }
 
     /** Builds a {@code term} query for {@code field} equal to {@code value}. */
@@ -767,9 +769,9 @@ public class CrudServiceTemplate {
         return TermQuery.of(t -> t.field(field).value(value))._toQuery();
     }
 
-    public CompletableFuture<Void> updateIndexMapping(String indexName,
+    public Future<Void> updateIndexMapping(String indexName,
                                                       Map<String, Property> mappings) {
-        return bindToContext(esAsyncClient.indices().exists(builder -> builder.index(indexName))
+        return toFuture(esAsyncClient.indices().exists(builder -> builder.index(indexName))
                             .thenCompose(exists -> {
                                 if (exists.value()) {
                                     return esAsyncClient.indices()
@@ -792,13 +794,13 @@ public class CrudServiceTemplate {
     /**
      * Updates an existing index template
      */
-    public CompletableFuture<Void> updateIndexTemplate(String templateName,
+    public Future<Void> updateIndexTemplate(String templateName,
                                                        Map<String, Property> mappings) {
         Validate.notNull(templateName, "templateName cannot be null");
         Validate.notNull(mappings, "mappings cannot be null");
         Validate.notEmpty(mappings, "mappings cannot be empty");
 
-        return bindToContext(esAsyncClient.indices()
+        return toFuture(esAsyncClient.indices()
                             .existsIndexTemplate(builder -> builder.name(templateName))
                             .thenCompose(exists -> {
                                 if (!exists.value()) {
@@ -877,30 +879,39 @@ public class CrudServiceTemplate {
     }
 
     /**
-     * Binds the continuations of the given {@link CompletableFuture} back to the Vert.x context
-     * that is current at the moment this method is invoked. Any downstream {@code thenCompose} /
-     * {@code thenApply} / {@code whenComplete} attached by the caller will then run on that
-     * context, which means {@code Vertx.currentContext()} — and by extension
+     * Converts a {@link CompletableFuture} produced by an asynchronous client (the Elasticsearch
+     * client, a Caffeine loader) into a {@link Future} whose handlers are dispatched on the Vert.x
+     * context that is current at the moment this method is invoked. Any {@code compose} /
+     * {@code map} / {@code onComplete} attached by the caller will then run on that context, which
+     * means {@code Vertx.currentContext()} — and by extension
      * {@link org.kinotic.core.api.security.SecurityContext#currentParticipant()} —
-     * will be observable across the Elasticsearch async boundary.
+     * will be observable across the client's async boundary. Failures are delivered as the
+     * raw cause, never wrapped in {@link CompletionException}.
      * <p>
-     * When invoked outside of any Vert.x context, the original future is returned unchanged so
+     * When invoked outside of any Vert.x context, handlers run on the completing thread so
      * non-Vert.x callers still work.
      */
-    private <T> CompletableFuture<T> bindToContext(CompletableFuture<T> original) {
-        Context ctx = Vertx.currentContext();
-        if (ctx == null) {
-            return original;
-        }
-        CompletableFuture<T> bound = new CompletableFuture<>();
-        original.whenComplete((result, err) -> ctx.runOnContext(v -> {
+    public <T> Future<T> toFuture(CompletableFuture<T> es) {
+        // a failure that crossed a dependent stage arrives CompletionException-wrapped; strip it here
+        // so every Vert.x consumer sees the raw cause. A bare Promise.promise() would not re-dispatch
+        // onto the context, so the context-bound fromCompletionStage overload is required.
+        CompletableFuture<T> unwrapped = new CompletableFuture<>();
+        es.whenComplete((result, err) -> {
             if (err != null) {
-                bound.completeExceptionally(err);
+                unwrapped.completeExceptionally(err instanceof CompletionException && err.getCause() != null
+                                                        ? err.getCause() : err);
             } else {
-                bound.complete(result);
+                unwrapped.complete(result);
             }
-        }));
-        return bound;
+        });
+        Context ctx = Vertx.currentContext();
+        Future<T> ret;
+        if (ctx != null) {
+            ret = Future.fromCompletionStage(unwrapped, ctx);
+        } else {
+            ret = Future.fromCompletionStage(unwrapped);
+        }
+        return ret;
     }
 
     private <T> JsonpDeserializer<T> getDeserializer(Class<T> type) {
@@ -926,7 +937,7 @@ public class CrudServiceTemplate {
      * @param pageable        to use for the search
      * @param type            of the documents to return
      * @param builderConsumer to customize the {@link SearchRequest}, or null if no customization is needed
-     * @return a {@link CompletableFuture} that will complete with a {@link SearchResponse} of documents
+     * @return a {@link Future} that will complete with a {@link SearchResponse} of documents
      */
     private <T> CompletableFuture<SearchResponse<T>> searchFullResponse(String indexName,
                                                                         Pageable pageable,

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/DefaultOrganizationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/DefaultOrganizationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.exceptions.AlreadyExistsException;
 import org.kinotic.domain.api.model.Organization;
@@ -9,7 +10,6 @@ import org.kinotic.domain.api.utils.DomainUtil;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultOrganizationService extends AbstractCrudService<Organization> implements OrganizationService {
@@ -19,7 +19,7 @@ public class DefaultOrganizationService extends AbstractCrudService<Organization
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(Organization entity) {
+    protected Future<Void> beforeSave(Organization entity) {
         Validate.notNull(entity.getName(), "Organization name cannot be null");
 
         if (entity.getId() == null) {
@@ -30,7 +30,7 @@ public class DefaultOrganizationService extends AbstractCrudService<Organization
         DomainUtil.validateOrganizationId(entity.getId());
 
         entity.setUpdated(new Date());
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     /**
@@ -39,14 +39,14 @@ public class DefaultOrganizationService extends AbstractCrudService<Organization
      * exists, rather than overwriting it.
      */
     @Override
-    public CompletableFuture<Organization> create(Organization entity) {
+    public Future<Organization> create(Organization entity) {
         Validate.notBlank(entity.getName(), "Organization name cannot be null");
         // Force the id to derive from the name; beforeSave mints it from the slug.
         entity.setId(null);
         return super.create(entity)
-                    .exceptionallyCompose(ex -> AlreadyExistsException.isCause(ex)
-                            ? CompletableFuture.failedFuture(new AlreadyExistsException(
+                    .recover(ex -> ex instanceof AlreadyExistsException
+                            ? Future.failedFuture(new AlreadyExistsException(
                                     "An organization named '" + entity.getName() + "' already exists"))
-                            : CompletableFuture.failedFuture(ex));
+                            : Future.failedFuture(ex));
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/EmailService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/EmailService.java
@@ -14,6 +14,8 @@ import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.context.MapValueResolver;
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.domain.api.config.KinoticDomainProperties;
@@ -62,6 +64,7 @@ public class EmailService {
 
     private final KinoticDomainProperties properties;
     private final InviteEmailTemplateRepository inviteEmailTemplateRepository;
+    private final Vertx vertx;
 
     private volatile EmailClient emailClient;
 
@@ -73,15 +76,15 @@ public class EmailService {
      * @param verificationToken the token to include in the verification URL
      * @return a future that completes once the send has finished (or fails if ACS rejects it)
      */
-    public CompletableFuture<Void> sendVerificationEmail(String email,
-                                                         String displayName,
-                                                         String verificationToken) {
+    public Future<Void> sendVerificationEmail(String email,
+                                              String displayName,
+                                              String verificationToken) {
         String verificationUrl = properties.getDomain().getAppBaseUrl() + VERIFICATION_PATH + verificationToken;
 
         if (!properties.getDomain().getEmail().isEnabled()) {
             log.warn("Email sending is disabled; verification URL for {} <{}>: {}",
                     displayName, email, verificationUrl);
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
 
         Map<String, Object> variables = Map.of("displayName", displayName,
@@ -103,14 +106,14 @@ public class EmailService {
      * @param organizationName display name of the inviting organization
      * @return a future that completes once the send has finished (or fails if ACS rejects it)
      */
-    public CompletableFuture<Void> sendInviteEmail(PendingInvite invite, String organizationName) {
+    public Future<Void> sendInviteEmail(PendingInvite invite, String organizationName) {
         String acceptUrl = properties.getDomain().getAppBaseUrl() + INVITE_PATH + invite.getVerificationToken();
         String toName = invite.getDisplayName() != null ? invite.getDisplayName() : invite.getEmail();
 
         if (!properties.getDomain().getEmail().isEnabled()) {
             log.warn("Email sending is disabled; invite accept URL for {} <{}>: {}",
                     toName, invite.getEmail(), acceptUrl);
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
 
         long expiresInDays = Math.max(1, Math.round(
@@ -138,8 +141,7 @@ public class EmailService {
         }
         return inviteEmailTemplateRepository.findByApplication(invite.getApplicationId(),
                                                                invite.getOrganizationId())
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(template -> {
+                .compose(template -> {
                     if (template == null) {
                         return send(invite.getEmail(), toName, defaultSubject,
                                     render(INVITE_HTML, variables),
@@ -203,11 +205,11 @@ public class EmailService {
         }
     }
 
-    private CompletableFuture<Void> send(String toEmail,
-                                         String toName,
-                                         String subject,
-                                         String htmlBody,
-                                         String textBody) {
+    private Future<Void> send(String toEmail,
+                              String toName,
+                              String subject,
+                              String htmlBody,
+                              String textBody) {
         EmailClient client = getOrBuildEmailClient();
 
         EmailMessage message = new EmailMessage()
@@ -217,7 +219,7 @@ public class EmailService {
                 .setBodyHtml(htmlBody)
                 .setBodyPlainText(textBody);
 
-        return CompletableFuture.supplyAsync(() -> {
+        return Future.fromCompletionStage(CompletableFuture.supplyAsync(() -> {
             SyncPoller<EmailSendResult, EmailSendResult> poller = client.beginSend(message);
             poller.waitForCompletion(properties.getDomain().getEmail().getSendTimeout());
             EmailSendResult result = poller.getFinalResult();
@@ -228,7 +230,7 @@ public class EmailService {
             }
             throw new IllegalStateException("Azure Communication Services rejected the send: status="
                     + result.getStatus() + " messageId=" + result.getId());
-        });
+        }), vertx.getOrCreateContext());
     }
 
     /**

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/EmailService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/EmailService.java
@@ -138,6 +138,7 @@ public class EmailService {
         }
         return inviteEmailTemplateRepository.findByApplication(invite.getApplicationId(),
                                                                invite.getOrganizationId())
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(template -> {
                     if (template == null) {
                         return send(invite.getEmail(), toName, defaultSubject,

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/AzureKeyVaultBackend.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/AzureKeyVaultBackend.java
@@ -4,12 +4,13 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.security.keyvault.secrets.SecretAsyncClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import org.kinotic.domain.api.config.AzureProperties;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Azure Key Vault backed secret storage.
@@ -18,8 +19,9 @@ import java.util.concurrent.CompletableFuture;
 public class AzureKeyVaultBackend implements SecretStorageBackend {
 
     private final SecretAsyncClient client;
+    private final Vertx vertx;
 
-    public AzureKeyVaultBackend(AzureProperties settings) {
+    public AzureKeyVaultBackend(AzureProperties settings, Vertx vertx) {
         if (settings == null || settings.getVaultUrl() == null) {
             throw new IllegalArgumentException("Azure vault URL must be configured when using azure backend");
         }
@@ -27,52 +29,59 @@ public class AzureKeyVaultBackend implements SecretStorageBackend {
                 .vaultUrl(settings.getVaultUrl())
                 .credential(new DefaultAzureCredentialBuilder().build())
                 .buildAsyncClient();
+        this.vertx = vertx;
     }
 
     @Override
-    public CompletableFuture<Void> setSecret(String derivedName, String value) {
-        return client.setSecret(derivedName, value)
-                     .then()
-                     .toFuture();
+    public Future<Void> setSecret(String derivedName, String value) {
+        return Future.fromCompletionStage(client.setSecret(derivedName, value)
+                                                .then()
+                                                .toFuture(),
+                                          vertx.getOrCreateContext());
     }
 
     @Override
-    public CompletableFuture<String> getSecret(String derivedName) {
-        return client.getSecret(derivedName)
-                     .map(KeyVaultSecret::getValue)
-                     .toFuture();
+    public Future<String> getSecret(String derivedName) {
+        return Future.fromCompletionStage(client.getSecret(derivedName)
+                                                .map(KeyVaultSecret::getValue)
+                                                .toFuture(),
+                                          vertx.getOrCreateContext());
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecret(String derivedName) {
-        return client.beginDeleteSecret(derivedName)
-                     .next()
-                     .then()
-                     .toFuture();
+    public Future<Void> deleteSecret(String derivedName) {
+        return Future.fromCompletionStage(client.beginDeleteSecret(derivedName)
+                                                .next()
+                                                .then()
+                                                .toFuture(),
+                                          vertx.getOrCreateContext());
     }
 
     @Override
-    public CompletableFuture<Void> setSecrets(Map<String, String> derivedNameToValue) {
-        return Flux.fromIterable(derivedNameToValue.entrySet())
-                   .flatMap(e -> client.setSecret(e.getKey(), e.getValue()))
-                   .then()
-                   .toFuture();
+    public Future<Void> setSecrets(Map<String, String> derivedNameToValue) {
+        return Future.fromCompletionStage(Flux.fromIterable(derivedNameToValue.entrySet())
+                                              .flatMap(e -> client.setSecret(e.getKey(), e.getValue()))
+                                              .then()
+                                              .toFuture(),
+                                          vertx.getOrCreateContext());
     }
 
     @Override
-    public CompletableFuture<Map<String, String>> getSecrets(List<String> derivedNames) {
-        return Flux.fromIterable(derivedNames)
-                   .flatMap(name -> client.getSecret(name)
-                                         .map(secret -> Map.entry(name, secret.getValue())))
-                   .collectMap(Map.Entry::getKey, Map.Entry::getValue)
-                   .toFuture();
+    public Future<Map<String, String>> getSecrets(List<String> derivedNames) {
+        return Future.fromCompletionStage(Flux.fromIterable(derivedNames)
+                                              .flatMap(name -> client.getSecret(name)
+                                                                    .map(secret -> Map.entry(name, secret.getValue())))
+                                              .collectMap(Map.Entry::getKey, Map.Entry::getValue)
+                                              .toFuture(),
+                                          vertx.getOrCreateContext());
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecrets(List<String> derivedNames) {
-        return Flux.fromIterable(derivedNames)
-                   .flatMap(name -> client.beginDeleteSecret(name).next())
-                   .then()
-                   .toFuture();
+    public Future<Void> deleteSecrets(List<String> derivedNames) {
+        return Future.fromCompletionStage(Flux.fromIterable(derivedNames)
+                                              .flatMap(name -> client.beginDeleteSecret(name).next())
+                                              .then()
+                                              .toFuture(),
+                                          vertx.getOrCreateContext());
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/AzureKeyVaultSecretReferenceResolver.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/AzureKeyVaultSecretReferenceResolver.java
@@ -5,14 +5,14 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.security.keyvault.secrets.SecretAsyncClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.domain.api.config.KinoticDomainProperties;
 import org.kinotic.core.api.secret.SecretReferenceResolver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Resolves named secrets from the platform Azure Key Vault. Authenticates via
@@ -31,31 +31,30 @@ import java.util.concurrent.CompletableFuture;
 public class AzureKeyVaultSecretReferenceResolver implements SecretReferenceResolver {
 
     private final SecretAsyncClient client;
+    private final Vertx vertx;
 
-    public AzureKeyVaultSecretReferenceResolver(KinoticDomainProperties properties) {
+    public AzureKeyVaultSecretReferenceResolver(KinoticDomainProperties properties, Vertx vertx) {
         String vaultUrl = properties.getDomain().getSecretStorage().getAzure().getVaultUrl();
         log.info("Resolving named secrets from Azure Key Vault at {}", vaultUrl);
         this.client = new SecretClientBuilder()
                 .vaultUrl(vaultUrl)
                 .credential(new DefaultAzureCredentialBuilder().build())
                 .buildAsyncClient();
-    }
-
-    AzureKeyVaultSecretReferenceResolver(SecretAsyncClient client) {
-        this.client = client;
+        this.vertx = vertx;
     }
 
     @Override
-    public CompletableFuture<String> resolve(String secretName) {
+    public Future<String> resolve(String secretName) {
         if (secretName == null || secretName.isBlank()) {
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
-        return client.getSecret(secretName)
-                     .map(KeyVaultSecret::getValue)
-                     .onErrorResume(ResourceNotFoundException.class, e -> {
-                         log.debug("Secret '{}' not found in Key Vault", secretName);
-                         return Mono.empty();
-                     })
-                     .toFuture();
+        return Future.fromCompletionStage(client.getSecret(secretName)
+                                                .map(KeyVaultSecret::getValue)
+                                                .onErrorResume(ResourceNotFoundException.class, e -> {
+                                                    log.debug("Secret '{}' not found in Key Vault", secretName);
+                                                    return Mono.empty();
+                                                })
+                                                .toFuture(),
+                                          vertx.getOrCreateContext());
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/ChronicleMapBackend.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/ChronicleMapBackend.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.secret;
 
+import io.vertx.core.Future;
 import net.openhft.chronicle.map.ChronicleMap;
 import org.kinotic.domain.api.config.ChronicleMapProperties;
 import org.springframework.beans.factory.DisposableBean;
@@ -9,7 +10,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Chronicle Map backed secret storage for local development.
@@ -41,30 +41,30 @@ public class ChronicleMapBackend implements SecretStorageBackend, DisposableBean
     }
 
     @Override
-    public CompletableFuture<Void> setSecret(String derivedName, String value) {
+    public Future<Void> setSecret(String derivedName, String value) {
         map.put(derivedName, value);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<String> getSecret(String derivedName) {
-        return CompletableFuture.completedFuture(map.get(derivedName));
+    public Future<String> getSecret(String derivedName) {
+        return Future.succeededFuture(map.get(derivedName));
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecret(String derivedName) {
+    public Future<Void> deleteSecret(String derivedName) {
         map.remove(derivedName);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Void> setSecrets(Map<String, String> derivedNameToValue) {
+    public Future<Void> setSecrets(Map<String, String> derivedNameToValue) {
         map.putAll(derivedNameToValue);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Map<String, String>> getSecrets(List<String> derivedNames) {
+    public Future<Map<String, String>> getSecrets(List<String> derivedNames) {
         Map<String, String> results = new HashMap<>();
         for (String name : derivedNames) {
             String value = map.get(name);
@@ -72,13 +72,13 @@ public class ChronicleMapBackend implements SecretStorageBackend, DisposableBean
                 results.put(name, value);
             }
         }
-        return CompletableFuture.completedFuture(results);
+        return Future.succeededFuture(results);
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecrets(List<String> derivedNames) {
+    public Future<Void> deleteSecrets(List<String> derivedNames) {
         derivedNames.forEach(map::remove);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/DefaultSecretStorageService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/DefaultSecretStorageService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.secret;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.domain.api.services.SecretStorageService;
 import org.springframework.stereotype.Component;
@@ -7,7 +8,6 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @Component
@@ -18,25 +18,25 @@ public class DefaultSecretStorageService implements SecretStorageService {
     private final SecretStorageBackend secretStorageBackend;
 
     @Override
-    public CompletableFuture<Void> setSecret(String secretScope, String key, String value) {
+    public Future<Void> setSecret(String secretScope, String key, String value) {
         String derivedName = secretNameDeriver.derive(secretScope, key);
         return secretStorageBackend.setSecret(derivedName, value);
     }
 
     @Override
-    public CompletableFuture<String> getSecret(String secretScope, String key) {
+    public Future<String> getSecret(String secretScope, String key) {
         String derivedName = secretNameDeriver.derive(secretScope, key);
         return secretStorageBackend.getSecret(derivedName);
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecret(String secretScope, String key) {
+    public Future<Void> deleteSecret(String secretScope, String key) {
         String derivedName = secretNameDeriver.derive(secretScope, key);
         return secretStorageBackend.deleteSecret(derivedName);
     }
 
     @Override
-    public CompletableFuture<Void> setSecrets(String secretScope, Map<String, String> secrets) {
+    public Future<Void> setSecrets(String secretScope, Map<String, String> secrets) {
         Map<String, String> derived = secrets.entrySet()
                                              .stream()
                                              .collect(Collectors.toMap(
@@ -46,14 +46,14 @@ public class DefaultSecretStorageService implements SecretStorageService {
     }
 
     @Override
-    public CompletableFuture<Map<String, String>> getSecrets(String secretScope, Set<String> keys) {
+    public Future<Map<String, String>> getSecrets(String secretScope, Set<String> keys) {
         Map<String, String> derivedToOriginal = keys.stream()
                                                     .collect(Collectors.toMap(
                                                             k -> secretNameDeriver.derive(secretScope, k),
                                                             k -> k));
 
         return secretStorageBackend.getSecrets(List.copyOf(derivedToOriginal.keySet()))
-                                   .thenApply(derivedResults ->
+                                   .map(derivedResults ->
                                            derivedResults.entrySet()
                                                          .stream()
                                                          .collect(Collectors.toMap(
@@ -62,7 +62,7 @@ public class DefaultSecretStorageService implements SecretStorageService {
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecrets(String secretScope, Set<String> keys) {
+    public Future<Void> deleteSecrets(String secretScope, Set<String> keys) {
         List<String> derivedNames = keys.stream()
                                         .map(k -> secretNameDeriver.derive(secretScope, k))
                                         .toList();

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/EnvVarSecretReferenceResolver.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/EnvVarSecretReferenceResolver.java
@@ -1,12 +1,11 @@
 package org.kinotic.domain.internal.api.services.secret;
 
+import io.vertx.core.Future;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.secret.SecretReferenceResolver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Dev fallback for {@link SecretReferenceResolver}. Resolves secrets from process env
@@ -31,15 +30,15 @@ public class EnvVarSecretReferenceResolver implements SecretReferenceResolver {
     }
 
     @Override
-    public CompletableFuture<String> resolve(String secretName) {
+    public Future<String> resolve(String secretName) {
         if (secretName == null || secretName.isBlank()) {
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
         String envName = "KINOTIC_AKV_" + secretName.replaceAll("[^a-zA-Z0-9]", "_").toUpperCase();
         String value = System.getenv(envName);
         if (value == null) {
             log.debug("Secret '{}' not found in env var {}", secretName, envName);
         }
-        return CompletableFuture.completedFuture(value);
+        return Future.succeededFuture(value);
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/InMemoryBackend.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/InMemoryBackend.java
@@ -1,8 +1,9 @@
 package org.kinotic.domain.internal.api.services.secret;
 
+import io.vertx.core.Future;
+
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -15,39 +16,39 @@ public class InMemoryBackend implements SecretStorageBackend {
     private final ConcurrentHashMap<String, String> store = new ConcurrentHashMap<>();
 
     @Override
-    public CompletableFuture<Void> setSecret(String derivedName, String value) {
+    public Future<Void> setSecret(String derivedName, String value) {
         store.put(derivedName, value);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<String> getSecret(String derivedName) {
-        return CompletableFuture.completedFuture(store.get(derivedName));
+    public Future<String> getSecret(String derivedName) {
+        return Future.succeededFuture(store.get(derivedName));
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecret(String derivedName) {
+    public Future<Void> deleteSecret(String derivedName) {
         store.remove(derivedName);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Void> setSecrets(Map<String, String> derivedNameToValue) {
+    public Future<Void> setSecrets(Map<String, String> derivedNameToValue) {
         store.putAll(derivedNameToValue);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Map<String, String>> getSecrets(List<String> derivedNames) {
+    public Future<Map<String, String>> getSecrets(List<String> derivedNames) {
         Map<String, String> results = derivedNames.stream()
                                                   .filter(store::containsKey)
                                                   .collect(Collectors.toMap(k -> k, store::get));
-        return CompletableFuture.completedFuture(results);
+        return Future.succeededFuture(results);
     }
 
     @Override
-    public CompletableFuture<Void> deleteSecrets(List<String> derivedNames) {
+    public Future<Void> deleteSecrets(List<String> derivedNames) {
         derivedNames.forEach(store::remove);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/SecretStorageBackend.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/secret/SecretStorageBackend.java
@@ -1,8 +1,9 @@
 package org.kinotic.domain.internal.api.services.secret;
 
+import io.vertx.core.Future;
+
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * SPI for secret storage backends. All methods operate on HKDF-derived opaque names,
@@ -17,7 +18,7 @@ public interface SecretStorageBackend {
      * @param value       the secret value to store
      * @return a future that completes when the secret has been persisted
      */
-    CompletableFuture<Void> setSecret(String derivedName, String value);
+    Future<Void> setSecret(String derivedName, String value);
 
     /**
      * Retrieves a secret value by its HKDF-derived name.
@@ -25,7 +26,7 @@ public interface SecretStorageBackend {
      * @param derivedName the opaque derived name
      * @return a future containing the secret value, or {@code null} if not found
      */
-    CompletableFuture<String> getSecret(String derivedName);
+    Future<String> getSecret(String derivedName);
 
     /**
      * Deletes a secret by its HKDF-derived name.
@@ -33,7 +34,7 @@ public interface SecretStorageBackend {
      * @param derivedName the opaque derived name
      * @return a future that completes when the secret has been deleted
      */
-    CompletableFuture<Void> deleteSecret(String derivedName);
+    Future<Void> deleteSecret(String derivedName);
 
     /**
      * Stores multiple secrets in a single batch.
@@ -41,7 +42,7 @@ public interface SecretStorageBackend {
      * @param derivedNameToValue a map of derived name to secret value
      * @return a future that completes when all secrets have been persisted
      */
-    CompletableFuture<Void> setSecrets(Map<String, String> derivedNameToValue);
+    Future<Void> setSecrets(Map<String, String> derivedNameToValue);
 
     /**
      * Retrieves multiple secrets in a single batch.
@@ -49,7 +50,7 @@ public interface SecretStorageBackend {
      * @param derivedNames the list of derived names to look up
      * @return a future containing a map of derived name to secret value (missing keys are omitted)
      */
-    CompletableFuture<Map<String, String>> getSecrets(List<String> derivedNames);
+    Future<Map<String, String>> getSecrets(List<String> derivedNames);
 
     /**
      * Deletes multiple secrets in a single batch.
@@ -57,5 +58,5 @@ public interface SecretStorageBackend {
      * @param derivedNames the list of derived names to delete
      * @return a future that completes when all secrets have been deleted
      */
-    CompletableFuture<Void> deleteSecrets(List<String> derivedNames);
+    Future<Void> deleteSecrets(List<String> derivedNames);
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/ClientMetadataDocumentService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/ClientMetadataDocumentService.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -60,10 +59,10 @@ public class ClientMetadataDocumentService {
      * is set to something displayable.
      *
      * @param clientId the {@code client_id} from the authorization request
-     * @return a {@link CompletableFuture} emitting the validated document, failing when the
+     * @return a {@link Future} emitting the validated document, failing when the
      *         client_id is not permitted or the document is unreachable or invalid
      */
-    public CompletableFuture<ClientMetadataDocument> resolve(String clientId) {
+    public Future<ClientMetadataDocument> resolve(String clientId) {
         Future<ClientMetadataDocument> ret;
         try {
             URI uri = validateClientIdUrl(clientId);
@@ -79,7 +78,7 @@ public class ClientMetadataDocumentService {
         } catch (IllegalArgumentException e) {
             ret = Future.failedFuture(e);
         }
-        return ret.toCompletionStage().toCompletableFuture();
+        return ret;
     }
 
     /**

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultDeviceCodeGrantService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultDeviceCodeGrantService.java
@@ -60,6 +60,7 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
                 .setIntervalSeconds(POLL_INTERVAL_SECONDS);
 
         return deviceCodeGrantRepository.saveSync(grant)
+                .toCompletionStage().toCompletableFuture()
                 .thenApply(saved -> new DeviceCodeGrantStart(deviceCode, userCode, expiresAt, POLL_INTERVAL_SECONDS));
     }
 
@@ -67,6 +68,7 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
     public CompletableFuture<DeviceCodePollResult> poll(String deviceCode) {
         Validate.notBlank(deviceCode, "deviceCode is required");
         return deviceCodeGrantRepository.findByDeviceCodeHash(DomainUtil.sha256Hex(deviceCode))
+                                        .toCompletionStage().toCompletableFuture()
                                         .thenCompose(this::evaluatePoll);
     }
 
@@ -77,13 +79,16 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
         Date now = new Date();
         if (grant.getExpiresAt().before(now)) {
             return deviceCodeGrantRepository.deleteById(grant.getId())
+                    .toCompletionStage().toCompletableFuture()
                     .thenApply(v -> new DeviceCodePollResult(PollStatus.EXPIRED, null, null));
         }
         if (grant.getIdentityId() != null) {
             // Approved — hand back the user and consume the grant so it cannot be replayed.
             return identityRepository.findById(grant.getIdentityId())
+                    .toCompletionStage().toCompletableFuture()
                     .thenApply(UserParticipantIdentity.class::cast)
                     .thenCompose(user -> deviceCodeGrantRepository.deleteById(grant.getId())
+                            .toCompletionStage().toCompletableFuture()
                             .thenApply(v -> (user == null || !user.isEnabled())
                                     ? new DeviceCodePollResult(PollStatus.INVALID, null, null)
                                     : new DeviceCodePollResult(PollStatus.APPROVED, user, grant.getDeviceName())));
@@ -93,6 +98,7 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
         }
         grant.setLastPolledAt(now);
         return deviceCodeGrantRepository.saveSync(grant)
+                .toCompletionStage().toCompletableFuture()
                 .thenApply(v -> new DeviceCodePollResult(PollStatus.AUTHORIZATION_PENDING, null, null));
     }
 
@@ -101,6 +107,7 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
         Validate.notBlank(userCode, "userCode is required");
         Validate.notBlank(identityId, "identityId is required");
         return deviceCodeGrantRepository.findByUserCode(normalizeUserCode(userCode))
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(grant -> {
                     if (grant == null) {
                         return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown user code"));
@@ -114,7 +121,9 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
                                 new IllegalArgumentException("Device authorization request has already been approved"));
                     }
                     grant.setIdentityId(identityId);
-                    return deviceCodeGrantRepository.saveSync(grant).thenApply(v -> null);
+                    return deviceCodeGrantRepository.saveSync(grant)
+                                                    .toCompletionStage().toCompletableFuture()
+                                                    .thenApply(v -> null);
                 });
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultDeviceCodeGrantService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultDeviceCodeGrantService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -18,7 +19,6 @@ import org.springframework.stereotype.Component;
 import java.security.SecureRandom;
 import java.util.Date;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
@@ -44,7 +44,7 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
     private final ParticipantIdentityRepository identityRepository;
 
     @Override
-    public CompletableFuture<DeviceCodeGrantStart> start(String deviceName) {
+    public Future<DeviceCodeGrantStart> start(String deviceName) {
         Date now = new Date();
         String deviceCode = DomainUtil.generateUrlSafeToken(DEVICE_CODE_BYTES);
         String userCode = generateUserCode();
@@ -60,70 +60,62 @@ public class DefaultDeviceCodeGrantService implements DeviceCodeGrantService {
                 .setIntervalSeconds(POLL_INTERVAL_SECONDS);
 
         return deviceCodeGrantRepository.saveSync(grant)
-                .toCompletionStage().toCompletableFuture()
-                .thenApply(saved -> new DeviceCodeGrantStart(deviceCode, userCode, expiresAt, POLL_INTERVAL_SECONDS));
+                .map(new DeviceCodeGrantStart(deviceCode, userCode, expiresAt, POLL_INTERVAL_SECONDS));
     }
 
     @Override
-    public CompletableFuture<DeviceCodePollResult> poll(String deviceCode) {
+    public Future<DeviceCodePollResult> poll(String deviceCode) {
         Validate.notBlank(deviceCode, "deviceCode is required");
         return deviceCodeGrantRepository.findByDeviceCodeHash(DomainUtil.sha256Hex(deviceCode))
-                                        .toCompletionStage().toCompletableFuture()
-                                        .thenCompose(this::evaluatePoll);
+                                        .compose(this::evaluatePoll);
     }
 
-    private CompletableFuture<DeviceCodePollResult> evaluatePoll(DeviceCodeGrant grant) {
+    private Future<DeviceCodePollResult> evaluatePoll(DeviceCodeGrant grant) {
         if (grant == null) {
-            return CompletableFuture.completedFuture(new DeviceCodePollResult(PollStatus.INVALID, null, null));
+            return Future.succeededFuture(new DeviceCodePollResult(PollStatus.INVALID, null, null));
         }
         Date now = new Date();
         if (grant.getExpiresAt().before(now)) {
             return deviceCodeGrantRepository.deleteById(grant.getId())
-                    .toCompletionStage().toCompletableFuture()
-                    .thenApply(v -> new DeviceCodePollResult(PollStatus.EXPIRED, null, null));
+                    .map(new DeviceCodePollResult(PollStatus.EXPIRED, null, null));
         }
         if (grant.getIdentityId() != null) {
             // Approved — hand back the user and consume the grant so it cannot be replayed.
             return identityRepository.findById(grant.getIdentityId())
-                    .toCompletionStage().toCompletableFuture()
-                    .thenApply(UserParticipantIdentity.class::cast)
-                    .thenCompose(user -> deviceCodeGrantRepository.deleteById(grant.getId())
-                            .toCompletionStage().toCompletableFuture()
-                            .thenApply(v -> (user == null || !user.isEnabled())
+                    .map(UserParticipantIdentity.class::cast)
+                    .compose(user -> deviceCodeGrantRepository.deleteById(grant.getId())
+                            .map(user == null || !user.isEnabled()
                                     ? new DeviceCodePollResult(PollStatus.INVALID, null, null)
                                     : new DeviceCodePollResult(PollStatus.APPROVED, user, grant.getDeviceName())));
         }
         if (polledTooSoon(grant, now)) {
-            return CompletableFuture.completedFuture(new DeviceCodePollResult(PollStatus.SLOW_DOWN, null, null));
+            return Future.succeededFuture(new DeviceCodePollResult(PollStatus.SLOW_DOWN, null, null));
         }
         grant.setLastPolledAt(now);
         return deviceCodeGrantRepository.saveSync(grant)
-                .toCompletionStage().toCompletableFuture()
-                .thenApply(v -> new DeviceCodePollResult(PollStatus.AUTHORIZATION_PENDING, null, null));
+                .map(new DeviceCodePollResult(PollStatus.AUTHORIZATION_PENDING, null, null));
     }
 
     @Override
-    public CompletableFuture<Void> approve(String userCode, String identityId) {
+    public Future<Void> approve(String userCode, String identityId) {
         Validate.notBlank(userCode, "userCode is required");
         Validate.notBlank(identityId, "identityId is required");
         return deviceCodeGrantRepository.findByUserCode(normalizeUserCode(userCode))
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(grant -> {
+                .compose(grant -> {
                     if (grant == null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown user code"));
+                        return Future.failedFuture(new IllegalArgumentException("Unknown user code"));
                     }
                     if (grant.getExpiresAt().before(new Date())) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Device authorization request has expired"));
                     }
                     if (grant.getIdentityId() != null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Device authorization request has already been approved"));
                     }
                     grant.setIdentityId(identityId);
                     return deviceCodeGrantRepository.saveSync(grant)
-                                                    .toCompletionStage().toCompletableFuture()
-                                                    .thenApply(v -> null);
+                                                    .mapEmpty();
                 });
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultInviteService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultInviteService.java
@@ -43,6 +43,7 @@ public class DefaultInviteService implements InviteService {
         invite.setEmail(DomainUtil.normalizeEmail(invite.getEmail()));
 
         return organizationService.findById(invite.getOrganizationId())
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(org -> {
                     if (org == null) {
                         return CompletableFuture.<Organization>failedFuture(
@@ -61,6 +62,7 @@ public class DefaultInviteService implements InviteService {
                     // saveSync because the console re-queries pending invites as soon as this
                     // returns — a plain save races the ES index refresh and the new row is missed.
                     return pendingInviteRepository.saveSync(invite)
+                            .toCompletionStage().toCompletableFuture()
                             .thenCompose(saved -> emailService.sendInviteEmail(saved, org.getName())
                                                               .thenApply(v -> saved));
                 });
@@ -76,9 +78,11 @@ public class DefaultInviteService implements InviteService {
     private CompletableFuture<Void> checkEmailAvailable(PendingInvite invite) {
         CompletableFuture<UserParticipantIdentity> existingUser = invite.getApplicationId() == null
                 ? identityService.findFirstOrgUserByEmail(invite.getEmail())
+                                 .toCompletionStage().toCompletableFuture()
                 : identityService.findByEmail(invite.getEmail(),
                                              invite.getOrganizationId(),
-                                             invite.getApplicationId());
+                                             invite.getApplicationId())
+                                 .toCompletionStage().toCompletableFuture();
         return existingUser
                 .thenCompose(user -> {
                     if (user != null) {
@@ -89,7 +93,8 @@ public class DefaultInviteService implements InviteService {
                     }
                     return pendingInviteRepository.findByEmailAndScope(invite.getEmail(),
                                                                        invite.getOrganizationId(),
-                                                                       invite.getApplicationId());
+                                                                       invite.getApplicationId())
+                                                  .toCompletionStage().toCompletableFuture();
                 })
                 .thenCompose(pending -> {
                     if (pending != null) {
@@ -103,7 +108,8 @@ public class DefaultInviteService implements InviteService {
     @Override
     public CompletableFuture<PendingInvite> getValidInvite(String token) {
         Validate.notBlank(token, "token is required");
-        return pendingInviteRepository.findValidByToken(token);
+        return pendingInviteRepository.findValidByToken(token)
+                                      .toCompletionStage().toCompletableFuture();
     }
 
     @Override
@@ -112,6 +118,7 @@ public class DefaultInviteService implements InviteService {
         Validate.notBlank(password, "password is required");
 
         return pendingInviteRepository.findValidByToken(token)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(invite -> acceptInvite(invite, password, displayName, null, null));
     }
 
@@ -126,6 +133,7 @@ public class DefaultInviteService implements InviteService {
         Validate.notBlank(verifiedEmail, "verifiedEmail is required");
 
         return pendingInviteRepository.findValidByToken(token)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(invite -> {
                     if (!invite.getEmail().equals(DomainUtil.normalizeEmail(verifiedEmail))) {
                         return CompletableFuture.failedFuture(new InviteEmailMismatchException(
@@ -158,7 +166,9 @@ public class DefaultInviteService implements InviteService {
                 .setOidcConfigId(oidcConfigId);
         }
         return identityService.createUser(user, password)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(saved -> pendingInviteRepository.deleteById(invite.getId())
+                                                             .toCompletionStage().toCompletableFuture()
                                                              .thenApply(v -> saved));
     }
 
@@ -167,7 +177,8 @@ public class DefaultInviteService implements InviteService {
                                                                      String applicationId,
                                                                      Pageable pageable) {
         Validate.notBlank(organizationId, "organizationId is required");
-        return pendingInviteRepository.findByScope(organizationId, applicationId, pageable);
+        return pendingInviteRepository.findByScope(organizationId, applicationId, pageable)
+                                      .toCompletionStage().toCompletableFuture();
     }
 
     @Override
@@ -176,6 +187,7 @@ public class DefaultInviteService implements InviteService {
         Validate.notBlank(organizationId, "organizationId is required");
 
         return pendingInviteRepository.findById(inviteId)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(invite -> {
                     // The repository deleteById is unscoped; this load-and-assert is the
                     // security boundary keeping one org from cancelling another's invites.
@@ -185,7 +197,8 @@ public class DefaultInviteService implements InviteService {
                                 new IllegalArgumentException("Invitation not found."));
                     }
                     // Sync delete so the console's immediate re-query no longer sees the row.
-                    return pendingInviteRepository.deleteByIdSync(inviteId);
+                    return pendingInviteRepository.deleteByIdSync(inviteId)
+                                                  .toCompletionStage().toCompletableFuture();
                 });
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultInviteService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultInviteService.java
@@ -1,12 +1,12 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
-import org.kinotic.domain.api.model.Organization;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
 import org.kinotic.domain.api.model.security.PendingInvite;
 import org.kinotic.domain.api.services.OrganizationService;
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
@@ -36,22 +35,21 @@ public class DefaultInviteService implements InviteService {
     private final EmailService emailService;
 
     @Override
-    public CompletableFuture<PendingInvite> createInvite(PendingInvite invite) {
+    public Future<PendingInvite> createInvite(PendingInvite invite) {
         Validate.notBlank(invite.getEmail(), "email is required");
         Validate.notBlank(invite.getOrganizationId(), "organizationId is required");
         Validate.notBlank(invite.getInvitedByName(), "invitedByName is required");
         invite.setEmail(DomainUtil.normalizeEmail(invite.getEmail()));
 
         return organizationService.findById(invite.getOrganizationId())
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(org -> {
+                .compose(org -> {
                     if (org == null) {
-                        return CompletableFuture.<Organization>failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Organization not found."));
                     }
-                    return checkEmailAvailable(invite).thenApply(v -> org);
+                    return checkEmailAvailable(invite).map(org);
                 })
-                .thenCompose(org -> {
+                .compose(org -> {
                     Date now = new Date();
                     invite.setId(UUID.randomUUID().toString())
                           .setVerificationToken(UUID.randomUUID().toString())
@@ -62,9 +60,8 @@ public class DefaultInviteService implements InviteService {
                     // saveSync because the console re-queries pending invites as soon as this
                     // returns — a plain save races the ES index refresh and the new row is missed.
                     return pendingInviteRepository.saveSync(invite)
-                            .toCompletionStage().toCompletableFuture()
-                            .thenCompose(saved -> emailService.sendInviteEmail(saved, org.getName())
-                                                              .thenApply(v -> saved));
+                            .compose(saved -> emailService.sendInviteEmail(saved, org.getName())
+                                                          .map(saved));
                 });
     }
 
@@ -75,68 +72,62 @@ public class DefaultInviteService implements InviteService {
      * scoped, so app invites only check within the target application. Both also reject when
      * an invitation is already pending in the scope.
      */
-    private CompletableFuture<Void> checkEmailAvailable(PendingInvite invite) {
-        CompletableFuture<UserParticipantIdentity> existingUser = invite.getApplicationId() == null
+    private Future<Void> checkEmailAvailable(PendingInvite invite) {
+        Future<UserParticipantIdentity> existingUser = invite.getApplicationId() == null
                 ? identityService.findFirstOrgUserByEmail(invite.getEmail())
-                                 .toCompletionStage().toCompletableFuture()
                 : identityService.findByEmail(invite.getEmail(),
                                              invite.getOrganizationId(),
-                                             invite.getApplicationId())
-                                 .toCompletionStage().toCompletableFuture();
+                                             invite.getApplicationId());
         return existingUser
-                .thenCompose(user -> {
+                .compose(user -> {
                     if (user != null) {
-                        return CompletableFuture.<PendingInvite>failedFuture(new IllegalArgumentException(
+                        return Future.<PendingInvite>failedFuture(new IllegalArgumentException(
                                 invite.getApplicationId() == null
                                         ? "This email already belongs to an organization."
                                         : "A user with this email already exists in this application."));
                     }
                     return pendingInviteRepository.findByEmailAndScope(invite.getEmail(),
                                                                        invite.getOrganizationId(),
-                                                                       invite.getApplicationId())
-                                                  .toCompletionStage().toCompletableFuture();
+                                                                       invite.getApplicationId());
                 })
-                .thenCompose(pending -> {
+                .compose(pending -> {
                     if (pending != null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException(
+                        return Future.failedFuture(new IllegalArgumentException(
                                 "An invitation is already pending for this email."));
                     }
-                    return CompletableFuture.completedFuture(null);
+                    return Future.succeededFuture();
                 });
     }
 
     @Override
-    public CompletableFuture<PendingInvite> getValidInvite(String token) {
+    public Future<PendingInvite> getValidInvite(String token) {
         Validate.notBlank(token, "token is required");
-        return pendingInviteRepository.findValidByToken(token)
-                                      .toCompletionStage().toCompletableFuture();
+        return pendingInviteRepository.findValidByToken(token);
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> acceptLocalInvite(String token, String password, String displayName) {
+    public Future<UserParticipantIdentity> acceptLocalInvite(String token, String password, String displayName) {
         Validate.notBlank(token, "token is required");
         Validate.notBlank(password, "password is required");
 
         return pendingInviteRepository.findValidByToken(token)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(invite -> acceptInvite(invite, password, displayName, null, null));
+                .compose(invite -> acceptInvite(invite, password, displayName, null, null));
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> acceptOidcInvite(String token,
-                                                       String oidcSubject,
-                                                       String oidcConfigId,
-                                                       String verifiedEmail) {
+    public Future<UserParticipantIdentity> acceptOidcInvite(String token,
+                                                            String oidcSubject,
+                                                            String oidcConfigId,
+                                                            String verifiedEmail) {
         Validate.notBlank(token, "token is required");
         Validate.notBlank(oidcSubject, "oidcSubject is required");
         Validate.notBlank(oidcConfigId, "oidcConfigId is required");
         Validate.notBlank(verifiedEmail, "verifiedEmail is required");
 
         return pendingInviteRepository.findValidByToken(token)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(invite -> {
+                .compose(invite -> {
                     if (!invite.getEmail().equals(DomainUtil.normalizeEmail(verifiedEmail))) {
-                        return CompletableFuture.failedFuture(new InviteEmailMismatchException(
+                        return Future.failedFuture(new InviteEmailMismatchException(
                                 "This invitation was sent to a different email address."));
                     }
                     return acceptInvite(invite, null, null, oidcSubject, oidcConfigId);
@@ -149,11 +140,11 @@ public class DefaultInviteService implements InviteService {
      * the invite is consumed on success. A concurrent double-accept is safe — createUser's
      * unique-email-in-scope check fails the second attempt.
      */
-    private CompletableFuture<UserParticipantIdentity> acceptInvite(PendingInvite invite,
-                                                    String password,
-                                                    String displayNameOverride,
-                                                    String oidcSubject,
-                                                    String oidcConfigId) {
+    private Future<UserParticipantIdentity> acceptInvite(PendingInvite invite,
+                                                         String password,
+                                                         String displayNameOverride,
+                                                         String oidcSubject,
+                                                         String oidcConfigId) {
         UserParticipantIdentity user = new UserParticipantIdentity();
         user.setEmail(invite.getEmail())
             .setDisplayName(StringUtils.isNotBlank(displayNameOverride)
@@ -166,39 +157,34 @@ public class DefaultInviteService implements InviteService {
                 .setOidcConfigId(oidcConfigId);
         }
         return identityService.createUser(user, password)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(saved -> pendingInviteRepository.deleteById(invite.getId())
-                                                             .toCompletionStage().toCompletableFuture()
-                                                             .thenApply(v -> saved));
+                .compose(saved -> pendingInviteRepository.deleteById(invite.getId())
+                                                         .map(saved));
     }
 
     @Override
-    public CompletableFuture<Page<PendingInvite>> findPendingInvites(String organizationId,
-                                                                     String applicationId,
-                                                                     Pageable pageable) {
+    public Future<Page<PendingInvite>> findPendingInvites(String organizationId,
+                                                          String applicationId,
+                                                          Pageable pageable) {
         Validate.notBlank(organizationId, "organizationId is required");
-        return pendingInviteRepository.findByScope(organizationId, applicationId, pageable)
-                                      .toCompletionStage().toCompletableFuture();
+        return pendingInviteRepository.findByScope(organizationId, applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<Void> cancelInvite(String inviteId, String organizationId) {
+    public Future<Void> cancelInvite(String inviteId, String organizationId) {
         Validate.notBlank(inviteId, "inviteId is required");
         Validate.notBlank(organizationId, "organizationId is required");
 
         return pendingInviteRepository.findById(inviteId)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(invite -> {
+                .compose(invite -> {
                     // The repository deleteById is unscoped; this load-and-assert is the
                     // security boundary keeping one org from cancelling another's invites.
                     // Same message for missing and foreign — no existence oracle.
                     if (invite == null || !organizationId.equals(invite.getOrganizationId())) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Invitation not found."));
                     }
                     // Sync delete so the console's immediate re-query no longer sees the row.
-                    return pendingInviteRepository.deleteByIdSync(inviteId)
-                                                  .toCompletionStage().toCompletableFuture();
+                    return pendingInviteRepository.deleteByIdSync(inviteId);
                 });
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultLocalAuthenticationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultLocalAuthenticationService.java
@@ -26,7 +26,8 @@ public class DefaultLocalAuthenticationService implements LocalAuthenticationSer
     public CompletableFuture<UserParticipantIdentity> authenticateLocal(String email, String password) {
         Validate.notBlank(email, "email cannot be blank");
         Validate.notBlank(password, "password cannot be blank");
-        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email));
+        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email)
+                                                                    .toCompletionStage().toCompletableFuture());
     }
 
     @Override
@@ -39,7 +40,8 @@ public class DefaultLocalAuthenticationService implements LocalAuthenticationSer
         if (applicationId != null) {
             Validate.notBlank(organizationId, "organizationId is required when applicationId is supplied");
         }
-        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email, organizationId, applicationId));
+        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email, organizationId, applicationId)
+                                                                    .toCompletionStage().toCompletableFuture());
     }
 
     private CompletableFuture<UserParticipantIdentity> verifyMatchingUser(String password,
@@ -51,6 +53,7 @@ public class DefaultLocalAuthenticationService implements LocalAuthenticationSer
                 return CompletableFuture.completedFuture(null);
             }
             return credentialRepository.findById(user.getId())
+                                  .toCompletionStage().toCompletableFuture()
                                   .thenApply(credential -> {
                                       if (credential == null
                                               || !DomainUtil.verifyPassword(password, credential.getSecretHash())) {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultLocalAuthenticationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultLocalAuthenticationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
@@ -11,7 +12,6 @@ import org.kinotic.domain.internal.api.repositories.IdentityCredentialRepository
 import org.kinotic.domain.api.utils.DomainUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 @Slf4j
@@ -23,38 +23,35 @@ public class DefaultLocalAuthenticationService implements LocalAuthenticationSer
     private final ParticipantIdentityRepository identityRepository;
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> authenticateLocal(String email, String password) {
+    public Future<UserParticipantIdentity> authenticateLocal(String email, String password) {
         Validate.notBlank(email, "email cannot be blank");
         Validate.notBlank(password, "password cannot be blank");
-        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email)
-                                                                    .toCompletionStage().toCompletableFuture());
+        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email));
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> authenticateLocal(String email,
-                                                        String password,
-                                                        String organizationId,
-                                                        String applicationId) {
+    public Future<UserParticipantIdentity> authenticateLocal(String email,
+                                                             String password,
+                                                             String organizationId,
+                                                             String applicationId) {
         Validate.notBlank(email, "email cannot be blank");
         Validate.notBlank(password, "password cannot be blank");
         if (applicationId != null) {
             Validate.notBlank(organizationId, "organizationId is required when applicationId is supplied");
         }
-        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email, organizationId, applicationId)
-                                                                    .toCompletionStage().toCompletableFuture());
+        return verifyMatchingUser(password, () -> identityRepository.findByEmail(email, organizationId, applicationId));
     }
 
-    private CompletableFuture<UserParticipantIdentity> verifyMatchingUser(String password,
-                                                          Supplier<CompletableFuture<UserParticipantIdentity>> lookup) {
-        return lookup.get().thenCompose(user -> {
+    private Future<UserParticipantIdentity> verifyMatchingUser(String password,
+                                                               Supplier<Future<UserParticipantIdentity>> lookup) {
+        return lookup.get().compose(user -> {
             if (user == null
                     || user.getAuthType() != AuthType.LOCAL
                     || !user.isEnabled()) {
-                return CompletableFuture.completedFuture(null);
+                return Future.succeededFuture(null);
             }
             return credentialRepository.findById(user.getId())
-                                  .toCompletionStage().toCompletableFuture()
-                                  .thenApply(credential -> {
+                                  .map(credential -> {
                                       if (credential == null
                                               || !DomainUtil.verifyPassword(password, credential.getSecretHash())) {
                                           return null;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOAuthAuthorizationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOAuthAuthorizationService.java
@@ -69,7 +69,9 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
                             .setState(state)
                             .setCreated(now)
                             .setExpiresAt(new Date(now.getTime() + REQUEST_TTL_MS));
-                    return grantRepository.saveSync(grant).thenApply(OAuthAuthorizationGrant::getId);
+                    return grantRepository.saveSync(grant)
+                                          .toCompletionStage().toCompletableFuture()
+                                          .thenApply(OAuthAuthorizationGrant::getId);
                 });
     }
 
@@ -92,6 +94,7 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
                          // the code's own, shorter expiry replaces the consent window
                          .setExpiresAt(new Date(System.currentTimeMillis() + CODE_TTL_MS));
                     return grantRepository.saveSync(grant)
+                                          .toCompletionStage().toCompletableFuture()
                                           .thenApply(saved -> redirectUrl(grant, "code", code));
                 });
     }
@@ -100,6 +103,7 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
     public CompletableFuture<String> deny(String requestId) {
         return loadPendingGrant(requestId)
                 .thenCompose(grant -> grantRepository.deleteById(grant.getId())
+                                                     .toCompletionStage().toCompletableFuture()
                                                      .thenApply(v -> redirectUrl(grant, "error", "access_denied")));
     }
 
@@ -113,13 +117,16 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
         Validate.notBlank(redirectUri, "redirect_uri is required");
         Validate.notBlank(codeVerifier, "code_verifier is required");
         return grantRepository.findByCodeHash(DomainUtil.sha256Hex(code))
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(grant -> {
                     if (grant == null) {
                         return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown authorization code"));
                     }
                     // consume the grant before judging it, so a failed exchange burns the code too.
                     // the delete must wait for the index refresh: findByCodeHash is a search
-                    return grantRepository.deleteByIdSync(grant.getId()).thenCompose(v -> {
+                    return grantRepository.deleteByIdSync(grant.getId())
+                                          .toCompletionStage().toCompletableFuture()
+                                          .thenCompose(v -> {
                         if (grant.getExpiresAt().before(new Date())) {
                             return CompletableFuture.failedFuture(new IllegalArgumentException("Authorization code has expired"));
                         }
@@ -183,12 +190,14 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
     private CompletableFuture<OAuthAuthorizationGrant> loadPendingGrant(String requestId) {
         Validate.notBlank(requestId, "requestId is required");
         return grantRepository.findById(requestId)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(grant -> {
                     if (grant == null) {
                         return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown authorization request"));
                     }
                     if (grant.getExpiresAt().before(new Date())) {
                         return grantRepository.deleteById(grant.getId())
+                                .toCompletionStage().toCompletableFuture()
                                 .thenCompose(v -> CompletableFuture.failedFuture(
                                         new IllegalArgumentException("Authorization request has expired")));
                     }
@@ -202,6 +211,7 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
 
     private CompletableFuture<UserParticipantIdentity> loadEnabledUser(String identityId) {
         return identityRepository.findById(identityId)
+                .toCompletionStage().toCompletableFuture()
                 .thenApply(UserParticipantIdentity.class::cast)
                 .thenCompose(user -> (user == null || !user.isEnabled())
                         ? CompletableFuture.failedFuture(new IllegalArgumentException("User is not available"))

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOAuthAuthorizationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOAuthAuthorizationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
@@ -21,7 +22,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
@@ -42,19 +42,19 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
     private final ParticipantIdentityRepository identityRepository;
 
     @Override
-    public CompletableFuture<String> createAuthorizationRequest(String clientId,
-                                                                String redirectUri,
-                                                                String codeChallenge,
-                                                                String scope,
-                                                                String resource,
-                                                                String state) {
+    public Future<String> createAuthorizationRequest(String clientId,
+                                                     String redirectUri,
+                                                     String codeChallenge,
+                                                     String scope,
+                                                     String resource,
+                                                     String state) {
         Validate.notBlank(clientId, "client_id is required");
         Validate.notBlank(redirectUri, "redirect_uri is required");
         Validate.notBlank(codeChallenge, "code_challenge is required");
         return clientMetadataDocumentService.resolve(clientId)
-                .thenCompose(client -> {
+                .compose(client -> {
                     if (!matchesRegisteredRedirectUri(client.getRedirectUris(), redirectUri)) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("redirect_uri is not registered for this client"));
                     }
                     Date now = new Date();
@@ -70,45 +70,42 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
                             .setCreated(now)
                             .setExpiresAt(new Date(now.getTime() + REQUEST_TTL_MS));
                     return grantRepository.saveSync(grant)
-                                          .toCompletionStage().toCompletableFuture()
-                                          .thenApply(OAuthAuthorizationGrant::getId);
+                                          .map(OAuthAuthorizationGrant::getId);
                 });
     }
 
     @Override
-    public CompletableFuture<PendingOAuthAuthorization> findPending(String requestId) {
+    public Future<PendingOAuthAuthorization> findPending(String requestId) {
         return loadPendingGrant(requestId)
-                .thenApply(grant -> new PendingOAuthAuthorization(grant.getClientName(),
-                                                                  grant.getClientId(),
-                                                                  grant.getScope()));
+                .map(grant -> new PendingOAuthAuthorization(grant.getClientName(),
+                                                            grant.getClientId(),
+                                                            grant.getScope()));
     }
 
     @Override
-    public CompletableFuture<String> approve(String requestId, String identityId) {
+    public Future<String> approve(String requestId, String identityId) {
         Validate.notBlank(identityId, "identityId is required");
         return loadPendingGrant(requestId)
-                .thenCompose(grant -> {
+                .compose(grant -> {
                     String code = DomainUtil.generateUrlSafeToken(TOKEN_BYTES);
                     grant.setIdentityId(identityId)
                          .setCodeHash(DomainUtil.sha256Hex(code))
                          // the code's own, shorter expiry replaces the consent window
                          .setExpiresAt(new Date(System.currentTimeMillis() + CODE_TTL_MS));
                     return grantRepository.saveSync(grant)
-                                          .toCompletionStage().toCompletableFuture()
-                                          .thenApply(saved -> redirectUrl(grant, "code", code));
+                                          .map(redirectUrl(grant, "code", code));
                 });
     }
 
     @Override
-    public CompletableFuture<String> deny(String requestId) {
+    public Future<String> deny(String requestId) {
         return loadPendingGrant(requestId)
-                .thenCompose(grant -> grantRepository.deleteById(grant.getId())
-                                                     .toCompletionStage().toCompletableFuture()
-                                                     .thenApply(v -> redirectUrl(grant, "error", "access_denied")));
+                .compose(grant -> grantRepository.deleteById(grant.getId())
+                                                 .map(redirectUrl(grant, "error", "access_denied")));
     }
 
     @Override
-    public CompletableFuture<CodeExchangeResult> exchangeCode(String code,
+    public Future<CodeExchangeResult> exchangeCode(String code,
                                                    String clientId,
                                                    String redirectUri,
                                                    String codeVerifier) {
@@ -117,30 +114,28 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
         Validate.notBlank(redirectUri, "redirect_uri is required");
         Validate.notBlank(codeVerifier, "code_verifier is required");
         return grantRepository.findByCodeHash(DomainUtil.sha256Hex(code))
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(grant -> {
+                .compose(grant -> {
                     if (grant == null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown authorization code"));
+                        return Future.failedFuture(new IllegalArgumentException("Unknown authorization code"));
                     }
                     // consume the grant before judging it, so a failed exchange burns the code too.
                     // the delete must wait for the index refresh: findByCodeHash is a search
                     return grantRepository.deleteByIdSync(grant.getId())
-                                          .toCompletionStage().toCompletableFuture()
-                                          .thenCompose(v -> {
+                                          .compose(v -> {
                         if (grant.getExpiresAt().before(new Date())) {
-                            return CompletableFuture.failedFuture(new IllegalArgumentException("Authorization code has expired"));
+                            return Future.failedFuture(new IllegalArgumentException("Authorization code has expired"));
                         }
                         if (!grant.getClientId().equals(clientId) || !grant.getRedirectUri().equals(redirectUri)) {
-                            return CompletableFuture.failedFuture(
+                            return Future.failedFuture(
                                     new IllegalArgumentException("Authorization code was not issued to this client"));
                         }
                         if (!OAuth2Util.s256Challenge(codeVerifier).equals(grant.getCodeChallenge())) {
-                            return CompletableFuture.failedFuture(new IllegalArgumentException("PKCE verification failed"));
+                            return Future.failedFuture(new IllegalArgumentException("PKCE verification failed"));
                         }
                         return loadEnabledUser(grant.getIdentityId())
-                                .thenApply(approver -> new CodeExchangeResult(approver,
-                                                                              grant.getClientId(),
-                                                                              grant.getClientName()));
+                                .map(approver -> new CodeExchangeResult(approver,
+                                                                        grant.getClientId(),
+                                                                        grant.getClientName()));
                     });
                 });
     }
@@ -187,35 +182,32 @@ public class DefaultOAuthAuthorizationService implements OAuthAuthorizationServi
         return ret;
     }
 
-    private CompletableFuture<OAuthAuthorizationGrant> loadPendingGrant(String requestId) {
+    private Future<OAuthAuthorizationGrant> loadPendingGrant(String requestId) {
         Validate.notBlank(requestId, "requestId is required");
         return grantRepository.findById(requestId)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(grant -> {
+                .compose(grant -> {
                     if (grant == null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown authorization request"));
+                        return Future.failedFuture(new IllegalArgumentException("Unknown authorization request"));
                     }
                     if (grant.getExpiresAt().before(new Date())) {
                         return grantRepository.deleteById(grant.getId())
-                                .toCompletionStage().toCompletableFuture()
-                                .thenCompose(v -> CompletableFuture.failedFuture(
+                                .compose(v -> Future.failedFuture(
                                         new IllegalArgumentException("Authorization request has expired")));
                     }
                     if (grant.getIdentityId() != null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Authorization request has already been decided"));
                     }
-                    return CompletableFuture.completedFuture(grant);
+                    return Future.succeededFuture(grant);
                 });
     }
 
-    private CompletableFuture<UserParticipantIdentity> loadEnabledUser(String identityId) {
+    private Future<UserParticipantIdentity> loadEnabledUser(String identityId) {
         return identityRepository.findById(identityId)
-                .toCompletionStage().toCompletableFuture()
-                .thenApply(UserParticipantIdentity.class::cast)
-                .thenCompose(user -> (user == null || !user.isEnabled())
-                        ? CompletableFuture.failedFuture(new IllegalArgumentException("User is not available"))
-                        : CompletableFuture.completedFuture(user));
+                .map(UserParticipantIdentity.class::cast)
+                .compose(user -> (user == null || !user.isEnabled())
+                        ? Future.failedFuture(new IllegalArgumentException("User is not available"))
+                        : Future.succeededFuture(user));
     }
 
     private static String redirectUrl(OAuthAuthorizationGrant grant, String parameter, String value) {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOidcConfigurationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOidcConfigurationService.java
@@ -1,9 +1,11 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.domain.api.model.security.BaseOidcConfiguration;
 import org.kinotic.domain.api.model.security.OidcConfiguration;
+import org.kinotic.domain.api.model.security.OrgSignupOidcConfiguration;
 import org.kinotic.domain.api.services.OrganizationService;
 import org.kinotic.domain.internal.api.repositories.ApplicationRepository;
 import org.kinotic.domain.internal.api.repositories.OidcConfigurationRepository;
@@ -17,7 +19,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultOidcConfigurationService extends AbstractOrganizationScopedService<OidcConfiguration> implements OidcConfigurationService {
@@ -40,64 +41,66 @@ public class DefaultOidcConfigurationService extends AbstractOrganizationScopedS
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(OidcConfiguration entity) {
+    protected Future<Void> beforeSave(OidcConfiguration entity) {
         Validate.notNull(entity.getName(), "OidcConfiguration name cannot be null");
         if (entity.getId() == null) {
             entity.setId(UUID.randomUUID().toString());
             entity.setCreated(new Date());
         }
         entity.setUpdated(new Date());
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId) {
+    public Future<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId) {
         Validate.notEmpty(ids, "ids cannot be null or empty");
         Validate.notBlank(orgId, "orgId cannot be blank");
         return oidcRepository.findEnabledByIds(ids, orgId);
     }
 
     @Override
-    public CompletableFuture<OidcConfiguration> findOrgLoginConfig(String organizationId) {
+    public Future<OidcConfiguration> findOrgLoginConfig(String organizationId) {
         Validate.notBlank(organizationId, "organizationId cannot be blank");
-        return organizationService.findById(organizationId).thenCompose(org -> {
+        return organizationService.findById(organizationId).compose(org -> {
             if (org == null || org.getSsoConfigId() == null) {
-                return CompletableFuture.completedFuture(null);
+                return Future.succeededFuture();
             }
             // Direct repository lookup bypasses AbstractCrudService scope enforcement so the
             // pre-auth login-lookup path can resolve without a participant. Defense in depth:
             // also confirm the row's organizationId matches and it's enabled.
             return oidcRepository.findById(org.getSsoConfigId(), organizationId)
-                                 .thenApply(c -> validForOrgLogin(c, organizationId));
+                                 .map(c -> validForOrgLogin(c, organizationId));
         });
     }
 
     @Override
-    public CompletableFuture<List<BaseOidcConfiguration>> findEnabledForScope(String organizationId, String applicationId) {
+    public Future<List<BaseOidcConfiguration>> findEnabledForScope(String organizationId, String applicationId) {
         Validate.notBlank(organizationId, "organizationId cannot be blank");
-        CompletableFuture<List<BaseOidcConfiguration>> ret;
+        Future<List<BaseOidcConfiguration>> ret;
         if (applicationId != null) {
             // Direct repository lookup so the pre-auth login pages can resolve without a participant.
             ret = applicationRepository.findById(applicationId, organizationId)
-                                       .thenCompose(app -> {
+                                       .compose(app -> {
                                            if (app == null
                                                    || app.getOidcConfigurationIds() == null
                                                    || app.getOidcConfigurationIds().isEmpty()) {
-                                               return CompletableFuture.completedFuture(List.<OidcConfiguration>of());
+                                               return Future.succeededFuture(List.<OidcConfiguration>of());
                                            }
                                            return findEnabledByIds(app.getOidcConfigurationIds(), organizationId);
                                        })
-                                       .thenApply(ArrayList::new);
+                                       .map(ArrayList::new);
         } else {
-            ret = orgSignupOidcConfigurationService.findAllEnabled()
-                                                   .thenCombine(findOrgLoginConfig(organizationId),
-                                                                (social, sso) -> {
-                                                                    List<BaseOidcConfiguration> providers = new ArrayList<>(social);
-                                                                    if (sso != null && sso.isEnabled()) {
-                                                                        providers.add(sso);
-                                                                    }
-                                                                    return providers;
-                                                                });
+            ret = Future.all(orgSignupOidcConfigurationService.findAllEnabled(),
+                             findOrgLoginConfig(organizationId))
+                        .map(cf -> {
+                            List<OrgSignupOidcConfiguration> social = cf.resultAt(0);
+                            OidcConfiguration sso = cf.resultAt(1);
+                            List<BaseOidcConfiguration> providers = new ArrayList<>(social);
+                            if (sso != null && sso.isEnabled()) {
+                                providers.add(sso);
+                            }
+                            return providers;
+                        });
         }
         return ret;
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOrgSignupOidcConfigurationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultOrgSignupOidcConfigurationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.domain.api.model.security.OidcProviderKind;
 import org.kinotic.domain.api.model.security.OrgSignupOidcConfiguration;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Component;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultOrgSignupOidcConfigurationService
@@ -26,7 +26,7 @@ public class DefaultOrgSignupOidcConfigurationService
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(OrgSignupOidcConfiguration entity) {
+    protected Future<Void> beforeSave(OrgSignupOidcConfiguration entity) {
         Validate.notNull(entity.getName(), "OrgSignupOidcConfiguration name cannot be null");
         Validate.notNull(entity.getProvider(), "OrgSignupOidcConfiguration provider cannot be null");
         if (entity.getId() == null) {
@@ -34,16 +34,16 @@ public class DefaultOrgSignupOidcConfigurationService
             entity.setCreated(new Date());
         }
         entity.setUpdated(new Date());
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<List<OrgSignupOidcConfiguration>> findAllEnabled() {
+    public Future<List<OrgSignupOidcConfiguration>> findAllEnabled() {
         return signupRepository.findAllEnabled();
     }
 
     @Override
-    public CompletableFuture<OrgSignupOidcConfiguration> findEnabledByProvider(OidcProviderKind provider) {
+    public Future<OrgSignupOidcConfiguration> findEnabledByProvider(OidcProviderKind provider) {
         Validate.notNull(provider, "provider cannot be null");
         return signupRepository.findEnabledByProvider(provider);
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultParticipantIdentityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultParticipantIdentityService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -21,8 +22,8 @@ import org.kinotic.domain.api.utils.DomainUtil;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultParticipantIdentityService extends AbstractCrudService<ParticipantIdentity> implements ParticipantIdentityService {
@@ -44,7 +45,7 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(ParticipantIdentity entity) {
+    protected Future<Void> beforeSave(ParticipantIdentity entity) {
         validateScopeFields(entity);
         if (entity.getId() == null) {
             entity.setId(UUID.randomUUID().toString());
@@ -71,7 +72,7 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
                 Validate.isTrue(machine.getAuthType() == AuthType.CLIENT_CREDENTIALS,
                                 "MACHINE authType must be CLIENT_CREDENTIALS");
                 // the machine's id is its client_id, so uniqueness is the id's own
-                yield CompletableFuture.completedFuture(null);
+                yield Future.succeededFuture();
             }
         };
     }
@@ -101,15 +102,16 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
      * {@code (email, organizationId, applicationId)}. Self-id is excluded so updating an
      * existing user doesn't trip on its own row.
      */
-    private CompletableFuture<Void> enforceUniqueEmailInScope(UserParticipantIdentity entity) {
+    private Future<Void> enforceUniqueEmailInScope(UserParticipantIdentity entity) {
         return findByEmail(entity.getEmail(), entity.getOrganizationId(), entity.getApplicationId())
-                .thenAccept(existing -> {
+                .compose(existing -> {
                     if (existing != null && !existing.getId().equals(entity.getId())) {
                         throw new IllegalArgumentException(
                                 "ParticipantIdentity with email " + entity.getEmail()
                                         + " already exists in scope "
                                         + DomainUtil.describeScope(entity.getOrganizationId(), entity.getApplicationId()));
                     }
+                    return Future.succeededFuture();
                 });
     }
 
@@ -118,14 +120,15 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
      * {@code (ownerId, clientKey)}. Self-id is excluded so updating an existing delegate
      * doesn't trip on its own row.
      */
-    private CompletableFuture<Void> enforceUniqueClientKeyForOwner(DelegatingParticipantIdentity entity) {
+    private Future<Void> enforceUniqueClientKeyForOwner(DelegatingParticipantIdentity entity) {
         return identityRepository.findByOwnerAndClientKey(entity.getOwnerId(), entity.getClientKey())
-                .thenAccept(existing -> {
+                .compose(existing -> {
                     if (existing != null && !existing.getId().equals(entity.getId())) {
                         throw new IllegalArgumentException(
                                 "DELEGATE with clientKey " + entity.getClientKey()
                                         + " already exists for owner " + entity.getOwnerId());
                     }
+                    return Future.succeededFuture();
                 });
     }
 
@@ -141,34 +144,34 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
      * Persists the hash of {@code secret} as the sole credential of the identity, replacing
      * any prior one.
      */
-    private CompletableFuture<IdentityCredential> saveCredential(String identityId, String secret) {
+    private Future<IdentityCredential> saveCredential(String identityId, String secret) {
         return credentialRepository.save(new IdentityCredential()
                 .setId(identityId)
                 .setSecretHash(DomainUtil.hashPassword(secret)));
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> findByEmail(String email, String organizationId, String applicationId) {
+    public Future<UserParticipantIdentity> findByEmail(String email, String organizationId, String applicationId) {
         return identityRepository.findByEmail(email, organizationId, applicationId);
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> findFirstOrgUserByEmail(String email) {
+    public Future<UserParticipantIdentity> findFirstOrgUserByEmail(String email) {
         Validate.notBlank(email, "email cannot be blank");
         return identityRepository.findFirstOrgUserByEmail(email);
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> findByEmail(String email) {
+    public Future<UserParticipantIdentity> findByEmail(String email) {
         Validate.notBlank(email, "email cannot be blank");
         return identityRepository.findByEmail(email);
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> findByOidcIdentity(String oidcSubject,
-                                                         String oidcConfigId,
-                                                         String organizationId,
-                                                         String applicationId) {
+    public Future<UserParticipantIdentity> findByOidcIdentity(String oidcSubject,
+                                                              String oidcConfigId,
+                                                              String organizationId,
+                                                              String applicationId) {
         Validate.notBlank(oidcSubject, "oidcSubject cannot be blank");
         Validate.notBlank(oidcConfigId, "oidcConfigId cannot be blank");
         requireOrgWithApp(organizationId, applicationId);
@@ -176,29 +179,29 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> findOrgUserByOidcIdentity(String oidcSubject, String oidcConfigId) {
+    public Future<UserParticipantIdentity> findOrgUserByOidcIdentity(String oidcSubject, String oidcConfigId) {
         Validate.notBlank(oidcSubject, "oidcSubject cannot be blank");
         Validate.notBlank(oidcConfigId, "oidcConfigId cannot be blank");
         return identityRepository.findOrgUserByOidcIdentity(oidcSubject, oidcConfigId);
     }
 
     @Override
-    public CompletableFuture<Page<UserParticipantIdentity>> findUsersByScope(String organizationId, String applicationId, Pageable pageable) {
+    public Future<Page<UserParticipantIdentity>> findUsersByScope(String organizationId, String applicationId, Pageable pageable) {
         requireOrgWithApp(organizationId, applicationId);
         return identityRepository.findUsersByScope(organizationId, applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<Page<UserParticipantIdentity>> searchUsersByScope(String searchText,
-                                                          String organizationId,
-                                                          String applicationId,
-                                                          Pageable pageable) {
+    public Future<Page<UserParticipantIdentity>> searchUsersByScope(String searchText,
+                                                                    String organizationId,
+                                                                    String applicationId,
+                                                                    Pageable pageable) {
         requireOrgWithApp(organizationId, applicationId);
         return identityRepository.searchUsersByScope(searchText, organizationId, applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> createUser(UserParticipantIdentity user, String password) {
+    public Future<UserParticipantIdentity> createUser(UserParticipantIdentity user, String password) {
         Validate.notNull(user.getEmail(), "UserParticipantIdentity email cannot be null");
         validateScopeFields(user);
 
@@ -216,13 +219,13 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
         }
 
         return applyTenantPolicy(user)
-                .thenCompose(this::save)
-                .thenApply(UserParticipantIdentity.class::cast)
-                .thenCompose(savedUser -> {
+                .compose(this::save)
+                .map(UserParticipantIdentity.class::cast)
+                .compose(savedUser -> {
                     if (password != null) {
-                        return saveCredential(savedUser.getId(), password).thenApply(c -> savedUser);
+                        return saveCredential(savedUser.getId(), password).map(savedUser);
                     }
-                    return CompletableFuture.completedFuture(savedUser);
+                    return Future.succeededFuture(savedUser);
                 });
     }
 
@@ -234,12 +237,12 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
      * createUser accepts caller-supplied ids of any shape; a dedicated UUID keeps tenant
      * identity decoupled from id semantics.
      */
-    private CompletableFuture<UserParticipantIdentity> applyTenantPolicy(UserParticipantIdentity user) {
+    private Future<UserParticipantIdentity> applyTenantPolicy(UserParticipantIdentity user) {
         if (user.getApplicationId() == null || user.getTenantId() != null) {
-            return CompletableFuture.completedFuture(user);
+            return Future.succeededFuture(user);
         }
         return applicationRepository.findById(user.getApplicationId(), user.getOrganizationId())
-                .thenApply(app -> {
+                .map(app -> {
                     if (app == null) {
                         throw new IllegalArgumentException(
                                 "Application " + user.getApplicationId() + " not found in organization "
@@ -253,38 +256,38 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
     }
 
 //    @Override // commented off the interface — kept for the eventual user-management UI
-    public CompletableFuture<Void> changePassword(String identityId, String currentPassword, String newPassword) {
+    public Future<Void> changePassword(String identityId, String currentPassword, String newPassword) {
         Validate.notNull(identityId, "identityId cannot be null");
         Validate.notNull(currentPassword, "currentPassword cannot be null");
         Validate.notNull(newPassword, "newPassword cannot be null");
 
         return credentialRepository.findById(identityId)
-                .thenCompose(credential -> {
+                .compose(credential -> {
                     if (credential == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("No credential found for user " + identityId));
                     }
                     if (!DomainUtil.verifyPassword(currentPassword, credential.getSecretHash())) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Current password is incorrect"));
                     }
-                    return saveCredential(identityId, newPassword).thenApply(c -> (Void) null);
+                    return saveCredential(identityId, newPassword).mapEmpty();
                 });
     }
 
 //    @Override
-    public CompletableFuture<Void> resetPassword(String identityId, String newPassword) {
+    public Future<Void> resetPassword(String identityId, String newPassword) {
         Validate.notNull(identityId, "identityId cannot be null");
         Validate.notNull(newPassword, "newPassword cannot be null");
 
-        return saveCredential(identityId, newPassword).thenApply(c -> null);
+        return saveCredential(identityId, newPassword).mapEmpty();
     }
 
     @Override
-    public CompletableFuture<DelegatingParticipantIdentity> findOrCreateDelegate(UserParticipantIdentity owner,
-                                                                                 DelegateKind kind,
-                                                                                 String clientKey,
-                                                                                 String displayName) {
+    public Future<DelegatingParticipantIdentity> findOrCreateDelegate(UserParticipantIdentity owner,
+                                                                      DelegateKind kind,
+                                                                      String clientKey,
+                                                                      String displayName) {
         Validate.notNull(owner, "owner is required");
         Validate.notBlank(owner.getId(), "owner id is required");
         Validate.notNull(kind, "kind is required");
@@ -292,7 +295,7 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
         Validate.notBlank(displayName, "displayName is required");
 
         return identityRepository.findByOwnerAndClientKey(owner.getId(), clientKey)
-                .thenCompose(existing -> {
+                .compose(existing -> {
                     DelegatingParticipantIdentity delegate;
                     if (existing != null) {
                         delegate = existing;
@@ -313,17 +316,17 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
                     delegate.setEnabled(true);
                     // sync so the (ownerId, clientKey) uniqueness search sees this write before
                     // the next approval of the same client can run
-                    return saveSync(delegate).thenApply(DelegatingParticipantIdentity.class::cast);
+                    return saveSync(delegate).map(DelegatingParticipantIdentity.class::cast);
                 });
     }
 
     @Override
-    public CompletableFuture<Page<DelegatingParticipantIdentity>> findDelegatesByOwner(String ownerId, Pageable pageable) {
+    public Future<Page<DelegatingParticipantIdentity>> findDelegatesByOwner(String ownerId, Pageable pageable) {
         return identityRepository.findDelegatesByOwner(ownerId, pageable);
     }
 
     @Override
-    public CompletableFuture<MachineProvisionResult> createMachine(MachineParticipantIdentity machine) {
+    public Future<MachineProvisionResult> createMachine(MachineParticipantIdentity machine) {
         Validate.notNull(machine, "machine is required");
 
         Date now = new Date();
@@ -336,43 +339,43 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
 
         // sync so the console's immediate re-query lists the new machine
         return saveSync(machine)
-                .thenApply(MachineParticipantIdentity.class::cast)
-                .thenCompose(saved -> saveCredential(saved.getId(), clientSecret)
-                        .thenApply(c -> new MachineProvisionResult(saved, clientSecret)));
+                .map(MachineParticipantIdentity.class::cast)
+                .compose(saved -> saveCredential(saved.getId(), clientSecret)
+                        .map(new MachineProvisionResult(saved, clientSecret)));
     }
 
     @Override
-    public CompletableFuture<Page<MachineParticipantIdentity>> findMachinesByScope(String organizationId, String applicationId, Pageable pageable) {
+    public Future<Page<MachineParticipantIdentity>> findMachinesByScope(String organizationId, String applicationId, Pageable pageable) {
         requireOrgWithApp(organizationId, applicationId);
         return identityRepository.findMachinesByScope(organizationId, applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<String> rotateMachineSecret(String machineId) {
+    public Future<String> rotateMachineSecret(String machineId) {
         Validate.notBlank(machineId, "machineId is required");
         return findById(machineId)
-                .thenCompose(identity -> {
+                .compose(identity -> {
                     if (!(identity instanceof MachineParticipantIdentity)) {
                         throw new IllegalArgumentException("Machine not found.");
                     }
                     String clientSecret = DomainUtil.generateUrlSafeToken(MACHINE_SECRET_BYTES);
-                    return saveCredential(identity.getId(), clientSecret).thenApply(c -> clientSecret);
+                    return saveCredential(identity.getId(), clientSecret).map(clientSecret);
                 });
     }
 
     @Override
-    public CompletableFuture<MachineParticipantIdentity> verifyMachineCredentials(String machineId, String clientSecret) {
+    public Future<MachineParticipantIdentity> verifyMachineCredentials(String machineId, String clientSecret) {
         Validate.notBlank(machineId, "machineId is required");
         Validate.notBlank(clientSecret, "clientSecret is required");
 
         return findById(machineId)
-                .thenCompose(identity -> {
+                .compose(identity -> {
                     // one generic failure for every miss — no oracle for which check failed
                     if (!(identity instanceof MachineParticipantIdentity machine) || !machine.isEnabled()) {
                         throw new IllegalArgumentException("Invalid client credentials");
                     }
                     return credentialRepository.findById(machine.getId())
-                            .thenApply(credential -> {
+                            .map(credential -> {
                                 if (credential == null
                                         || !DomainUtil.verifyPassword(clientSecret, credential.getSecretHash())) {
                                     throw new IllegalArgumentException("Invalid client credentials");
@@ -383,18 +386,18 @@ public class DefaultParticipantIdentityService extends AbstractCrudService<Parti
     }
 
     @Override
-    protected CompletableFuture<Void> beforeDelete(String id) {
+    protected Future<Void> beforeDelete(String id) {
         // Cascade the IdentityCredential. Credential lookups are by id (realtime GETs), so the
         // credential delete never needs to wait for search visibility.
         // Delegates owned by the deleted identity go with it — a delegate must not outlive
         // the authority it wields (resolveParticipant would reject it anyway; this is hygiene).
         return credentialRepository.deleteById(id)
-                .thenCompose(v -> identityRepository.findDelegatesByOwner(id, Pageable.create(0, 1000, Sort.by("created"))))
-                .thenCompose(delegates -> {
-                    CompletableFuture<?>[] deletes = delegates.getContent().stream()
+                .compose(v -> identityRepository.findDelegatesByOwner(id, Pageable.create(0, 1000, Sort.by("created"))))
+                .compose(delegates -> {
+                    List<Future<Void>> deletes = delegates.getContent().stream()
                             .map(delegate -> deleteById(delegate.getId()))
-                            .toArray(CompletableFuture[]::new);
-                    return CompletableFuture.allOf(deletes);
+                            .toList();
+                    return Future.all(deletes).mapEmpty();
                 });
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultRefreshTokenService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultRefreshTokenService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -17,7 +18,6 @@ import org.springframework.stereotype.Component;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 @Slf4j
@@ -35,20 +35,19 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
     private final ParticipantIdentityRepository identityRepository;
 
     @Override
-    public CompletableFuture<String> issue(String identityId, KinoticAudience audience, String label) {
+    public Future<String> issue(String identityId, KinoticAudience audience, String label) {
         Validate.notBlank(identityId, "identityId is required");
         Validate.notNull(audience, "audience is required");
         return mint(identityId, UUID.randomUUID().toString(), audience, StringUtils.trimToNull(label))
-                .thenApply(Minted::plaintext);
+                .map(Minted::plaintext);
     }
 
     @Override
-    public CompletableFuture<List<DelegateSession>> findActiveSessions(String identityId) {
+    public Future<List<DelegateSession>> findActiveSessions(String identityId) {
         Validate.notBlank(identityId, "identityId is required");
         Date now = new Date();
         return refreshTokenRepository.findActiveByIdentityId(identityId)
-                .toCompletionStage().toCompletableFuture()
-                .thenApply(tokens -> tokens.stream()
+                .map(tokens -> tokens.stream()
                         .filter(t -> t.getExpiresAt().after(now))
                         .map(t -> new DelegateSession(t.getFamilyId(), t.getLabel(),
                                                       t.getCreated(), t.getExpiresAt()))
@@ -56,80 +55,74 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
     }
 
     @Override
-    public CompletableFuture<Void> revokeFamily(String identityId, String familyId) {
+    public Future<Void> revokeFamily(String identityId, String familyId) {
         Validate.notBlank(identityId, "identityId is required");
         Validate.notBlank(familyId, "familyId is required");
         // identity scoping over every row: a family id from another identity's
         // lineage revokes nothing
-        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId)
-                                                    .toCompletionStage().toCompletableFuture(),
+        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId),
                               t -> identityId.equals(t.getIdentityId()));
     }
 
     @Override
-    public CompletableFuture<Void> revokeAllFor(String identityId) {
+    public Future<Void> revokeAllFor(String identityId) {
         Validate.notBlank(identityId, "identityId is required");
-        return revokeMatching(refreshTokenRepository.findActiveByIdentityId(identityId)
-                                                    .toCompletionStage().toCompletableFuture(),
+        return revokeMatching(refreshTokenRepository.findActiveByIdentityId(identityId),
                               t -> true);
     }
 
     @Override
-    public CompletableFuture<RefreshTokenRotation> rotate(String token) {
+    public Future<RefreshTokenRotation> rotate(String token) {
         Validate.notBlank(token, "token is required");
         return refreshTokenRepository.findByTokenHash(DomainUtil.sha256Hex(token))
-                                     .toCompletionStage().toCompletableFuture()
-                                     .thenCompose(this::rotateExisting);
+                                     .compose(this::rotateExisting);
     }
 
-    private CompletableFuture<RefreshTokenRotation> rotateExisting(RefreshToken current) {
+    private Future<RefreshTokenRotation> rotateExisting(RefreshToken current) {
         if (current == null) {
-            return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown refresh token"));
+            return Future.failedFuture(new IllegalArgumentException("Unknown refresh token"));
         }
         if (current.isRevoked()) {
             // Reuse of an already-rotated token — the lineage is compromised; revoke it entirely.
             log.warn("Refresh token reuse detected for family {}; revoking the whole family", current.getFamilyId());
             return revokeFamily(current.getFamilyId())
-                    .thenCompose(v -> CompletableFuture.failedFuture(
+                    .compose(v -> Future.failedFuture(
                             new IllegalArgumentException("Refresh token reuse detected")));
         }
         if (current.getExpiresAt().before(new Date())) {
-            return CompletableFuture.failedFuture(new IllegalArgumentException("Refresh token has expired"));
+            return Future.failedFuture(new IllegalArgumentException("Refresh token has expired"));
         }
         if (current.getAudience() == null) {
             // mint() stamps every lineage, so this is a corrupted record; failing beats guessing an
             // audience, which would hand the replacement a surface the lineage never covered
             log.error("Refresh token {} in family {} has no audience", current.getId(), current.getFamilyId());
-            return CompletableFuture.failedFuture(new IllegalStateException("Refresh token has no audience"));
+            return Future.failedFuture(new IllegalStateException("Refresh token has no audience"));
         }
         return identityRepository.findById(current.getIdentityId())
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(identity -> {
+                .compose(identity -> {
                     if (identity == null || !identity.isEnabled()) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Refresh token identity is missing or disabled"));
                     }
                     // Mint the replacement before revoking the current token so a failure mid-rotation
                     // never leaves the client without a usable token.
                     return mint(current.getIdentityId(), current.getFamilyId(), current.getAudience(),
                                 current.getLabel())
-                            .thenCompose(minted -> {
+                            .compose(minted -> {
                                 current.setRevoked(true)
                                        .setLastUsedAt(new Date())
                                        .setReplacedById(minted.record().getId());
                                 return refreshTokenRepository.saveSync(current)
-                                        .toCompletionStage().toCompletableFuture()
-                                        .thenApply(v -> new RefreshTokenRotation(identity, minted.plaintext(),
-                                                                                  current.getAudience()));
+                                        .map(new RefreshTokenRotation(identity, minted.plaintext(),
+                                                                      current.getAudience()));
                             });
                 });
     }
 
     // unscoped by design: reuse detection already proved the lineage compromised, so the
     // whole family dies regardless of which identity its rows carry
-    private CompletableFuture<Void> revokeFamily(String familyId) {
-        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId)
-                                                    .toCompletionStage().toCompletableFuture(),
+    private Future<Void> revokeFamily(String familyId) {
+        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId),
                               t -> true);
     }
 
@@ -138,19 +131,18 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
      * revoked. The scope predicate is the security-relevant part of every revocation — each
      * caller states its own.
      */
-    private CompletableFuture<Void> revokeMatching(CompletableFuture<List<RefreshToken>> tokens,
-                                                   Predicate<RefreshToken> scope) {
-        return tokens.thenCompose(list -> {
-            CompletableFuture<?>[] saves = list.stream()
+    private Future<Void> revokeMatching(Future<List<RefreshToken>> tokens,
+                                        Predicate<RefreshToken> scope) {
+        return tokens.compose(list -> {
+            List<Future<RefreshToken>> saves = list.stream()
                     .filter(t -> !t.isRevoked() && scope.test(t))
-                    .map(t -> refreshTokenRepository.saveSync(t.setRevoked(true))
-                                                    .toCompletionStage().toCompletableFuture())
-                    .toArray(CompletableFuture[]::new);
-            return CompletableFuture.allOf(saves);
+                    .map(t -> refreshTokenRepository.saveSync(t.setRevoked(true)))
+                    .toList();
+            return Future.all(saves).mapEmpty();
         });
     }
 
-    private CompletableFuture<Minted> mint(String identityId, String familyId, KinoticAudience audience, String label) {
+    private Future<Minted> mint(String identityId, String familyId, KinoticAudience audience, String label) {
         String plaintext = DomainUtil.generateUrlSafeToken(TOKEN_BYTES);
         Date now = new Date();
         RefreshToken record = new RefreshToken()
@@ -164,8 +156,7 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
                 .setExpiresAt(new Date(now.getTime() + TOKEN_TTL_MS))
                 .setRevoked(false);
         return refreshTokenRepository.saveSync(record)
-                                     .toCompletionStage().toCompletableFuture()
-                                     .thenApply(saved -> new Minted(record, plaintext));
+                                     .map(new Minted(record, plaintext));
     }
 
     /** A persisted {@link RefreshToken} paired with its plaintext, which exists only at mint time. */

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultRefreshTokenService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultRefreshTokenService.java
@@ -47,6 +47,7 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
         Validate.notBlank(identityId, "identityId is required");
         Date now = new Date();
         return refreshTokenRepository.findActiveByIdentityId(identityId)
+                .toCompletionStage().toCompletableFuture()
                 .thenApply(tokens -> tokens.stream()
                         .filter(t -> t.getExpiresAt().after(now))
                         .map(t -> new DelegateSession(t.getFamilyId(), t.getLabel(),
@@ -60,20 +61,24 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
         Validate.notBlank(familyId, "familyId is required");
         // identity scoping over every row: a family id from another identity's
         // lineage revokes nothing
-        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId),
+        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId)
+                                                    .toCompletionStage().toCompletableFuture(),
                               t -> identityId.equals(t.getIdentityId()));
     }
 
     @Override
     public CompletableFuture<Void> revokeAllFor(String identityId) {
         Validate.notBlank(identityId, "identityId is required");
-        return revokeMatching(refreshTokenRepository.findActiveByIdentityId(identityId), t -> true);
+        return revokeMatching(refreshTokenRepository.findActiveByIdentityId(identityId)
+                                                    .toCompletionStage().toCompletableFuture(),
+                              t -> true);
     }
 
     @Override
     public CompletableFuture<RefreshTokenRotation> rotate(String token) {
         Validate.notBlank(token, "token is required");
         return refreshTokenRepository.findByTokenHash(DomainUtil.sha256Hex(token))
+                                     .toCompletionStage().toCompletableFuture()
                                      .thenCompose(this::rotateExisting);
     }
 
@@ -98,6 +103,7 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
             return CompletableFuture.failedFuture(new IllegalStateException("Refresh token has no audience"));
         }
         return identityRepository.findById(current.getIdentityId())
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(identity -> {
                     if (identity == null || !identity.isEnabled()) {
                         return CompletableFuture.failedFuture(
@@ -112,6 +118,7 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
                                        .setLastUsedAt(new Date())
                                        .setReplacedById(minted.record().getId());
                                 return refreshTokenRepository.saveSync(current)
+                                        .toCompletionStage().toCompletableFuture()
                                         .thenApply(v -> new RefreshTokenRotation(identity, minted.plaintext(),
                                                                                   current.getAudience()));
                             });
@@ -121,7 +128,9 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
     // unscoped by design: reuse detection already proved the lineage compromised, so the
     // whole family dies regardless of which identity its rows carry
     private CompletableFuture<Void> revokeFamily(String familyId) {
-        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId), t -> true);
+        return revokeMatching(refreshTokenRepository.findByFamilyId(familyId)
+                                                    .toCompletionStage().toCompletableFuture(),
+                              t -> true);
     }
 
     /**
@@ -134,7 +143,8 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
         return tokens.thenCompose(list -> {
             CompletableFuture<?>[] saves = list.stream()
                     .filter(t -> !t.isRevoked() && scope.test(t))
-                    .map(t -> refreshTokenRepository.saveSync(t.setRevoked(true)))
+                    .map(t -> refreshTokenRepository.saveSync(t.setRevoked(true))
+                                                    .toCompletionStage().toCompletableFuture())
                     .toArray(CompletableFuture[]::new);
             return CompletableFuture.allOf(saves);
         });
@@ -153,7 +163,9 @@ public class DefaultRefreshTokenService implements RefreshTokenService {
                 .setCreated(now)
                 .setExpiresAt(new Date(now.getTime() + TOKEN_TTL_MS))
                 .setRevoked(false);
-        return refreshTokenRepository.saveSync(record).thenApply(saved -> new Minted(record, plaintext));
+        return refreshTokenRepository.saveSync(record)
+                                     .toCompletionStage().toCompletableFuture()
+                                     .thenApply(saved -> new Minted(record, plaintext));
     }
 
     /** A persisted {@link RefreshToken} paired with its plaintext, which exists only at mint time. */

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultSignUpService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultSignUpService.java
@@ -37,12 +37,14 @@ public class DefaultSignUpService implements SignUpService {
         Validate.notBlank(displayName, "Display name is required");
 
         return pendingSignUpRepository.findByEmail(email)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(existing -> {
                     if (existing != null) {
                         return CompletableFuture.failedFuture(new IllegalArgumentException(
                                 "A sign-up is already pending for this email. Check your inbox for the verification link."));
                     }
-                    return identityService.findFirstOrgUserByEmail(email);
+                    return identityService.findFirstOrgUserByEmail(email)
+                                          .toCompletionStage().toCompletableFuture();
                 })
                 .thenCompose(existingUser -> {
                     if (existingUser != null) {
@@ -60,6 +62,7 @@ public class DefaultSignUpService implements SignUpService {
                             .setCreated(now)
                             .setExpiresAt(new Date(now.getTime() + LOCAL_TTL_MS));
                     return pendingSignUpRepository.save(pending)
+                            .toCompletionStage().toCompletableFuture()
                             .thenCompose(saved -> emailService.sendVerificationEmail(email, displayName, token));
                 });
     }
@@ -76,7 +79,8 @@ public class DefaultSignUpService implements SignUpService {
                .setVerificationToken(UUID.randomUUID().toString())
                .setCreated(now)
                .setExpiresAt(new Date(now.getTime() + OIDC_TTL_MS));
-        return pendingSignUpRepository.saveSync(pending);
+        return pendingSignUpRepository.saveSync(pending)
+                                      .toCompletionStage().toCompletableFuture();
     }
 
     @Override
@@ -86,8 +90,10 @@ public class DefaultSignUpService implements SignUpService {
         Validate.notBlank(password, "Password is required");
 
         return pendingSignUpRepository.findValidByToken(token)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(pending -> createOrgWithAdmin(orgName, orgDescription, newUser(pending), password)
                         .thenCompose(savedAdmin -> pendingSignUpRepository.deleteById(pending.getId())
+                                .toCompletionStage().toCompletableFuture()
                                 .thenApply(v -> savedAdmin)));
     }
 
@@ -95,8 +101,10 @@ public class DefaultSignUpService implements SignUpService {
     public CompletableFuture<UserParticipantIdentity> completeOidcWithNewOrg(String token, String orgName, String orgDescription) {
         Validate.notBlank(orgName, "Organization name is required");
         return pendingSignUpRepository.findValidByToken(token)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(pending -> createOrgWithAdmin(orgName, orgDescription, newUser(pending), null)
                         .thenCompose(savedAdmin -> pendingSignUpRepository.deleteById(pending.getId())
+                                .toCompletionStage().toCompletableFuture()
                                 .thenApply(v -> savedAdmin)));
     }
 
@@ -108,12 +116,16 @@ public class DefaultSignUpService implements SignUpService {
     private CompletableFuture<UserParticipantIdentity> createOrgWithAdmin(String orgName, String orgDescription, UserParticipantIdentity admin, String password) {
         Organization org = new Organization().setName(orgName).setDescription(orgDescription);
         return organizationService.create(org)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(savedOrg -> {
                     admin.setOrganizationId(savedOrg.getId());
                     return identityService.createUser(admin, password)
+                            .toCompletionStage().toCompletableFuture()
                             .thenCompose(savedAdmin -> {
                                 savedOrg.setCreatedBy(savedAdmin.getId());
-                                return organizationService.save(savedOrg).thenApply(o -> savedAdmin);
+                                return organizationService.save(savedOrg)
+                                                          .toCompletionStage().toCompletableFuture()
+                                                          .thenApply(o -> savedAdmin);
                             });
                 });
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultSignUpService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/DefaultSignUpService.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
@@ -16,7 +17,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
@@ -32,23 +32,21 @@ public class DefaultSignUpService implements SignUpService {
     private final EmailService emailService;
 
     @Override
-    public CompletableFuture<Void> initiateLocalSignUp(String email, String displayName) {
+    public Future<Void> initiateLocalSignUp(String email, String displayName) {
         Validate.notBlank(email, "Email is required");
         Validate.notBlank(displayName, "Display name is required");
 
         return pendingSignUpRepository.findByEmail(email)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(existing -> {
+                .compose(existing -> {
                     if (existing != null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException(
+                        return Future.failedFuture(new IllegalArgumentException(
                                 "A sign-up is already pending for this email. Check your inbox for the verification link."));
                     }
-                    return identityService.findFirstOrgUserByEmail(email)
-                                          .toCompletionStage().toCompletableFuture();
+                    return identityService.findFirstOrgUserByEmail(email);
                 })
-                .thenCompose(existingUser -> {
+                .compose(existingUser -> {
                     if (existingUser != null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException(
+                        return Future.failedFuture(new IllegalArgumentException(
                                 "An account with this email already exists."));
                     }
                     String token = UUID.randomUUID().toString();
@@ -62,13 +60,12 @@ public class DefaultSignUpService implements SignUpService {
                             .setCreated(now)
                             .setExpiresAt(new Date(now.getTime() + LOCAL_TTL_MS));
                     return pendingSignUpRepository.save(pending)
-                            .toCompletionStage().toCompletableFuture()
-                            .thenCompose(saved -> emailService.sendVerificationEmail(email, displayName, token));
+                            .compose(saved -> emailService.sendVerificationEmail(email, displayName, token));
                 });
     }
 
     @Override
-    public CompletableFuture<PendingSignUp> createOidcPending(PendingSignUp pending) {
+    public Future<PendingSignUp> createOidcPending(PendingSignUp pending) {
         Validate.notBlank(pending.getOidcSubject(), "oidcSubject is required");
         Validate.notBlank(pending.getOidcConfigId(), "oidcConfigId is required");
         Validate.notBlank(pending.getEmail(), "email is required");
@@ -79,33 +76,28 @@ public class DefaultSignUpService implements SignUpService {
                .setVerificationToken(UUID.randomUUID().toString())
                .setCreated(now)
                .setExpiresAt(new Date(now.getTime() + OIDC_TTL_MS));
-        return pendingSignUpRepository.saveSync(pending)
-                                      .toCompletionStage().toCompletableFuture();
+        return pendingSignUpRepository.saveSync(pending);
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> completeLocalSignUp(String token, String orgName, String orgDescription, String password) {
+    public Future<UserParticipantIdentity> completeLocalSignUp(String token, String orgName, String orgDescription, String password) {
         Validate.notBlank(token, "Verification token is required");
         Validate.notBlank(orgName, "Organization name is required");
         Validate.notBlank(password, "Password is required");
 
         return pendingSignUpRepository.findValidByToken(token)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(pending -> createOrgWithAdmin(orgName, orgDescription, newUser(pending), password)
-                        .thenCompose(savedAdmin -> pendingSignUpRepository.deleteById(pending.getId())
-                                .toCompletionStage().toCompletableFuture()
-                                .thenApply(v -> savedAdmin)));
+                .compose(pending -> createOrgWithAdmin(orgName, orgDescription, newUser(pending), password)
+                        .compose(savedAdmin -> pendingSignUpRepository.deleteById(pending.getId())
+                                .map(savedAdmin)));
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> completeOidcWithNewOrg(String token, String orgName, String orgDescription) {
+    public Future<UserParticipantIdentity> completeOidcWithNewOrg(String token, String orgName, String orgDescription) {
         Validate.notBlank(orgName, "Organization name is required");
         return pendingSignUpRepository.findValidByToken(token)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(pending -> createOrgWithAdmin(orgName, orgDescription, newUser(pending), null)
-                        .thenCompose(savedAdmin -> pendingSignUpRepository.deleteById(pending.getId())
-                                .toCompletionStage().toCompletableFuture()
-                                .thenApply(v -> savedAdmin)));
+                .compose(pending -> createOrgWithAdmin(orgName, orgDescription, newUser(pending), null)
+                        .compose(savedAdmin -> pendingSignUpRepository.deleteById(pending.getId())
+                                .map(savedAdmin)));
     }
 
     /**
@@ -113,19 +105,16 @@ public class DefaultSignUpService implements SignUpService {
      * member and creator. The admin (and its credential, when {@code password} is non-null) is
      * created through {@link ParticipantIdentityService#createUser} so member creation has a single code path.
      */
-    private CompletableFuture<UserParticipantIdentity> createOrgWithAdmin(String orgName, String orgDescription, UserParticipantIdentity admin, String password) {
+    private Future<UserParticipantIdentity> createOrgWithAdmin(String orgName, String orgDescription, UserParticipantIdentity admin, String password) {
         Organization org = new Organization().setName(orgName).setDescription(orgDescription);
         return organizationService.create(org)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(savedOrg -> {
+                .compose(savedOrg -> {
                     admin.setOrganizationId(savedOrg.getId());
                     return identityService.createUser(admin, password)
-                            .toCompletionStage().toCompletableFuture()
-                            .thenCompose(savedAdmin -> {
+                            .compose(savedAdmin -> {
                                 savedOrg.setCreatedBy(savedAdmin.getId());
                                 return organizationService.save(savedOrg)
-                                                          .toCompletionStage().toCompletableFuture()
-                                                          .thenApply(o -> savedAdmin);
+                                                          .map(savedAdmin);
                             });
                 });
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
@@ -146,19 +146,18 @@ public class KinoticSecurityService implements SecurityService {
             return Future.failedFuture(new AuthenticationException(
                     "clientId and clientSecret headers are required for credential authentication"));
         }
-        return Future.fromCompletionStage(identityService.verifyMachineCredentials(clientId, clientSecret),
-                                          vertx.getOrCreateContext())
-                     .compose(machine -> {
-                         Future<Participant> ret;
-                         if ((organizationId != null && !organizationId.equals(machine.getOrganizationId()))
-                                 || (applicationId != null && !applicationId.equals(machine.getApplicationId()))) {
-                             ret = Future.failedFuture(new AuthenticationException("Invalid credentials"));
-                         } else {
-                             ret = Future.succeededFuture(DomainUtil.createParticipant(machine));
-                         }
-                         return ret;
-                     })
-                     .recover(err -> Future.failedFuture(new AuthenticationException("Invalid credentials")));
+        return identityService.verifyMachineCredentials(clientId, clientSecret)
+                              .compose(machine -> {
+                                  Future<Participant> ret;
+                                  if ((organizationId != null && !organizationId.equals(machine.getOrganizationId()))
+                                          || (applicationId != null && !applicationId.equals(machine.getApplicationId()))) {
+                                      ret = Future.failedFuture(new AuthenticationException("Invalid credentials"));
+                                  } else {
+                                      ret = Future.succeededFuture(DomainUtil.createParticipant(machine));
+                                  }
+                                  return ret;
+                              })
+                              .recover(err -> Future.failedFuture(new AuthenticationException("Invalid credentials")));
     }
 
     /**
@@ -189,50 +188,49 @@ public class KinoticSecurityService implements SecurityService {
     }
 
     private Future<Participant> resolveParticipant(String sub, String jwtOrgId, String jwtAppId) {
-        return Future.fromCompletionStage(identityService.findById(sub), vertx.getOrCreateContext())
-                     .recover(err -> Future.failedFuture(new AuthenticationException("User lookup failed", err)))
-                     .compose(identity -> {
-                         Future<Participant> ret;
-                         if (identity == null) {
-                             ret = Future.failedFuture(new AuthenticationException("No user for sub " + sub));
-                         } else if (!identity.isEnabled()) {
-                             ret = Future.failedFuture(new AuthenticationException("User account is disabled"));
-                         } else if (!Objects.equals(identity.getOrganizationId(), jwtOrgId)
-                                 || !Objects.equals(identity.getApplicationId(), jwtAppId)) {
-                             // the user was moved or re-scoped after the token was minted, so the
-                             // signed claims no longer describe the authority the record grants.
-                             // The scopes stay in the log; the caller gets no ids back.
-                             log.warn("JWT scope {} does not match scope {} of user {}",
-                                      DomainUtil.describeScope(jwtOrgId, jwtAppId),
-                                      DomainUtil.describeScope(identity.getOrganizationId(), identity.getApplicationId()),
-                                      sub);
-                             ret = Future.failedFuture(new AuthenticationException("JWT scope does not match user scope"));
-                         } else if (identity instanceof DelegatingParticipantIdentity delegate) {
-                             // a delegate wields its owner's authority, so revoking the owner
-                             // revokes every delegate on the next request, with no cascade to miss
-                             ret = requireEnabledOwner(delegate)
-                                     .map(v -> DomainUtil.createParticipant(delegate));
-                         } else {
-                             ret = Future.succeededFuture(DomainUtil.createParticipant(identity));
-                         }
-                         return ret;
-                     });
+        return identityService.findById(sub)
+                              .recover(err -> Future.failedFuture(new AuthenticationException("User lookup failed", err)))
+                              .compose(identity -> {
+                                  Future<Participant> ret;
+                                  if (identity == null) {
+                                      ret = Future.failedFuture(new AuthenticationException("No user for sub " + sub));
+                                  } else if (!identity.isEnabled()) {
+                                      ret = Future.failedFuture(new AuthenticationException("User account is disabled"));
+                                  } else if (!Objects.equals(identity.getOrganizationId(), jwtOrgId)
+                                          || !Objects.equals(identity.getApplicationId(), jwtAppId)) {
+                                      // the user was moved or re-scoped after the token was minted, so the
+                                      // signed claims no longer describe the authority the record grants.
+                                      // The scopes stay in the log; the caller gets no ids back.
+                                      log.warn("JWT scope {} does not match scope {} of user {}",
+                                               DomainUtil.describeScope(jwtOrgId, jwtAppId),
+                                               DomainUtil.describeScope(identity.getOrganizationId(), identity.getApplicationId()),
+                                               sub);
+                                      ret = Future.failedFuture(new AuthenticationException("JWT scope does not match user scope"));
+                                  } else if (identity instanceof DelegatingParticipantIdentity delegate) {
+                                      // a delegate wields its owner's authority, so revoking the owner
+                                      // revokes every delegate on the next request, with no cascade to miss
+                                      ret = requireEnabledOwner(delegate)
+                                              .map(v -> DomainUtil.createParticipant(delegate));
+                                  } else {
+                                      ret = Future.succeededFuture(DomainUtil.createParticipant(identity));
+                                  }
+                                  return ret;
+                              });
     }
 
     private Future<Void> requireEnabledOwner(DelegatingParticipantIdentity delegate) {
-        return Future.fromCompletionStage(identityService.findById(delegate.getOwnerId()),
-                                          vertx.getOrCreateContext())
-                     .recover(err -> Future.failedFuture(new AuthenticationException("Owner lookup failed", err)))
-                     .compose(owner -> {
-                         Future<Void> ret;
-                         if (owner == null || !owner.isEnabled()) {
-                             log.warn("Delegate {} rejected: owner {} is missing or disabled",
-                                      delegate.getId(), delegate.getOwnerId());
-                             ret = Future.failedFuture(new AuthenticationException("Delegate owner is not available"));
-                         } else {
-                             ret = Future.succeededFuture();
-                         }
-                         return ret;
-                     });
+        return identityService.findById(delegate.getOwnerId())
+                              .recover(err -> Future.failedFuture(new AuthenticationException("Owner lookup failed", err)))
+                              .compose(owner -> {
+                                  Future<Void> ret;
+                                  if (owner == null || !owner.isEnabled()) {
+                                      log.warn("Delegate {} rejected: owner {} is missing or disabled",
+                                               delegate.getId(), delegate.getOwnerId());
+                                      ret = Future.failedFuture(new AuthenticationException("Delegate owner is not available"));
+                                  } else {
+                                      ret = Future.succeededFuture();
+                                  }
+                                  return ret;
+                              });
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
@@ -1,7 +1,6 @@
 package org.kinotic.domain.internal.api.services.security;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,7 +57,6 @@ public class KinoticSecurityService implements SecurityService {
     private final ParticipantIdentityService identityService;
     private final LocalAuthenticationService localAuthenticationService;
     private final KinoticJwtIssuer jwtIssuer;
-    private final Vertx vertx;
 
     @Override
     public Future<Participant> authenticate(Map<String, String> authenticationInfo) {
@@ -118,9 +116,7 @@ public class KinoticSecurityService implements SecurityService {
             return Future.failedFuture(new AuthenticationException("clientId and clientSecret headers are required for credential authentication"));
         }
 
-        return Future.fromCompletionStage(localAuthenticationService.authenticateLocal(email, password,
-                                                                                       organizationId, applicationId),
-                                          vertx.getOrCreateContext())
+        return localAuthenticationService.authenticateLocal(email, password, organizationId, applicationId)
                      .compose(user -> {
                          Future<Participant> ret;
                          if (user == null) {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/config/SecretStorageConfiguration.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/config/SecretStorageConfiguration.java
@@ -1,5 +1,6 @@
 package org.kinotic.domain.internal.config;
 
+import io.vertx.core.Vertx;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.domain.api.config.KinoticDomainProperties;
 import org.kinotic.domain.api.config.SecretStorageProperties;
@@ -17,7 +18,7 @@ import java.io.IOException;
 public class SecretStorageConfiguration {
 
     @Bean
-    public SecretStorageBackend secretStorageBackend(KinoticDomainProperties properties) throws IOException {
+    public SecretStorageBackend secretStorageBackend(KinoticDomainProperties properties, Vertx vertx) throws IOException {
         SecretStorageProperties settings = properties.getDomain().getSecretStorage();
         if (settings == null || settings.getBackend() == null) {
             log.info("No secret storage backend configured, using in-memory storage");
@@ -25,7 +26,7 @@ public class SecretStorageConfiguration {
         }
         return switch (settings.getBackend()) {
             case HFT -> createChronicleMapBackend(settings);
-            case AZURE -> createAzureBackend(settings);
+            case AZURE -> createAzureBackend(settings, vertx);
         };
     }
 
@@ -34,8 +35,8 @@ public class SecretStorageConfiguration {
         return new ChronicleMapBackend(secretStorageProperties.getChronicleMap());
     }
 
-    private AzureKeyVaultBackend createAzureBackend(SecretStorageProperties settings) {
+    private AzureKeyVaultBackend createAzureBackend(SecretStorageProperties settings, Vertx vertx) {
         log.info("Using Azure Key Vault secret storage");
-        return new AzureKeyVaultBackend(settings.getAzure());
+        return new AzureKeyVaultBackend(settings.getAzure(), vertx);
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/mocks/MockProjectRepoProvisioner.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/mocks/MockProjectRepoProvisioner.java
@@ -1,13 +1,12 @@
 package org.kinotic.domain.mocks;
 
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.domain.api.model.Project;
 import org.kinotic.domain.api.model.RepositoryConnectionStatus;
 import org.kinotic.domain.api.services.ProjectRepoProvisioner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Fallback {@link ProjectRepoProvisioner} used when the GitHub module is disabled
@@ -26,7 +25,7 @@ public class MockProjectRepoProvisioner implements ProjectRepoProvisioner {
     private static final String FAKE_DEFAULT_BRANCH = "main";
 
     @Override
-    public CompletableFuture<Project> provision(Project project) {
+    public Future<Project> provision(Project project) {
         String repoName = project.getName() == null ? "unnamed" : project.getName();
         project.setRepoFullName(FAKE_OWNER + "/" + repoName);
         project.setRepoId(FAKE_REPO_ID);
@@ -34,12 +33,12 @@ public class MockProjectRepoProvisioner implements ProjectRepoProvisioner {
         project.setRepoConnectionStatus(RepositoryConnectionStatus.CONNECTED);
         log.debug("MockProjectRepoProvisioner stamped {} on project {}",
                   project.getRepoFullName(), project.getId());
-        return CompletableFuture.completedFuture(project);
+        return Future.succeededFuture(project);
     }
 
     @Override
-    public CompletableFuture<Project> reinitialize(Project project) {
+    public Future<Project> reinitialize(Project project) {
         project.setRepoConnectionStatus(RepositoryConnectionStatus.CONNECTED);
-        return CompletableFuture.completedFuture(project);
+        return Future.succeededFuture(project);
     }
 }

--- a/kinotic-domain/src/test/java/org/kinotic/domain/internal/api/services/DefaultOrganizationServiceTest.java
+++ b/kinotic-domain/src/test/java/org/kinotic/domain/internal/api/services/DefaultOrganizationServiceTest.java
@@ -23,7 +23,7 @@ class DefaultOrganizationServiceTest {
     void mintsIdFromSlugifiedName() {
         Organization organization = new Organization().setName("Acme Rockets");
 
-        service.beforeSave(organization).join();
+        service.beforeSave(organization).await();
 
         assertEquals("acme-rockets", organization.getId());
         assertNotNull(organization.getCreated());
@@ -33,7 +33,7 @@ class DefaultOrganizationServiceTest {
     void mintsLabelSafeIdsFromPunctuatedNames() {
         Organization organization = new Organization().setName("Acme Inc.");
 
-        service.beforeSave(organization).join();
+        service.beforeSave(organization).await();
 
         assertEquals("acme-inc", organization.getId());
     }
@@ -51,7 +51,7 @@ class DefaultOrganizationServiceTest {
     void allowsNamesNearTheReservedPrefix() {
         Organization organization = new Organization().setName("Kinetic Corp");
 
-        service.beforeSave(organization).join();
+        service.beforeSave(organization).await();
 
         assertEquals("kinetic-corp", organization.getId());
     }

--- a/kinotic-github/src/main/java/org/kinotic/github/api/services/GitHubAppInstallationService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/api/services/GitHubAppInstallationService.java
@@ -1,10 +1,9 @@
 package org.kinotic.github.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.github.api.model.GitHubAppInstallation;
 import org.kinotic.github.api.model.GitHubInstallCompletion;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service the frontend uses to drive GitHub-linking from the existing Kinotic
@@ -42,7 +41,7 @@ public interface GitHubAppInstallationService {
      *                 May carry query params (e.g. {@code /projects?openNewProject=1})
      *                 to signal "what to do on arrival" to the destination page. May be null.
      */
-    CompletableFuture<String> startInstall(String returnTo);
+    Future<String> startInstall(String returnTo);
 
     /**
      * Finalises the install once GitHub has redirected the browser back to the SPA
@@ -65,19 +64,19 @@ public interface GitHubAppInstallationService {
      *         doesn't match the caller's org, or when the authorizing GitHub user cannot
      *         access the claimed installation
      */
-    CompletableFuture<GitHubInstallCompletion> completeInstall(long installationId, String state, String code);
+    Future<GitHubInstallCompletion> completeInstall(long installationId, String state, String code);
 
     /**
      * Returns the installation bound to the caller's organization, or {@code null} if
      * GitHub is not yet linked. Drives the "linked / not linked" indicator in the
      * org-settings UI.
      */
-    CompletableFuture<GitHubAppInstallation> findForCurrentOrg();
+    Future<GitHubAppInstallation> findForCurrentOrg();
 
     /**
      * Removes the caller's organization's GitHub link, waiting for the removal to be visible
      * to {@link #findForCurrentOrg()} before completing. No-op when nothing is linked. The
      * organization can link again through {@link #startInstall(String)}.
      */
-    CompletableFuture<Void> unlink();
+    Future<Void> unlink();
 }

--- a/kinotic-github/src/main/java/org/kinotic/github/api/services/GitHubProjectRepoService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/api/services/GitHubProjectRepoService.java
@@ -1,8 +1,7 @@
 package org.kinotic.github.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.github.api.model.GitHubRepoToken;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Operations against a Kinotic Project's backing GitHub repository: minting
@@ -23,8 +22,8 @@ public interface GitHubProjectRepoService {
      * @return token + expiry + clone URL + default branch, or a failed future if the
      *         project has no GitHub repo provisioned
      */
-    CompletableFuture<GitHubRepoToken> issueRepoToken(String organizationId,
-                                                      String projectId);
+    Future<GitHubRepoToken> issueRepoToken(String organizationId,
+                                           String projectId);
 
     /**
      * Creates a lightweight tag on the project's backing repo.
@@ -35,16 +34,16 @@ public interface GitHubProjectRepoService {
      * @param tagName        e.g. {@code v1.2.0}
      * @param sha            full 40-character commit SHA the tag should point at
      */
-    CompletableFuture<Void> createTag(String organizationId,
-                                      String projectId,
-                                      String tagName,
-                                      String sha);
+    Future<Void> createTag(String organizationId,
+                           String projectId,
+                           String tagName,
+                           String sha);
 
     /**
      * Creates a branch on the project's backing repo pointing at {@code sha}.
      */
-    CompletableFuture<Void> createBranch(String organizationId,
-                                         String projectId,
-                                         String branchName,
-                                         String sha);
+    Future<Void> createBranch(String organizationId,
+                              String projectId,
+                              String branchName,
+                              String sha);
 }

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/repositories/GitHubAppInstallationRepository.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/repositories/GitHubAppInstallationRepository.java
@@ -1,11 +1,10 @@
 package org.kinotic.github.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.internal.api.repositories.AbstractOrganizationScopedRepository;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.kinotic.github.api.model.GitHubAppInstallation;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class GitHubAppInstallationRepository extends AbstractOrganizationScopedRepository<GitHubAppInstallation> {
@@ -14,7 +13,7 @@ public class GitHubAppInstallationRepository extends AbstractOrganizationScopedR
         super("kinotic_github_app_installation", GitHubAppInstallation.class, crudServiceTemplate);
     }
 
-    public CompletableFuture<GitHubAppInstallation> findByGithubInstallationId(long githubInstallationId) {
+    public Future<GitHubAppInstallation> findByGithubInstallationId(long githubInstallationId) {
         return findFirst(b -> b.query(termFilter("githubInstallationId", githubInstallationId)));
     }
 }

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/rest/GitHubWebhookHandler.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/rest/GitHubWebhookHandler.java
@@ -103,12 +103,9 @@ public class GitHubWebhookHandler implements SuppliesGatewayRoutes {
 
             log.trace("Processing webhook {} {} with payload {}", eventType, deliveryId, payload);
 
-            webhookEventService.process(event).whenComplete((v, err) -> {
-                if (err != null) {
+            webhookEventService.process(event).onFailure(err ->
                     log.warn("Webhook processing failed for {} {}: {}",
-                             eventType, deliveryId, err.getMessage());
-                }
-            });
+                             eventType, deliveryId, err.getMessage()));
         });
     }
 

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Default impl of the install round-trip over the {@code kinotic_github_app_installation}
@@ -62,34 +61,34 @@ public class DefaultGitHubAppInstallationService
     }
 
     @Override
-    public CompletableFuture<String> startInstall(String returnTo) {
+    public Future<String> startInstall(String returnTo) {
         String orgId = requireOrganizationId();
         StagedInstall staged = new StagedInstall()
                 .setOrganizationId(orgId)
                 .setReturnTo(returnTo);
         String state = stateService.stage(staged);
-        return CompletableFuture.completedFuture(
+        return Future.succeededFuture(
                 "https://github.com/apps/" + properties.getGithub().getAppSlug()
                         + "/installations/new?state=" + state);
     }
 
     @Override
-    public CompletableFuture<GitHubInstallCompletion> completeInstall(long installationId, String state, String code) {
+    public Future<GitHubInstallCompletion> completeInstall(long installationId, String state, String code) {
         String callerOrgId = requireOrganizationId();
         StagedInstall staged = stateService.consume(state);
         if (staged == null) {
-            return CompletableFuture.failedFuture(new IllegalStateException(
+            return Future.failedFuture(new IllegalStateException(
                     "Install state is missing, expired, or already used. Please re-link GitHub."));
         }
         if (!callerOrgId.equals(staged.getOrganizationId())) {
-            return CompletableFuture.failedFuture(new AuthorizationException(
+            return Future.failedFuture(new AuthorizationException(
                     "Install state does not belong to the current organization."));
         }
         if (code == null || code.isBlank()) {
-            return CompletableFuture.failedFuture(new IllegalStateException(
+            return Future.failedFuture(new IllegalStateException(
                     "Install redirect carried no user-authorization code. Please re-link GitHub."));
         }
-        return Future.fromCompletionStage(findForCurrentOrg(), vertx.getOrCreateContext())
+        return findForCurrentOrg()
                 .compose(existing -> existing == null
                                      || Long.valueOf(installationId).equals(existing.getGithubInstallationId())
                         ? verifiedInstallation(installationId, code)
@@ -100,8 +99,7 @@ public class DefaultGitHubAppInstallationService
                 .compose(details -> persist(staged.getOrganizationId(), installationId, details))
                 .map(installation -> new GitHubInstallCompletion()
                         .setInstallation(installation)
-                        .setReturnTo(staged.getReturnTo()))
-                .toCompletionStage().toCompletableFuture();
+                        .setReturnTo(staged.getReturnTo()));
     }
 
     private Future<InstallationDetails> verifiedInstallation(long installationId, String code) {
@@ -116,24 +114,23 @@ public class DefaultGitHubAppInstallationService
     private Future<String> userAccessToken(String code) {
         // Must exchange with the App's own OAuth credential (the github-platform sign-in
         // row): /user/installations only reports installations of the app that minted the token.
-        return Future.fromCompletionStage(orgSignupOidcConfigurationService.findEnabledByProvider(OidcProviderKind.GITHUB),
-                                          vertx.getOrCreateContext())
-                     .compose(config -> {
-                         if (config == null) {
-                             return Future.failedFuture(new IllegalStateException(
-                                     "No enabled GitHub OAuth configuration exists to verify the install."));
-                         }
-                         return Future.fromCompletionStage(secretReferenceResolver.resolve(config.getSecretNameRef()),
-                                                           vertx.getOrCreateContext())
-                                      .compose(secret -> {
-                                          if (secret == null) {
-                                              return Future.failedFuture(new IllegalStateException(
-                                                      "GitHub OAuth client secret '" + config.getSecretNameRef()
-                                                              + "' could not be resolved."));
-                                          }
-                                          return apiClient.exchangeUserAccessCode(config.getClientId(), secret, code);
-                                      });
-                     });
+        return orgSignupOidcConfigurationService.findEnabledByProvider(OidcProviderKind.GITHUB)
+                .compose(config -> {
+                    if (config == null) {
+                        return Future.failedFuture(new IllegalStateException(
+                                "No enabled GitHub OAuth configuration exists to verify the install."));
+                    }
+                    return Future.fromCompletionStage(secretReferenceResolver.resolve(config.getSecretNameRef()),
+                                                      vertx.getOrCreateContext())
+                            .compose(secret -> {
+                                if (secret == null) {
+                                    return Future.failedFuture(new IllegalStateException(
+                                            "GitHub OAuth client secret '" + config.getSecretNameRef()
+                                                    + "' could not be resolved."));
+                                }
+                                return apiClient.exchangeUserAccessCode(config.getClientId(), secret, code);
+                            });
+                });
     }
 
     private Future<InstallationDetails> requireAccessible(List<InstallationDetails> installations,
@@ -171,23 +168,23 @@ public class DefaultGitHubAppInstallationService
                 .setUpdated(now);
         // saveSync (not save) so the row is searchable before completeInstall resolves —
         // the SPA reads it straight back via findForCurrentOrg(), which is a search.
-        return Future.fromCompletionStage(saveSync(install), vertx.getOrCreateContext());
+        return saveSync(install);
     }
 
     @Override
-    public CompletableFuture<GitHubAppInstallation> findForCurrentOrg() {
+    public Future<GitHubAppInstallation> findForCurrentOrg() {
         return installationRepository.findAll(requireOrganizationId(), Pageable.ofSize(1))
-                                     .thenApply(page -> page.getContent().isEmpty() ? null : page.getContent().getFirst());
+                                     .map(page -> page.getContent().isEmpty() ? null : page.getContent().getFirst());
     }
 
     @Override
-    public CompletableFuture<Void> unlink() {
+    public Future<Void> unlink() {
         String orgId = requireOrganizationId();
-        return findForCurrentOrg().thenCompose(
+        return findForCurrentOrg().compose(
                 // deleteByIdSync (not deleteById) so the row is gone from search before unlink
                 // resolves — the SPA reads it straight back via findForCurrentOrg(), a search.
                 installation -> installation == null
-                        ? CompletableFuture.<Void>completedFuture(null)
+                        ? Future.<Void>succeededFuture()
                         : installationRepository.deleteByIdSync(installation.getId(), orgId));
     }
 }

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationService.java
@@ -1,7 +1,6 @@
 package org.kinotic.github.internal.api.services;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.core.api.exceptions.AuthorizationException;
@@ -40,7 +39,6 @@ public class DefaultGitHubAppInstallationService
     private final GitHubApiClient apiClient;
     private final OrgSignupOidcConfigurationService orgSignupOidcConfigurationService;
     private final SecretReferenceResolver secretReferenceResolver;
-    private final Vertx vertx;
 
     public DefaultGitHubAppInstallationService(GitHubAppInstallationRepository repository,
                                                SecurityContext securityContext,
@@ -48,8 +46,7 @@ public class DefaultGitHubAppInstallationService
                                                GitHubInstallStateService stateService,
                                                GitHubApiClient apiClient,
                                                OrgSignupOidcConfigurationService orgSignupOidcConfigurationService,
-                                               SecretReferenceResolver secretReferenceResolver,
-                                               Vertx vertx) {
+                                               SecretReferenceResolver secretReferenceResolver) {
         super(repository, securityContext);
         this.installationRepository = repository;
         this.properties = properties;
@@ -57,7 +54,6 @@ public class DefaultGitHubAppInstallationService
         this.apiClient = apiClient;
         this.orgSignupOidcConfigurationService = orgSignupOidcConfigurationService;
         this.secretReferenceResolver = secretReferenceResolver;
-        this.vertx = vertx;
     }
 
     @Override
@@ -120,8 +116,7 @@ public class DefaultGitHubAppInstallationService
                         return Future.failedFuture(new IllegalStateException(
                                 "No enabled GitHub OAuth configuration exists to verify the install."));
                     }
-                    return Future.fromCompletionStage(secretReferenceResolver.resolve(config.getSecretNameRef()),
-                                                      vertx.getOrCreateContext())
+                    return secretReferenceResolver.resolve(config.getSecretNameRef())
                             .compose(secret -> {
                                 if (secret == null) {
                                     return Future.failedFuture(new IllegalStateException(

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubProjectRepoService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubProjectRepoService.java
@@ -1,5 +1,6 @@
 package org.kinotic.github.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.exceptions.AuthorizationException;
@@ -14,8 +15,6 @@ import org.kinotic.domain.api.model.Project;
 import org.kinotic.os.api.services.ProjectService;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -27,8 +26,8 @@ public class DefaultGitHubProjectRepoService implements GitHubProjectRepoService
     private final GitHubApiClient apiClient;
 
     @Override
-    public CompletableFuture<GitHubRepoToken> issueRepoToken(String organizationId, String projectId) {
-        return resolve(organizationId, projectId).thenCompose(ctx ->
+    public Future<GitHubRepoToken> issueRepoToken(String organizationId, String projectId) {
+        return resolve(organizationId, projectId).compose(ctx ->
                 apiClient.getToken(ctx.install().getGithubInstallationId(),
                                    ctx.project().getRepoId(),
                                    GitHubApiClient.READ_CONTENTS)
@@ -36,32 +35,30 @@ public class DefaultGitHubProjectRepoService implements GitHubProjectRepoService
                                  base.getToken(),
                                  base.getExpiresAt(),
                                  "https://github.com/" + ctx.project().getRepoFullName() + ".git",
-                                 ctx.project().getRepoDefaultBranch()))
-                         .toCompletionStage().toCompletableFuture());
+                                 ctx.project().getRepoDefaultBranch())));
     }
 
     @Override
-    public CompletableFuture<Void> createTag(String organizationId, String projectId, String tagName, String sha) {
+    public Future<Void> createTag(String organizationId, String projectId, String tagName, String sha) {
         return createRef(organizationId, projectId, "refs/tags/" + tagName, sha);
     }
 
     @Override
-    public CompletableFuture<Void> createBranch(String organizationId, String projectId, String branchName, String sha) {
+    public Future<Void> createBranch(String organizationId, String projectId, String branchName, String sha) {
         return createRef(organizationId, projectId, "refs/heads/" + branchName, sha);
     }
 
-    private CompletableFuture<Void> createRef(String organizationId, String projectId, String refName, String sha) {
-        return resolve(organizationId, projectId).thenCompose(ctx ->
+    private Future<Void> createRef(String organizationId, String projectId, String refName, String sha) {
+        return resolve(organizationId, projectId).compose(ctx ->
                 apiClient.getToken(ctx.install().getGithubInstallationId(),
                                    ctx.project().getRepoId(),
                                    GitHubApiClient.WRITE_CONTENTS)
                          .compose(token -> apiClient.createRef(token.getToken(),
                                                                ctx.project().getRepoFullName(),
-                                                               refName, sha))
-                         .toCompletionStage().toCompletableFuture());
+                                                               refName, sha)));
     }
 
-    private CompletableFuture<RepoContext> resolve(String organizationId, String projectId) {
+    private Future<RepoContext> resolve(String organizationId, String projectId) {
 
         OrganizationParticipant caller = securityContext.requireParticipant(OrganizationParticipant.class);
         if (!organizationId.equals(caller.getOrganizationId())) {
@@ -70,7 +67,7 @@ public class DefaultGitHubProjectRepoService implements GitHubProjectRepoService
                             + "' does not match requested '" + organizationId + "'");
         }
 
-        return projectService.findById(projectId).thenCompose(project -> {
+        return projectService.findById(projectId).compose(project -> {
             if (project == null || project.getRepoFullName() == null || project.getRepoId() == null) {
                 throw new IllegalStateException(
                         "Project " + projectId + " has no GitHub repo provisioned");
@@ -79,7 +76,7 @@ public class DefaultGitHubProjectRepoService implements GitHubProjectRepoService
                 throw new AuthorizationException(
                         "Project " + projectId + " does not belong to organization " + organizationId);
             }
-            return installationService.findForCurrentOrg().thenApply(install -> {
+            return installationService.findForCurrentOrg().map(install -> {
                 if (install == null) {
                     throw new IllegalStateException(
                             "GitHub install for organization " + organizationId + " no longer exists");

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubWebhookEventService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubWebhookEventService.java
@@ -1,6 +1,7 @@
 package org.kinotic.github.internal.api.services;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,6 @@ import reactor.core.publisher.Sinks;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Default impl: mutates installation state for management events, flips backing
@@ -62,8 +62,8 @@ public class DefaultGitHubWebhookEventService implements GitHubWebhookEventServi
     }
 
     @Override
-    public CompletableFuture<Void> process(GitHubWebhookEvent event) {
-        CompletableFuture<Void> ret;
+    public Future<Void> process(GitHubWebhookEvent event) {
+        Future<Void> ret;
         try {
             ret = switch (event.getEventType()) {
                 case "installation" -> handleInstallation(event);
@@ -71,69 +71,69 @@ public class DefaultGitHubWebhookEventService implements GitHubWebhookEventServi
                 default -> handleRepoEvent(event);
             };
         } catch (Exception e) {
-            ret = CompletableFuture.failedFuture(e);
+            ret = Future.failedFuture(e);
         }
         // Swallowing here rather than at each handler is what makes the "always succeeds"
         // contract hold for asynchronous failures too, not just synchronous throws.
-        return ret.exceptionally(err -> {
+        return ret.otherwise(err -> {
             log.warn("Webhook processing failed for delivery {}: {}", event.getDeliveryId(), err.getMessage());
             return null;
         });
     }
 
-    private CompletableFuture<Void> handleInstallation(GitHubWebhookEvent event) {
+    private Future<Void> handleInstallation(GitHubWebhookEvent event) {
         String action = event.getPayload().getString("action");
         Long installationId = event.getInstallationId();
         if (installationId == null) {
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
         return installationRepository.findByGithubInstallationId(installationId)
-                .thenCompose(existing -> {
+                .compose(existing -> {
                     if (existing == null) {
                         // Created elsewhere or already removed — nothing to mutate.
-                        return CompletableFuture.completedFuture(null);
+                        return Future.succeededFuture();
                     }
                     String orgId = existing.getOrganizationId();
                     return switch (action == null ? "" : action) {
                         case "deleted" -> installationRepository.deleteById(existing.getId(), orgId);
                         case "suspend" -> {
                             existing.setSuspendedAt(new Date()).setUpdated(new Date());
-                            yield installationRepository.save(existing, orgId).thenApply(saved -> null);
+                            yield installationRepository.save(existing, orgId).mapEmpty();
                         }
                         case "unsuspend" -> {
                             existing.setSuspendedAt(null).setUpdated(new Date());
-                            yield installationRepository.save(existing, orgId).thenApply(saved -> null);
+                            yield installationRepository.save(existing, orgId).mapEmpty();
                         }
-                        default -> CompletableFuture.completedFuture(null);
+                        default -> Future.succeededFuture();
                     };
                 });
     }
 
-    private CompletableFuture<Void> handleInstallationRepos(GitHubWebhookEvent event) {
+    private Future<Void> handleInstallationRepos(GitHubWebhookEvent event) {
         if (!"removed".equals(event.getPayload().getString("action"))) {
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
         var removed = event.getPayload().getJsonArray("repositories_removed");
         if (removed == null || removed.isEmpty()) {
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
-        List<CompletableFuture<Void>> pending = new ArrayList<>();
+        List<Future<Void>> pending = new ArrayList<>();
         for (int i = 0; i < removed.size(); i++) {
             String fullName = removed.getJsonObject(i).getString("full_name");
             if (fullName != null) {
                 pending.add(markDisconnected(fullName));
             }
         }
-        return CompletableFuture.allOf(pending.toArray(CompletableFuture[]::new));
+        return Future.all(pending).mapEmpty();
     }
 
-    private CompletableFuture<Void> markDisconnected(String repoFullName) {
+    private Future<Void> markDisconnected(String repoFullName) {
         return projectRepository.findByRepoFullName(repoFullName)
-                .thenCompose(projects -> {
+                .compose(projects -> {
                     if (projects.isEmpty()) {
                         log.debug("Installation lost access to {}; no Kinotic project backed by it", repoFullName);
                     }
-                    List<CompletableFuture<Project>> saves = new ArrayList<>();
+                    List<Future<Project>> saves = new ArrayList<>();
                     for (Project project : projects) {
                         if (project.getRepoConnectionStatus() == RepositoryConnectionStatus.DISCONNECTED) {
                             continue;
@@ -143,26 +143,27 @@ public class DefaultGitHubWebhookEventService implements GitHubWebhookEventServi
                                  project.getId(), project.getOrganizationId(), repoFullName);
                         saves.add(projectRepository.save(project, project.getOrganizationId()));
                     }
-                    return CompletableFuture.allOf(saves.toArray(CompletableFuture[]::new));
+                    return Future.all(saves).mapEmpty();
                 });
     }
 
-    private CompletableFuture<Void> handleRepoEvent(GitHubWebhookEvent event) {
+    private Future<Void> handleRepoEvent(GitHubWebhookEvent event) {
         if (event.getRepoFullName() == null) {
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
         return projectRepository.findByRepoFullName(event.getRepoFullName())
-                .thenAccept(projects -> {
+                .compose(projects -> {
                     if (projects.isEmpty()) {
                         log.debug("No Kinotic project for repo {} (event {}); dropping",
                                   event.getRepoFullName(), event.getEventType());
-                        return;
+                    } else {
+                        for (Project project : projects) {
+                            emit(new GitHubProjectEvent().setOrganizationId(project.getOrganizationId())
+                                                         .setProjectId(project.getId())
+                                                         .setWebhookEvent(event));
+                        }
                     }
-                    for (Project project : projects) {
-                        emit(new GitHubProjectEvent().setOrganizationId(project.getOrganizationId())
-                                                     .setProjectId(project.getId())
-                                                     .setWebhookEvent(event));
-                    }
+                    return Future.succeededFuture();
                 });
     }
 

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisioner.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisioner.java
@@ -31,7 +31,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -74,7 +73,7 @@ public class GitHubProjectRepoProvisioner implements ProjectRepoProvisioner {
     private final GraalJsSpawnRenderer spawnRenderer;
 
     @Override
-    public CompletableFuture<Project> provision(Project project) {
+    public Future<Project> provision(Project project) {
         Validate.notBlank(project.getName(), "Project name must not be blank");
         String repoName = toRepoName(project.getName());
         return requireInstallation().compose(install -> {
@@ -101,26 +100,25 @@ public class GitHubProjectRepoProvisioner implements ProjectRepoProvisioner {
                                 p.setRepoConnectionStatus(RepositoryConnectionStatus.INITIALIZATION_FAILED);
                                 return Future.succeededFuture(p);
                             }));
-        }).toCompletionStage().toCompletableFuture();
+        });
     }
 
     @Override
-    public CompletableFuture<Project> reinitialize(Project project) {
+    public Future<Project> reinitialize(Project project) {
         Validate.notNull(project.getRepoId(), "Project repoId must be set to reinitialize");
         Validate.notBlank(project.getRepoFullName(), "Project repoFullName must be set to reinitialize");
         Validate.notBlank(project.getRepoDefaultBranch(), "Project repoDefaultBranch must be set to reinitialize");
         return requireInstallation()
-                .compose(install -> initializeRepo(install.getGithubInstallationId(), project))
-                .toCompletionStage().toCompletableFuture();
+                .compose(install -> initializeRepo(install.getGithubInstallationId(), project));
     }
 
     private Future<GitHubAppInstallation> requireInstallation() {
-        return Future.fromCompletionStage(installationService.findForCurrentOrg(), vertx.getOrCreateContext())
-                     .compose(install -> install == null
-                             ? Future.failedFuture(new IllegalStateException(
-                                     "GitHub is not linked for this organization. "
-                                     + "Link GitHub before creating a project."))
-                             : Future.succeededFuture(install));
+        return installationService.findForCurrentOrg()
+                .compose(install -> install == null
+                        ? Future.failedFuture(new IllegalStateException(
+                                "GitHub is not linked for this organization. "
+                                + "Link GitHub before creating a project."))
+                        : Future.succeededFuture(install));
     }
 
     /**

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubWebhookEventService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubWebhookEventService.java
@@ -1,11 +1,10 @@
 package org.kinotic.github.internal.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.github.api.model.GitHubProjectEvent;
 import org.kinotic.github.api.model.GitHubWebhookEvent;
 import org.kinotic.github.api.services.GitHubProjectEventService;
 import reactor.core.publisher.Flux;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Internal-only service the gateway's webhook handler calls after HMAC verification.
@@ -24,7 +23,7 @@ public interface GitHubWebhookEventService {
      * can't find a backing project. There is no platform-side delivery dedup —
      * GitHub may redeliver, and subscribers must be idempotent.
      */
-    CompletableFuture<Void> process(GitHubWebhookEvent event);
+    Future<Void> process(GitHubWebhookEvent event);
 
     /**
      * A hot stream of repository deliveries that resolved to a Kinotic Project, shared by every

--- a/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationServiceTest.java
+++ b/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationServiceTest.java
@@ -25,10 +25,8 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -67,11 +65,11 @@ class DefaultGitHubAppInstallationServiceTest {
         repository = mock(GitHubAppInstallationRepository.class);
         when(repository.getType()).thenReturn(GitHubAppInstallation.class);
         when(repository.saveSync(any(GitHubAppInstallation.class), anyString()))
-                .thenAnswer(invocation -> CompletableFuture.completedFuture(invocation.getArgument(0)));
+                .thenAnswer(invocation -> Future.succeededFuture(invocation.getArgument(0)));
         // Org not yet linked unless a test overrides this — completeInstall consults
         // findForCurrentOrg (a findAll under the hood) before verifying ownership
         when(repository.findAll(eq(CALLER_ORG), any(Pageable.class)))
-                .thenReturn(CompletableFuture.completedFuture(new Page<>(List.of(), 0L)));
+                .thenReturn(Future.succeededFuture(new Page<>(List.of(), 0L)));
 
         OrganizationParticipant participant = mock(OrganizationParticipant.class);
         when(participant.getOrganizationId()).thenReturn(CALLER_ORG);
@@ -90,7 +88,7 @@ class DefaultGitHubAppInstallationServiceTest {
         credential.setSecretNameRef("github-platform");
         OrgSignupOidcConfigurationService oidcConfigurationService = mock(OrgSignupOidcConfigurationService.class);
         when(oidcConfigurationService.findEnabledByProvider(OidcProviderKind.GITHUB))
-                .thenReturn(CompletableFuture.completedFuture(credential));
+                .thenReturn(Future.succeededFuture(credential));
 
         SecretReferenceResolver secretReferenceResolver = mock(SecretReferenceResolver.class);
         when(secretReferenceResolver.resolve("github-platform"))
@@ -111,14 +109,14 @@ class DefaultGitHubAppInstallationServiceTest {
     }
 
     @Test
-    void bindsAnInstallationTheAuthorizingUserControls() throws Exception {
+    void bindsAnInstallationTheAuthorizingUserControls() {
         when(apiClient.listUserInstallations("user-token"))
                 .thenReturn(Future.succeededFuture(List.of(
                         new InstallationDetails(11L, 777L, "personal", "User"),
                         new InstallationDetails(INSTALLATION_ID, 777L, "acme", "Organization"))));
         String state = stage(CALLER_ORG, "/projects?openNewProject=1");
 
-        GitHubInstallCompletion completion = service.completeInstall(INSTALLATION_ID, state, "good-code").get();
+        GitHubInstallCompletion completion = service.completeInstall(INSTALLATION_ID, state, "good-code").await();
 
         assertEquals("/projects?openNewProject=1", completion.getReturnTo());
         ArgumentCaptor<GitHubAppInstallation> captor = ArgumentCaptor.forClass(GitHubAppInstallation.class);
@@ -161,7 +159,7 @@ class DefaultGitHubAppInstallationServiceTest {
         GitHubAppInstallation existing = new GitHubAppInstallation();
         existing.setGithubInstallationId(66L);
         when(repository.findAll(eq(CALLER_ORG), any(Pageable.class)))
-                .thenReturn(CompletableFuture.completedFuture(new Page<>(List.of(existing), 1L)));
+                .thenReturn(Future.succeededFuture(new Page<>(List.of(existing), 1L)));
         String state = stage(CALLER_ORG, null);
 
         assertFailsWith(IllegalStateException.class,
@@ -171,17 +169,17 @@ class DefaultGitHubAppInstallationServiceTest {
     }
 
     @Test
-    void refreshesTheInstallationAlreadyBoundAfterReverifying() throws Exception {
+    void refreshesTheInstallationAlreadyBoundAfterReverifying() {
         GitHubAppInstallation existing = new GitHubAppInstallation();
         existing.setGithubInstallationId(INSTALLATION_ID);
         when(repository.findAll(eq(CALLER_ORG), any(Pageable.class)))
-                .thenReturn(CompletableFuture.completedFuture(new Page<>(List.of(existing), 1L)));
+                .thenReturn(Future.succeededFuture(new Page<>(List.of(existing), 1L)));
         when(apiClient.listUserInstallations("user-token"))
                 .thenReturn(Future.succeededFuture(List.of(
                         new InstallationDetails(INSTALLATION_ID, 777L, "acme", "Organization"))));
         String state = stage(CALLER_ORG, null);
 
-        service.completeInstall(INSTALLATION_ID, state, "good-code").get();
+        service.completeInstall(INSTALLATION_ID, state, "good-code").await();
 
         // The refresh path still demands the ownership proof before re-persisting
         verify(apiClient).listUserInstallations("user-token");
@@ -223,8 +221,7 @@ class DefaultGitHubAppInstallationServiceTest {
     }
 
     private static void assertFailsWith(Class<? extends Throwable> expected,
-                                        CompletableFuture<GitHubInstallCompletion> future) {
-        ExecutionException failure = assertThrows(ExecutionException.class, future::get);
-        assertInstanceOf(expected, failure.getCause());
+                                        Future<GitHubInstallCompletion> future) {
+        assertThrows(expected, future::await);
     }
 }

--- a/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationServiceTest.java
+++ b/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationServiceTest.java
@@ -1,9 +1,6 @@
 package org.kinotic.github.internal.api.services;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.api.crud.Page;
@@ -24,7 +21,6 @@ import org.kinotic.github.internal.api.services.client.InstallationDetails;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,22 +39,10 @@ class DefaultGitHubAppInstallationServiceTest {
     private static final String APP_ID = "777";
     private static final long INSTALLATION_ID = 55L;
 
-    private static Vertx vertx;
-
     private GitHubAppInstallationRepository repository;
     private GitHubInstallStateService stateService;
     private GitHubApiClient apiClient;
     private DefaultGitHubAppInstallationService service;
-
-    @BeforeAll
-    static void createVertx() {
-        vertx = Vertx.vertx();
-    }
-
-    @AfterAll
-    static void closeVertx() {
-        vertx.close();
-    }
 
     @BeforeEach
     void setUp() {
@@ -92,7 +76,7 @@ class DefaultGitHubAppInstallationServiceTest {
 
         SecretReferenceResolver secretReferenceResolver = mock(SecretReferenceResolver.class);
         when(secretReferenceResolver.resolve("github-platform"))
-                .thenReturn(CompletableFuture.completedFuture("client-secret"));
+                .thenReturn(Future.succeededFuture("client-secret"));
 
         apiClient = mock(GitHubApiClient.class);
         when(apiClient.exchangeUserAccessCode("client-id", "client-secret", "good-code"))
@@ -104,8 +88,7 @@ class DefaultGitHubAppInstallationServiceTest {
                                                           stateService,
                                                           apiClient,
                                                           oidcConfigurationService,
-                                                          secretReferenceResolver,
-                                                          vertx);
+                                                          secretReferenceResolver);
     }
 
     @Test

--- a/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisionerTest.java
+++ b/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisionerTest.java
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -70,7 +69,7 @@ class GitHubProjectRepoProvisionerTest {
         install.setGithubInstallationId(42L);
         install.setAccountLogin("acme");
         when(installationService.findForCurrentOrg())
-                .thenReturn(CompletableFuture.completedFuture(install));
+                .thenReturn(Future.succeededFuture(install));
         when(apiClient.getToken(eq(42L), isNull(), eq(GitHubApiClient.CREATE_REPOSITORY)))
                 .thenReturn(Future.succeededFuture(new GitHubToken("install-token", Instant.now().plusSeconds(3600))));
         when(apiClient.getToken(eq(42L), eq(99L), eq(GitHubApiClient.WRITE_CONTENTS)))
@@ -93,7 +92,7 @@ class GitHubProjectRepoProvisionerTest {
         when(apiClient.downloadTarball(eq("repo-token"), eq("acme/demo"), eq("main")))
                 .thenReturn(Future.succeededFuture(templateTarball()));
 
-        Project project = provisioner.provision(project()).get();
+        Project project = provisioner.provision(project()).await();
 
         assertEquals("acme/demo", project.getRepoFullName());
         assertEquals(99L, project.getRepoId());
@@ -139,7 +138,7 @@ class GitHubProjectRepoProvisionerTest {
                 .thenReturn(Future.failedFuture(new GitHubApiException("downloadTarball failed: HTTP 404")))
                 .thenReturn(Future.succeededFuture(templateTarball()));
 
-        Project project = provisioner.provision(project()).get();
+        Project project = provisioner.provision(project()).await();
 
         assertEquals(RepositoryConnectionStatus.CONNECTED, project.getRepoConnectionStatus());
         verify(apiClient, times(2)).downloadTarball(eq("repo-token"), eq("acme/demo"), eq("main"));
@@ -154,7 +153,7 @@ class GitHubProjectRepoProvisionerTest {
 
         // provision succeeds even though initialization failed: the repo was created,
         // so the project is adopted with a retryable status rather than orphaned.
-        Project project = provisioner.provision(project()).get();
+        Project project = provisioner.provision(project()).await();
 
         assertEquals("acme/demo", project.getRepoFullName());
         assertEquals(99L, project.getRepoId());
@@ -172,7 +171,7 @@ class GitHubProjectRepoProvisionerTest {
         failed.setRepoDefaultBranch("main");
         failed.setRepoConnectionStatus(RepositoryConnectionStatus.INITIALIZATION_FAILED);
 
-        Project project = provisioner.reinitialize(failed).get();
+        Project project = provisioner.reinitialize(failed).await();
 
         assertEquals(RepositoryConnectionStatus.CONNECTED, project.getRepoConnectionStatus());
         verify(apiClient, never()).createRepoFromTemplate(anyString(), anyString(), anyString(),

--- a/kinotic-orchestrator/build.gradle
+++ b/kinotic-orchestrator/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 
     implementation 'io.projectreactor:reactor-core'
 
+    implementation 'io.vertx:vertx-core'
+
     implementation 'org.reactivestreams:reactive-streams'
 
     implementation 'tools.jackson.core:jackson-core'

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/JobRunService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/JobRunService.java
@@ -1,12 +1,11 @@
 package org.kinotic.orchestrator.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.grind.JobOwner;
 import org.kinotic.orchestrator.api.model.grind.JobRun;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service for managing {@link JobRun} entities, the persistent history of grind job executions.
@@ -19,7 +18,7 @@ public interface JobRunService extends IdentifiableCrudService<JobRun, String> {
      * @param pageable the page of runs to return
      * @return a future that will complete with the page of runs
      */
-    CompletableFuture<Page<JobRun>> findByName(String name, Pageable pageable);
+    Future<Page<JobRun>> findByName(String name, Pageable pageable);
 
     /**
      * Finds the runs owned by the given {@link JobOwner}: all of an organization's runs,
@@ -29,6 +28,6 @@ public interface JobRunService extends IdentifiableCrudService<JobRun, String> {
      * @param pageable the page of runs to return
      * @return a future that will complete with the page of runs
      */
-    CompletableFuture<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable);
+    Future<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/TaskRecordService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/TaskRecordService.java
@@ -1,12 +1,11 @@
 package org.kinotic.orchestrator.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.grind.JobRun;
 import org.kinotic.orchestrator.api.model.grind.TaskRecord;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service for managing {@link TaskRecord} entities, the per-step history of a {@link JobRun}.
@@ -19,6 +18,6 @@ public interface TaskRecordService extends IdentifiableCrudService<TaskRecord, S
      * @param pageable the page of records to return
      * @return a future that will complete with the page of records
      */
-    CompletableFuture<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable);
+    Future<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/VmNodeOrchestrationService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/VmNodeOrchestrationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.orchestrator.api.model.workload.VmNode;
 import org.kinotic.orchestrator.api.services.VmNodeService;
@@ -7,7 +8,6 @@ import org.kinotic.orchestrator.api.services.VmNodeService;
 import org.kinotic.orchestrator.api.workload.VmNodeRegistration;
 import org.kinotic.orchestrator.api.workload.WorkloadStatusReport;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service responsible for tracking and managing VmManager nodes in the cluster.
@@ -26,7 +26,7 @@ public interface VmNodeOrchestrationService {
      * @param registration the node registration info
      * @return a future that will complete with the registered node
      */
-    CompletableFuture<VmNode> registerNode(VmNodeRegistration registration);
+    Future<VmNode> registerNode(VmNodeRegistration registration);
 
     /**
      * Heartbeat from a running vm-manager node.
@@ -35,7 +35,7 @@ public interface VmNodeOrchestrationService {
      * @param nodeId the id of the node sending the heartbeat
      * @return a future that will complete with the updated node, or fail if the node is not registered
      */
-    CompletableFuture<VmNode> heartbeat(String nodeId);
+    Future<VmNode> heartbeat(String nodeId);
 
     /**
      * Applies a node's report of its workloads' actual statuses. The vm-manager sends a
@@ -48,7 +48,7 @@ public interface VmNodeOrchestrationService {
      * @param reports one report per workload
      * @return a future that will complete when the reports have been applied
      */
-    CompletableFuture<Void> reportWorkloadStatus(String nodeId, List<WorkloadStatusReport> reports);
+    Future<Void> reportWorkloadStatus(String nodeId, List<WorkloadStatusReport> reports);
 
     /**
      * Removes a node from the orchestrator. The node must have no active workloads.
@@ -56,7 +56,7 @@ public interface VmNodeOrchestrationService {
      * @param nodeId the id of the node to deregister
      * @return a future that will complete when the node has been removed
      */
-    CompletableFuture<Void> deregisterNode(String nodeId);
+    Future<Void> deregisterNode(String nodeId);
 
     /**
      * Finds a node with sufficient resources to host a workload with the given requirements.
@@ -66,6 +66,6 @@ public interface VmNodeOrchestrationService {
      * @param requiredDiskMb the amount of disk space required in megabytes
      * @return a future that will complete with a suitable node, or null if none available
      */
-    CompletableFuture<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb);
+    Future<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/VmNodeService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/VmNodeService.java
@@ -1,12 +1,11 @@
 package org.kinotic.orchestrator.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.orchestrator.api.model.workload.VmNode;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service for managing {@link VmNode} entities.
@@ -23,6 +22,6 @@ public interface VmNodeService extends IdentifiableCrudService<VmNode, String> {
      * @param requiredDiskMb the amount of disk space required in megabytes
      * @return a future that will complete with a suitable node, or null if none available
      */
-    CompletableFuture<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb);
+    Future<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/WorkloadOrchestrationService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/WorkloadOrchestrationService.java
@@ -1,12 +1,11 @@
 package org.kinotic.orchestrator.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.orchestrator.api.model.workload.Workload;
 import org.kinotic.orchestrator.api.services.WorkloadService;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service responsible for orchestrating workload deployment across the cluster.
@@ -29,7 +28,7 @@ public interface WorkloadOrchestrationService {
      * @param workload the workload configuration to deploy
      * @return a future that will complete with the deployed workload (including assigned nodeId and id)
      */
-    CompletableFuture<Workload> deployWorkload(Workload workload);
+    Future<Workload> deployWorkload(Workload workload);
 
     /**
      * Restarts a stopped workload in place on the node it is deployed to. The same VM
@@ -40,7 +39,7 @@ public interface WorkloadOrchestrationService {
      * @param workloadId the id of the workload to restart
      * @return a future that will complete with the restarted workload
      */
-    CompletableFuture<Workload> restartWorkload(String workloadId);
+    Future<Workload> restartWorkload(String workloadId);
 
     /**
      * Stops a running workload.
@@ -49,7 +48,7 @@ public interface WorkloadOrchestrationService {
      * @param workloadId the id of the workload to stop
      * @return a future that will complete when the workload has been stopped
      */
-    CompletableFuture<Void> stopWorkload(String workloadId);
+    Future<Void> stopWorkload(String workloadId);
 
     /**
      * Destroys a workload, removing it from the node and cleaning up all resources.
@@ -57,6 +56,6 @@ public interface WorkloadOrchestrationService {
      * @param workloadId the id of the workload to destroy
      * @return a future that will complete when the workload has been destroyed
      */
-    CompletableFuture<Void> destroyWorkload(String workloadId);
+    Future<Void> destroyWorkload(String workloadId);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/WorkloadService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/WorkloadService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
@@ -7,8 +8,6 @@ import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.orchestrator.api.model.workload.Workload;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service for managing {@link Workload} entities.
@@ -24,13 +23,13 @@ public interface WorkloadService extends IdentifiableCrudService<Workload, Strin
      * @param pageable the page to return
      * @return a future that will complete with a page of workloads
      */
-    CompletableFuture<Page<Workload>> findAllForNode(String nodeId, Pageable pageable);
+    Future<Page<Workload>> findAllForNode(String nodeId, Pageable pageable);
 
     /**
      * Counts all workloads deployed on the given node.
      * @param nodeId the id of the node to count workloads for
      * @return a future that will complete with the number of workloads
      */
-    CompletableFuture<Long> countForNode(String nodeId);
+    Future<Long> countForNode(String nodeId);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/workload/VmManagerProxy.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/workload/VmManagerProxy.java
@@ -1,11 +1,11 @@
 package org.kinotic.orchestrator.api.workload;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Proxy;
 import org.kinotic.core.api.annotations.Scope;
 import org.kinotic.orchestrator.api.model.workload.Workload;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Proxy interface for communicating with a VmManager instance running on a specific node.
@@ -24,7 +24,7 @@ public interface VmManagerProxy {
      * @param workload the workload configuration to start
      * @return a future that will complete with the started workload
      */
-    CompletableFuture<Workload> startWorkload(@Scope String nodeId, Workload workload);
+    Future<Workload> startWorkload(@Scope String nodeId, Workload workload);
 
     /**
      * Restarts a stopped workload in place on the VmManager running on the given node.
@@ -34,7 +34,7 @@ public interface VmManagerProxy {
      * @param workloadId the id of the workload to restart
      * @return a future that will complete with the restarted workload
      */
-    CompletableFuture<Workload> restartWorkload(@Scope String nodeId, String workloadId);
+    Future<Workload> restartWorkload(@Scope String nodeId, String workloadId);
 
     /**
      * Stops a running workload on the VmManager running on the given node.
@@ -42,7 +42,7 @@ public interface VmManagerProxy {
      * @param workloadId the id of the workload to stop
      * @return a future that will complete when the workload has been stopped
      */
-    CompletableFuture<Void> stopWorkload(@Scope String nodeId, String workloadId);
+    Future<Void> stopWorkload(@Scope String nodeId, String workloadId);
 
     /**
      * Destroys a workload on the VmManager running on the given node.
@@ -50,7 +50,7 @@ public interface VmManagerProxy {
      * @param workloadId the id of the workload to destroy
      * @return a future that will complete when the workload has been destroyed
      */
-    CompletableFuture<Void> destroyWorkload(@Scope String nodeId, String workloadId);
+    Future<Void> destroyWorkload(@Scope String nodeId, String workloadId);
 
     /**
      * Gets the current state of a workload from the VmManager running on the given node.
@@ -58,13 +58,13 @@ public interface VmManagerProxy {
      * @param workloadId the id of the workload
      * @return a future that will complete with the workload
      */
-    CompletableFuture<Workload> getWorkload(@Scope String nodeId, String workloadId);
+    Future<Workload> getWorkload(@Scope String nodeId, String workloadId);
 
     /**
      * Lists all workloads managed by the VmManager running on the given node.
      * @param nodeId the id of the node to route to
      * @return a future that will complete with the list of workloads
      */
-    CompletableFuture<List<Workload>> listWorkloads(@Scope String nodeId);
+    Future<List<Workload>> listWorkloads(@Scope String nodeId);
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/model/grind/JobRunRecorder.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/model/grind/JobRunRecorder.java
@@ -75,13 +75,13 @@ public class JobRunRecorder {
         jobRun.setOrganizationId(organizationId)
               .setApplicationId(applicationId)
               .setProjectId(projectId);
-        enqueue(() -> jobRunService.save(jobRun));
+        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
     }
 
     public void runStarted() {
         jobRun.setStatus(ExecutionStatus.RUNNING)
               .setStarted(new Date());
-        enqueue(() -> jobRunService.save(jobRun));
+        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
     }
 
     public void record(Result<?> result) {
@@ -98,14 +98,14 @@ public class JobRunRecorder {
         TaskRecord record = recordsByPath.get(stepPath);
         if(record != null){
             record.setDynamicSteps(true);
-            enqueue(() -> taskRecordService.save(record));
+            enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
         }
     }
 
     public void runCompleted() {
         jobRun.setStatus(ExecutionStatus.COMPLETED)
               .setFinished(new Date());
-        enqueue(() -> jobRunService.save(jobRun));
+        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
     }
 
     public void runFailed(Throwable throwable) {
@@ -113,14 +113,14 @@ public class JobRunRecorder {
         jobRun.setStatus(ExecutionStatus.FAILED)
               .setError(throwable.toString())
               .setFinished(new Date());
-        enqueue(() -> jobRunService.save(jobRun));
+        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
     }
 
     public void runCancelled() {
         finishRemainingRecords(ExecutionStatus.CANCELLED);
         jobRun.setStatus(ExecutionStatus.CANCELLED)
               .setFinished(new Date());
-        enqueue(() -> jobRunService.save(jobRun));
+        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
     }
 
     private void stepStarted(String stepPath, String description) {
@@ -131,7 +131,7 @@ public class JobRunRecorder {
                                             .setStatus(ExecutionStatus.RUNNING)
                                             .setStarted(new Date());
         recordsByPath.put(stepPath, record);
-        enqueue(() -> taskRecordService.save(record));
+        enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
     }
 
     private void stepCompleted(String stepPath, StepCompletion completion) {
@@ -176,7 +176,7 @@ public class JobRunRecorder {
                              + completion.getStoredValue().getClass().getName() + " is not serializable", e);
                 }
             }
-            enqueue(() -> taskRecordService.save(record));
+            enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
         }
     }
 
@@ -189,7 +189,7 @@ public class JobRunRecorder {
         record.setStatus(ExecutionStatus.FAILED)
               .setError(message)
               .setFinished(new Date());
-        enqueue(() -> taskRecordService.save(record));
+        enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
         throw new IllegalStateException(message, cause);
     }
 
@@ -201,7 +201,7 @@ public class JobRunRecorder {
             record.setStatus(ExecutionStatus.FAILED)
                   .setError(throwable.toString())
                   .setFinished(new Date());
-            enqueue(() -> taskRecordService.save(record));
+            enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
         }
     }
 
@@ -214,7 +214,7 @@ public class JobRunRecorder {
             if(record.getStatus() == ExecutionStatus.RUNNING){
                 record.setStatus(status)
                       .setFinished(new Date());
-                enqueue(() -> taskRecordService.save(record));
+                enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
             }
         }
     }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/model/grind/JobRunRecorder.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/model/grind/JobRunRecorder.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.model.grind;
 
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.orchestrator.api.model.grind.ExecutionStatus;
 import org.kinotic.orchestrator.api.model.grind.JobRun;
@@ -18,7 +19,6 @@ import java.util.ArrayDeque;
 import java.util.Date;
 import java.util.Deque;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -38,7 +38,7 @@ public class JobRunRecorder {
 
     private final Map<String, TaskRecord> recordsByPath = new ConcurrentHashMap<>();
     // Persistence calls are chained so writes for the same document can never race each other
-    private CompletableFuture<Void> writeChain = CompletableFuture.completedFuture(null);
+    private Future<Void> writeChain = Future.succeededFuture();
 
     public JobRunRecorder(String jobRunId,
                           JobDefinition jobDefinition,
@@ -75,13 +75,13 @@ public class JobRunRecorder {
         jobRun.setOrganizationId(organizationId)
               .setApplicationId(applicationId)
               .setProjectId(projectId);
-        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
+        enqueue(() -> jobRunService.save(jobRun));
     }
 
     public void runStarted() {
         jobRun.setStatus(ExecutionStatus.RUNNING)
               .setStarted(new Date());
-        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
+        enqueue(() -> jobRunService.save(jobRun));
     }
 
     public void record(Result<?> result) {
@@ -98,14 +98,14 @@ public class JobRunRecorder {
         TaskRecord record = recordsByPath.get(stepPath);
         if(record != null){
             record.setDynamicSteps(true);
-            enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
+            enqueue(() -> taskRecordService.save(record));
         }
     }
 
     public void runCompleted() {
         jobRun.setStatus(ExecutionStatus.COMPLETED)
               .setFinished(new Date());
-        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
+        enqueue(() -> jobRunService.save(jobRun));
     }
 
     public void runFailed(Throwable throwable) {
@@ -113,14 +113,14 @@ public class JobRunRecorder {
         jobRun.setStatus(ExecutionStatus.FAILED)
               .setError(throwable.toString())
               .setFinished(new Date());
-        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
+        enqueue(() -> jobRunService.save(jobRun));
     }
 
     public void runCancelled() {
         finishRemainingRecords(ExecutionStatus.CANCELLED);
         jobRun.setStatus(ExecutionStatus.CANCELLED)
               .setFinished(new Date());
-        enqueue(() -> jobRunService.save(jobRun).toCompletionStage().toCompletableFuture());
+        enqueue(() -> jobRunService.save(jobRun));
     }
 
     private void stepStarted(String stepPath, String description) {
@@ -131,7 +131,7 @@ public class JobRunRecorder {
                                             .setStatus(ExecutionStatus.RUNNING)
                                             .setStarted(new Date());
         recordsByPath.put(stepPath, record);
-        enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
+        enqueue(() -> taskRecordService.save(record));
     }
 
     private void stepCompleted(String stepPath, StepCompletion completion) {
@@ -176,7 +176,7 @@ public class JobRunRecorder {
                              + completion.getStoredValue().getClass().getName() + " is not serializable", e);
                 }
             }
-            enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
+            enqueue(() -> taskRecordService.save(record));
         }
     }
 
@@ -189,7 +189,7 @@ public class JobRunRecorder {
         record.setStatus(ExecutionStatus.FAILED)
               .setError(message)
               .setFinished(new Date());
-        enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
+        enqueue(() -> taskRecordService.save(record));
         throw new IllegalStateException(message, cause);
     }
 
@@ -201,7 +201,7 @@ public class JobRunRecorder {
             record.setStatus(ExecutionStatus.FAILED)
                   .setError(throwable.toString())
                   .setFinished(new Date());
-            enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
+            enqueue(() -> taskRecordService.save(record));
         }
     }
 
@@ -214,7 +214,7 @@ public class JobRunRecorder {
             if(record.getStatus() == ExecutionStatus.RUNNING){
                 record.setStatus(status)
                       .setFinished(new Date());
-                enqueue(() -> taskRecordService.save(record).toCompletionStage().toCompletableFuture());
+                enqueue(() -> taskRecordService.save(record));
             }
         }
     }
@@ -229,14 +229,14 @@ public class JobRunRecorder {
                         .collect(Collectors.joining("/"));
     }
 
-    private synchronized void enqueue(Supplier<CompletableFuture<?>> writeOperation) {
-        writeChain = writeChain.thenCompose(v -> writeOperation.get()
-                                                               .handle((r, t) -> {
-                                                                   if(t != null){
-                                                                       log.warn("Failed to persist record for run {}", jobRunId, t);
-                                                                   }
-                                                                   return null;
-                                                               }));
+    private synchronized void enqueue(Supplier<Future<?>> writeOperation) {
+        writeChain = writeChain.compose(v -> writeOperation.get()
+                                                           .transform(ar -> {
+                                                               if(ar.failed()){
+                                                                   log.warn("Failed to persist record for run {}", jobRunId, ar.cause());
+                                                               }
+                                                               return Future.succeededFuture();
+                                                           }));
     }
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/JobRunRepository.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/JobRunRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.grind.JobOwner;
@@ -7,8 +8,6 @@ import org.kinotic.orchestrator.api.model.grind.JobRun;
 import org.kinotic.domain.internal.api.repositories.AbstractRepository;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class JobRunRepository extends AbstractRepository<JobRun> {
@@ -20,7 +19,7 @@ public class JobRunRepository extends AbstractRepository<JobRun> {
     /**
      * Returns the page of runs recorded for the given job name.
      */
-    public CompletableFuture<Page<JobRun>> findByName(String name, Pageable pageable) {
+    public Future<Page<JobRun>> findByName(String name, Pageable pageable) {
         return findAll(pageable, b -> b.query(termFilter("name", name)));
     }
 
@@ -29,7 +28,7 @@ public class JobRunRepository extends AbstractRepository<JobRun> {
      * runs, narrowed to an application and/or project when the owner carries those ids. The
      * system owner selects platform runs - those owned by no organization.
      */
-    public CompletableFuture<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable) {
+    public Future<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable) {
         return findAll(pageable, b -> b.query(composeFilter(
             owner.getOrganizationId() != null ? termFilter("organizationId", owner.getOrganizationId())
                                               : missingFilter("organizationId"),

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/TaskRecordRepository.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/TaskRecordRepository.java
@@ -1,13 +1,12 @@
 package org.kinotic.orchestrator.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.grind.TaskRecord;
 import org.kinotic.domain.internal.api.repositories.AbstractRepository;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class TaskRecordRepository extends AbstractRepository<TaskRecord> {
@@ -19,7 +18,7 @@ public class TaskRecordRepository extends AbstractRepository<TaskRecord> {
     /**
      * Returns the page of records for the given {@link org.kinotic.orchestrator.api.model.grind.JobRun} id.
      */
-    public CompletableFuture<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable) {
+    public Future<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable) {
         return findAll(pageable, b -> b.query(termFilter("jobRunId", jobRunId)));
     }
 

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/VmNodeRepository.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/VmNodeRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.workload.VmNode;
@@ -7,8 +8,6 @@ import org.kinotic.orchestrator.api.model.workload.VmNodeStatus;
 import org.kinotic.domain.internal.api.repositories.AbstractRepository;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class VmNodeRepository extends AbstractRepository<VmNode> {
@@ -22,7 +21,7 @@ public class VmNodeRepository extends AbstractRepository<VmNode> {
      * Resource-availability filtering is left to the caller because Elasticsearch can't express the
      * "available = total - allocated" computation as a server-side query.
      */
-    public CompletableFuture<Page<VmNode>> findOnlineNodes() {
+    public Future<Page<VmNode>> findOnlineNodes() {
         return findAll(Pageable.ofSize(100), b -> b.query(termFilter("status", VmNodeStatus.ONLINE.name())));
     }
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/WorkloadRepository.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/repositories/WorkloadRepository.java
@@ -1,13 +1,12 @@
 package org.kinotic.orchestrator.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.workload.Workload;
 import org.kinotic.domain.internal.api.repositories.AbstractRepository;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class WorkloadRepository extends AbstractRepository<Workload> {
@@ -16,11 +15,11 @@ public class WorkloadRepository extends AbstractRepository<Workload> {
         super("kinotic_workload", Workload.class, crudServiceTemplate);
     }
 
-    public CompletableFuture<Page<Workload>> findAllForNode(String nodeId, Pageable pageable) {
+    public Future<Page<Workload>> findAllForNode(String nodeId, Pageable pageable) {
         return findAll(pageable, b -> b.query(termFilter("nodeId", nodeId)));
     }
 
-    public CompletableFuture<Long> countForNode(String nodeId) {
+    public Future<Long> countForNode(String nodeId) {
         return count(b -> b.query(termFilter("nodeId", nodeId)));
     }
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobRunService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobRunService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.services;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -9,8 +10,6 @@ import org.kinotic.domain.internal.api.services.AbstractCrudService;
 import org.kinotic.orchestrator.api.services.JobRunService;
 import org.kinotic.orchestrator.internal.api.repositories.JobRunRepository;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultJobRunService extends AbstractCrudService<JobRun> implements JobRunService {
@@ -23,19 +22,19 @@ public class DefaultJobRunService extends AbstractCrudService<JobRun> implements
     }
 
     @Override
-    public CompletableFuture<Page<JobRun>> findByName(String name, Pageable pageable) {
+    public Future<Page<JobRun>> findByName(String name, Pageable pageable) {
         Validate.notBlank(name, "name cannot be blank");
         return jobRunRepository.findByName(name, pageable);
     }
 
     @Override
-    public CompletableFuture<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable) {
+    public Future<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable) {
         Validate.notNull(owner, "owner cannot be null");
         return jobRunRepository.findAllForOwner(owner, pageable);
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(JobRun entity) {
+    protected Future<Void> beforeSave(JobRun entity) {
         Validate.notNull(entity, "JobRun cannot be null");
         Validate.notNull(entity.getId(), "JobRun id cannot be null");
         Validate.notNull(entity.getStatus(), "JobRun status cannot be null");
@@ -43,7 +42,7 @@ public class DefaultJobRunService extends AbstractCrudService<JobRun> implements
                         "JobRun applicationId requires organizationId");
         Validate.isTrue(entity.getProjectId() == null || entity.getOrganizationId() != null,
                         "JobRun projectId requires organizationId");
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobService.java
@@ -122,7 +122,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
                                                      objectMapper);
 
         Flux<Result<?>> results =
-            Flux.defer(() -> Mono.fromFuture(() -> jobRunService.findById(jobRunId))
+            Flux.defer(() -> Mono.fromFuture(() -> jobRunService.findById(jobRunId).toCompletionStage().toCompletableFuture())
                                  .switchIfEmpty(Mono.error(() -> new IllegalArgumentException("No JobRun found with id " + jobRunId)))
                                  .flatMapMany(originalRun -> {
                                      Flux<Result<?>> ret;
@@ -190,6 +190,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
 
     private CompletableFuture<Void> loadRecordsPage(String jobRunId, int page, Map<String, ReplayEntry> entries) {
         return taskRecordService.findAllForJobRun(jobRunId, Pageable.create(page, RECORD_PAGE_SIZE, null))
+                                .toCompletionStage().toCompletableFuture()
                                 .thenCompose(recordPage -> {
                                     for(TaskRecord record : recordPage.getContent()){
                                         if(record.getStatus() == ExecutionStatus.COMPLETED){

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultJobService.java
@@ -2,6 +2,7 @@
 
 package org.kinotic.orchestrator.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
@@ -36,7 +37,6 @@ import reactor.core.publisher.Mono;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
  *
@@ -122,7 +122,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
                                                      objectMapper);
 
         Flux<Result<?>> results =
-            Flux.defer(() -> Mono.fromFuture(() -> jobRunService.findById(jobRunId).toCompletionStage().toCompletableFuture())
+            Flux.defer(() -> Mono.fromCompletionStage(() -> jobRunService.findById(jobRunId).toCompletionStage())
                                  .switchIfEmpty(Mono.error(() -> new IllegalArgumentException("No JobRun found with id " + jobRunId)))
                                  .flatMapMany(originalRun -> {
                                      Flux<Result<?>> ret;
@@ -141,7 +141,7 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
                                          recorder.ownerResolved(originalRun.getOrganizationId(),
                                                                 originalRun.getApplicationId(),
                                                                 originalRun.getProjectId());
-                                         ret = Mono.fromFuture(() -> loadReplayLedger(jobRunId))
+                                         ret = Mono.fromCompletionStage(() -> loadReplayLedger(jobRunId).toCompletionStage())
                                                    .flatMapMany(ledger -> assembleInternal(jobDefinition, options, ledger));
                                      }
                                      return ret;
@@ -183,23 +183,22 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
      * STATE values. A value that cannot be restored leaves its entry without a value, so the
      * step re-executes rather than replaying corrupt state.
      */
-    private CompletableFuture<ReplayLedger> loadReplayLedger(String jobRunId) {
+    private Future<ReplayLedger> loadReplayLedger(String jobRunId) {
         Map<String, ReplayEntry> entries = new HashMap<>();
-        return loadRecordsPage(jobRunId, 0, entries).thenApply(v -> entries::get);
+        return loadRecordsPage(jobRunId, 0, entries).map(v -> entries::get);
     }
 
-    private CompletableFuture<Void> loadRecordsPage(String jobRunId, int page, Map<String, ReplayEntry> entries) {
+    private Future<Void> loadRecordsPage(String jobRunId, int page, Map<String, ReplayEntry> entries) {
         return taskRecordService.findAllForJobRun(jobRunId, Pageable.create(page, RECORD_PAGE_SIZE, null))
-                                .toCompletionStage().toCompletableFuture()
-                                .thenCompose(recordPage -> {
+                                .compose(recordPage -> {
                                     for(TaskRecord record : recordPage.getContent()){
                                         if(record.getStatus() == ExecutionStatus.COMPLETED){
                                             entries.put(record.getStepPath(), toReplayEntry(record));
                                         }
                                     }
-                                    CompletableFuture<Void> ret;
+                                    Future<Void> ret;
                                     if(recordPage.getContent().size() < RECORD_PAGE_SIZE){
-                                        ret = CompletableFuture.completedFuture(null);
+                                        ret = Future.succeededFuture();
                                     }else{
                                         ret = loadRecordsPage(jobRunId, page + 1, entries);
                                     }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultTaskRecordService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultTaskRecordService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.services;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -8,8 +9,6 @@ import org.kinotic.domain.internal.api.services.AbstractCrudService;
 import org.kinotic.orchestrator.api.services.TaskRecordService;
 import org.kinotic.orchestrator.internal.api.repositories.TaskRecordRepository;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultTaskRecordService extends AbstractCrudService<TaskRecord> implements TaskRecordService {
@@ -22,19 +21,19 @@ public class DefaultTaskRecordService extends AbstractCrudService<TaskRecord> im
     }
 
     @Override
-    public CompletableFuture<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable) {
+    public Future<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable) {
         Validate.notBlank(jobRunId, "jobRunId cannot be blank");
         return taskRecordRepository.findAllForJobRun(jobRunId, pageable);
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(TaskRecord entity) {
+    protected Future<Void> beforeSave(TaskRecord entity) {
         Validate.notNull(entity, "TaskRecord cannot be null");
         Validate.notNull(entity.getId(), "TaskRecord id cannot be null");
         Validate.notNull(entity.getJobRunId(), "TaskRecord jobRunId cannot be null");
         Validate.notNull(entity.getStepPath(), "TaskRecord stepPath cannot be null");
         Validate.notNull(entity.getStatus(), "TaskRecord status cannot be null");
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeOrchestrationService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeOrchestrationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.services;
 
+import io.vertx.core.Future;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -60,13 +60,13 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
     }
 
     @Override
-    public CompletableFuture<VmNode> registerNode(VmNodeRegistration registration) {
+    public Future<VmNode> registerNode(VmNodeRegistration registration) {
         Validate.notNull(registration, "Registration cannot be null");
         Validate.notNull(registration.getId(), "Node id cannot be null");
 
         return vmNodeService.findById(registration.getId())
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(existing -> {
+                .compose(existing -> {
+                    Future<VmNode> ret;
                     if (existing != null) {
                         existing.setHostname(registration.getHostname())
                                 .setName(registration.getName())
@@ -75,7 +75,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                                 .setTotalDiskMb(registration.getTotalDiskMb())
                                 .setStatus(VmNodeStatus.ONLINE);
                         log.info("Re-registering VmNode: {} ({})", existing.getName(), existing.getId());
-                        return vmNodeService.saveSync(existing).toCompletionStage().toCompletableFuture();
+                        ret = vmNodeService.saveSync(existing);
                     } else {
                         VmNode node = new VmNode(registration.getId(), registration.getName(), registration.getHostname());
                         node.setTotalCpus(registration.getTotalCpus());
@@ -83,20 +83,20 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                         node.setTotalDiskMb(registration.getTotalDiskMb());
                         node.setStatus(VmNodeStatus.ONLINE);
                         log.info("Registering new VmNode: {} ({})", node.getName(), node.getId());
-                        return vmNodeService.saveSync(node).toCompletionStage().toCompletableFuture();
+                        ret = vmNodeService.saveSync(node);
                     }
+                    return ret;
                 });
     }
 
     @Override
-    public CompletableFuture<VmNode> heartbeat(String nodeId) {
+    public Future<VmNode> heartbeat(String nodeId) {
         Validate.notNull(nodeId, "Node id cannot be null");
 
         return vmNodeService.findById(nodeId)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(node -> {
+                .compose(node -> {
                     if (node == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Node not registered: " + nodeId));
                     }
                     node.setLastSeen(new Date());
@@ -104,68 +104,66 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                         log.info("VmNode {} came back online", nodeId);
                         node.setStatus(VmNodeStatus.ONLINE);
                     }
-                    return vmNodeService.saveSync(node).toCompletionStage().toCompletableFuture();
+                    return vmNodeService.saveSync(node);
                 });
     }
 
     @Override
-    public CompletableFuture<Void> reportWorkloadStatus(String nodeId, List<WorkloadStatusReport> reports) {
+    public Future<Void> reportWorkloadStatus(String nodeId, List<WorkloadStatusReport> reports) {
         Validate.notNull(nodeId, "Node id cannot be null");
         Validate.notNull(reports, "Reports cannot be null");
 
-        return CompletableFuture.allOf(reports.stream()
-                                              .map(report -> applyStatusReport(nodeId, report))
-                                              .toArray(CompletableFuture[]::new));
+        return Future.all(reports.stream()
+                                 .map(report -> applyStatusReport(nodeId, report))
+                                 .toList())
+                     .mapEmpty();
     }
 
-    private CompletableFuture<Workload> applyStatusReport(String nodeId, WorkloadStatusReport report) {
+    private Future<Workload> applyStatusReport(String nodeId, WorkloadStatusReport report) {
         return workloadService.findById(report.getWorkloadId())
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(workload -> {
+                .compose(workload -> {
                     if (workload == null) {
                         // Destroyed since the node recorded the status — stale report
-                        return CompletableFuture.completedFuture(null);
+                        return Future.succeededFuture();
                     }
                     if (!nodeId.equals(workload.getNodeId())) {
                         log.warn("Ignoring status report from node {} for workload {} deployed on node {}",
                                  nodeId, report.getWorkloadId(), workload.getNodeId());
-                        return CompletableFuture.completedFuture(workload);
+                        return Future.succeededFuture(workload);
                     }
                     // A report older than the record's last transition must not clobber it;
                     // snapshot re-sends of an already-applied report are skipped the same way
                     if (workload.getStatus() == report.getStatus()
                             || (workload.getUpdated() != null
                                 && report.getUpdated() <= workload.getUpdated().getTime())) {
-                        return CompletableFuture.completedFuture(workload);
+                        return Future.succeededFuture(workload);
                     }
                     log.info("Workload {} status {} -> {} per report from node {}",
                              report.getWorkloadId(), workload.getStatus(), report.getStatus(), nodeId);
                     workload.setStatus(report.getStatus());
-                    return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
+                    return workloadService.saveSync(workload);
                 });
     }
 
     @Override
-    public CompletableFuture<Void> deregisterNode(String nodeId) {
+    public Future<Void> deregisterNode(String nodeId) {
         Validate.notNull(nodeId, "Node id cannot be null");
 
         return workloadService.countForNode(nodeId)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(count -> {
+                .compose(count -> {
                     if (count > 0) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalStateException("Cannot deregister node with active workloads. "
                                         + "Destroy all workloads on node " + nodeId + " first."));
                     }
                     log.info("Deregistering VmNode: {}", nodeId);
-                    return vmNodeService.deleteById(nodeId).toCompletionStage().toCompletableFuture();
+                    return vmNodeService.deleteById(nodeId);
                 });
     }
 
     @Override
-    public CompletableFuture<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb) {
-        return vmNodeService.findAvailableNode(requiredCpus, requiredMemoryMb, requiredDiskMb)
-                            .toCompletionStage().toCompletableFuture();
+    public Future<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb) {
+        return vmNodeService.findAvailableNode(requiredCpus, requiredMemoryMb, requiredDiskMb);
     }
 
     /**
@@ -179,8 +177,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
             Date cutoffDate = new Date(cutoff);
 
             vmNodeService.findAll(Pageable.create(0, 500, null))
-                    .toCompletionStage().toCompletableFuture()
-                    .thenAccept(page -> {
+                    .onSuccess(page -> {
                         for (VmNode node : page.getContent()) {
                             if (node.getStatus() == VmNodeStatus.ONLINE
                                     && node.getLastSeen() != null
@@ -191,39 +188,30 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
 
                                 node.setStatus(VmNodeStatus.OFFLINE);
                                 vmNodeService.saveSync(node)
-                                        .toCompletionStage().toCompletableFuture()
-                                        .thenCompose(offlineNode -> markNodeWorkloadsFailed(offlineNode.getId()))
-                                        .exceptionally(error -> {
-                                            log.error("Error handling offline node {}", node.getId(), error);
-                                            return null;
-                                        });
+                                        .compose(offlineNode -> markNodeWorkloadsFailed(offlineNode.getId()))
+                                        .onFailure(error -> log.error("Error handling offline node {}", node.getId(), error));
                             }
                         }
                     })
-                    .exceptionally(error -> {
-                        log.error("Error during node health check", error);
-                        return null;
-                    });
+                    .onFailure(error -> log.error("Error during node health check", error));
         } catch (Exception e) {
             log.error("Unexpected error during node health check", e);
         }
     }
 
-    private CompletableFuture<Void> markNodeWorkloadsFailed(String nodeId) {
+    private Future<Void> markNodeWorkloadsFailed(String nodeId) {
         return workloadService.findAllForNode(nodeId, Pageable.create(0, 500, null))
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(page -> {
-                    CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
+                .compose(page -> {
+                    Future<Void> chain = Future.succeededFuture();
                     for (Workload workload : page.getContent()) {
                         if (workload.getStatus() == WorkloadStatus.RUNNING
                                 || workload.getStatus() == WorkloadStatus.STARTING) {
-                            chain = chain.thenCompose(v -> {
+                            chain = chain.compose(v -> {
                                 log.warn("Marking workload {} as FAILED due to node {} going offline",
                                          workload.getId(), nodeId);
                                 workload.setStatus(WorkloadStatus.FAILED);
                                 return workloadService.saveSync(workload)
-                                                      .toCompletionStage().toCompletableFuture()
-                                                      .thenApply(w -> null);
+                                                      .mapEmpty();
                             });
                         }
                     }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeOrchestrationService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeOrchestrationService.java
@@ -65,6 +65,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
         Validate.notNull(registration.getId(), "Node id cannot be null");
 
         return vmNodeService.findById(registration.getId())
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(existing -> {
                     if (existing != null) {
                         existing.setHostname(registration.getHostname())
@@ -74,7 +75,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                                 .setTotalDiskMb(registration.getTotalDiskMb())
                                 .setStatus(VmNodeStatus.ONLINE);
                         log.info("Re-registering VmNode: {} ({})", existing.getName(), existing.getId());
-                        return vmNodeService.saveSync(existing);
+                        return vmNodeService.saveSync(existing).toCompletionStage().toCompletableFuture();
                     } else {
                         VmNode node = new VmNode(registration.getId(), registration.getName(), registration.getHostname());
                         node.setTotalCpus(registration.getTotalCpus());
@@ -82,7 +83,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                         node.setTotalDiskMb(registration.getTotalDiskMb());
                         node.setStatus(VmNodeStatus.ONLINE);
                         log.info("Registering new VmNode: {} ({})", node.getName(), node.getId());
-                        return vmNodeService.saveSync(node);
+                        return vmNodeService.saveSync(node).toCompletionStage().toCompletableFuture();
                     }
                 });
     }
@@ -92,6 +93,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
         Validate.notNull(nodeId, "Node id cannot be null");
 
         return vmNodeService.findById(nodeId)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(node -> {
                     if (node == null) {
                         return CompletableFuture.failedFuture(
@@ -102,7 +104,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                         log.info("VmNode {} came back online", nodeId);
                         node.setStatus(VmNodeStatus.ONLINE);
                     }
-                    return vmNodeService.saveSync(node);
+                    return vmNodeService.saveSync(node).toCompletionStage().toCompletableFuture();
                 });
     }
 
@@ -118,6 +120,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
 
     private CompletableFuture<Workload> applyStatusReport(String nodeId, WorkloadStatusReport report) {
         return workloadService.findById(report.getWorkloadId())
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(workload -> {
                     if (workload == null) {
                         // Destroyed since the node recorded the status — stale report
@@ -138,7 +141,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                     log.info("Workload {} status {} -> {} per report from node {}",
                              report.getWorkloadId(), workload.getStatus(), report.getStatus(), nodeId);
                     workload.setStatus(report.getStatus());
-                    return workloadService.saveSync(workload);
+                    return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
                 });
     }
 
@@ -147,6 +150,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
         Validate.notNull(nodeId, "Node id cannot be null");
 
         return workloadService.countForNode(nodeId)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(count -> {
                     if (count > 0) {
                         return CompletableFuture.failedFuture(
@@ -154,13 +158,14 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                                         + "Destroy all workloads on node " + nodeId + " first."));
                     }
                     log.info("Deregistering VmNode: {}", nodeId);
-                    return vmNodeService.deleteById(nodeId);
+                    return vmNodeService.deleteById(nodeId).toCompletionStage().toCompletableFuture();
                 });
     }
 
     @Override
     public CompletableFuture<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb) {
-        return vmNodeService.findAvailableNode(requiredCpus, requiredMemoryMb, requiredDiskMb);
+        return vmNodeService.findAvailableNode(requiredCpus, requiredMemoryMb, requiredDiskMb)
+                            .toCompletionStage().toCompletableFuture();
     }
 
     /**
@@ -174,6 +179,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
             Date cutoffDate = new Date(cutoff);
 
             vmNodeService.findAll(Pageable.create(0, 500, null))
+                    .toCompletionStage().toCompletableFuture()
                     .thenAccept(page -> {
                         for (VmNode node : page.getContent()) {
                             if (node.getStatus() == VmNodeStatus.ONLINE
@@ -185,6 +191,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
 
                                 node.setStatus(VmNodeStatus.OFFLINE);
                                 vmNodeService.saveSync(node)
+                                        .toCompletionStage().toCompletableFuture()
                                         .thenCompose(offlineNode -> markNodeWorkloadsFailed(offlineNode.getId()))
                                         .exceptionally(error -> {
                                             log.error("Error handling offline node {}", node.getId(), error);
@@ -204,6 +211,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
 
     private CompletableFuture<Void> markNodeWorkloadsFailed(String nodeId) {
         return workloadService.findAllForNode(nodeId, Pageable.create(0, 500, null))
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(page -> {
                     CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
                     for (Workload workload : page.getContent()) {
@@ -213,7 +221,9 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                                 log.warn("Marking workload {} as FAILED due to node {} going offline",
                                          workload.getId(), nodeId);
                                 workload.setStatus(WorkloadStatus.FAILED);
-                                return workloadService.saveSync(workload).thenApply(w -> null);
+                                return workloadService.saveSync(workload)
+                                                      .toCompletionStage().toCompletableFuture()
+                                                      .thenApply(w -> null);
                             });
                         }
                     }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeService.java
@@ -1,14 +1,14 @@
 package org.kinotic.orchestrator.internal.api.services;
 
-import org.kinotic.domain.internal.api.services.AbstractCrudService;
-import java.util.Date;
-import java.util.concurrent.CompletableFuture;
-
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
+import org.kinotic.domain.internal.api.services.AbstractCrudService;
 import org.kinotic.orchestrator.api.model.workload.VmNode;
-import org.kinotic.orchestrator.internal.api.repositories.VmNodeRepository;
 import org.kinotic.orchestrator.api.services.VmNodeService;
+import org.kinotic.orchestrator.internal.api.repositories.VmNodeRepository;
 import org.springframework.stereotype.Component;
+
+import java.util.Date;
 
 @Component
 public class DefaultVmNodeService extends AbstractCrudService<VmNode> implements VmNodeService {
@@ -21,25 +21,25 @@ public class DefaultVmNodeService extends AbstractCrudService<VmNode> implements
     }
 
     @Override
-    public CompletableFuture<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb) {
+    public Future<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb) {
         // Elasticsearch can't express "available = total - allocated" in a server-side query, so
         // we fetch the online nodes and filter locally.
         return vmNodeRepository.findOnlineNodes()
-                .thenApply(page -> page.getContent()
-                                       .stream()
-                                       .filter(node -> node.getAvailableCpus() >= requiredCpus
-                                               && node.getAvailableMemoryMb() >= requiredMemoryMb
-                                               && node.getAvailableDiskMb() >= requiredDiskMb)
-                                       .findFirst()
-                                       .orElse(null));
+                .map(page -> page.getContent()
+                                 .stream()
+                                 .filter(node -> node.getAvailableCpus() >= requiredCpus
+                                         && node.getAvailableMemoryMb() >= requiredMemoryMb
+                                         && node.getAvailableDiskMb() >= requiredDiskMb)
+                                 .findFirst()
+                                 .orElse(null));
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(VmNode entity) {
+    protected Future<Void> beforeSave(VmNode entity) {
         Validate.notNull(entity, "VmNode cannot be null");
         Validate.notNull(entity.getId(), "VmNode id cannot be null");
         entity.setLastSeen(new Date());
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultWorkloadOrchestrationService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultWorkloadOrchestrationService.java
@@ -47,11 +47,13 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
 
                     // Persist the workload and update node resource allocation
                     return workloadService.saveSync(workload)
+                            .toCompletionStage().toCompletableFuture()
                             .thenCompose(savedWorkload -> {
                                 node.setAllocatedCpus(node.getAllocatedCpus() + savedWorkload.getVcpus());
                                 node.setAllocatedMemoryMb(node.getAllocatedMemoryMb() + savedWorkload.getMemoryMb());
                                 node.setAllocatedDiskMb(node.getAllocatedDiskMb() + savedWorkload.getDiskSizeMb());
                                 return vmNodeService.saveSync(node)
+                                        .toCompletionStage().toCompletableFuture()
                                         .thenApply(updatedNode -> savedWorkload);
                             })
                             .thenCompose(savedWorkload ->
@@ -60,13 +62,14 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                                         .thenCompose(startedWorkload -> {
                                             // VmManager started the workload, mark as RUNNING
                                             startedWorkload.setStatus(WorkloadStatus.RUNNING);
-                                            return workloadService.saveSync(startedWorkload);
+                                            return workloadService.saveSync(startedWorkload).toCompletionStage().toCompletableFuture();
                                         })
                                         .exceptionallyCompose(error -> {
                                             log.error("Failed to start workload {} on node {}",
                                                       savedWorkload.getId(), node.getId(), error);
                                             savedWorkload.setStatus(WorkloadStatus.FAILED);
                                             return workloadService.saveSync(savedWorkload)
+                                                    .toCompletionStage().toCompletableFuture()
                                                     .thenCompose(failed -> CompletableFuture.failedFuture(error));
                                         })
                             );
@@ -78,6 +81,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
         Validate.notNull(workloadId, "Workload id cannot be null");
 
         return workloadService.findById(workloadId)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(workload -> {
                     if (workload == null) {
                         return CompletableFuture.failedFuture(
@@ -89,19 +93,20 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                     }
 
                     workload.setStatus(WorkloadStatus.STARTING);
-                    return workloadService.saveSync(workload);
+                    return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
                 })
                 .thenCompose(workload ->
                     vmManagerProxy.restartWorkload(workload.getNodeId(), workloadId)
                             .thenCompose(restarted -> {
                                 restarted.setStatus(WorkloadStatus.RUNNING);
-                                return workloadService.saveSync(restarted);
+                                return workloadService.saveSync(restarted).toCompletionStage().toCompletableFuture();
                             })
                             .exceptionallyCompose(error -> {
                                 log.error("Failed to restart workload {} on node {}",
                                           workloadId, workload.getNodeId(), error);
                                 workload.setStatus(WorkloadStatus.FAILED);
                                 return workloadService.saveSync(workload)
+                                        .toCompletionStage().toCompletableFuture()
                                         .thenCompose(failed -> CompletableFuture.failedFuture(error));
                             })
                 );
@@ -112,6 +117,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
         Validate.notNull(workloadId, "Workload id cannot be null");
 
         return workloadService.findById(workloadId)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(workload -> {
                     if (workload == null) {
                         return CompletableFuture.failedFuture(
@@ -119,13 +125,13 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                     }
 
                     workload.setStatus(WorkloadStatus.STOPPING);
-                    return workloadService.saveSync(workload);
+                    return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
                 })
                 .thenCompose(workload ->
                     vmManagerProxy.stopWorkload(workload.getNodeId(), workloadId)
                             .thenCompose(v -> {
                                 workload.setStatus(WorkloadStatus.STOPPED);
-                                return workloadService.saveSync(workload);
+                                return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
                             })
                 )
                 .thenApply(workload -> null);
@@ -136,6 +142,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
         Validate.notNull(workloadId, "Workload id cannot be null");
 
         return workloadService.findById(workloadId)
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(workload -> {
                     if (workload == null) {
                         return CompletableFuture.failedFuture(
@@ -147,17 +154,18 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                             .thenCompose(v ->
                                 // Free allocated resources on the node
                                 vmNodeService.findById(workload.getNodeId())
+                                        .toCompletionStage().toCompletableFuture()
                                         .thenCompose(node -> {
                                             if (node != null) {
                                                 node.setAllocatedCpus(Math.max(0, node.getAllocatedCpus() - workload.getVcpus()));
                                                 node.setAllocatedMemoryMb(Math.max(0, node.getAllocatedMemoryMb() - workload.getMemoryMb()));
                                                 node.setAllocatedDiskMb(Math.max(0, node.getAllocatedDiskMb() - workload.getDiskSizeMb()));
-                                                return vmNodeService.saveSync(node);
+                                                return vmNodeService.saveSync(node).toCompletionStage().toCompletableFuture();
                                             }
                                             return CompletableFuture.completedFuture(node);
                                         })
                             )
-                            .thenCompose(node -> workloadService.deleteById(workloadId));
+                            .thenCompose(node -> workloadService.deleteById(workloadId).toCompletionStage().toCompletableFuture());
                 });
     }
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultWorkloadOrchestrationService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultWorkloadOrchestrationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
@@ -8,11 +9,10 @@ import org.kinotic.orchestrator.api.services.WorkloadService;
 import org.kinotic.orchestrator.api.services.VmNodeOrchestrationService;
 import org.kinotic.orchestrator.api.workload.VmManagerProxy;
 import org.kinotic.orchestrator.api.services.WorkloadOrchestrationService;
+import org.kinotic.orchestrator.api.model.workload.VmNode;
 import org.kinotic.orchestrator.api.model.workload.Workload;
 import org.kinotic.orchestrator.api.model.workload.WorkloadStatus;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
@@ -26,16 +26,16 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
     private final WorkloadService workloadService;
 
     @Override
-    public CompletableFuture<Workload> deployWorkload(Workload workload) {
+    public Future<Workload> deployWorkload(Workload workload) {
         Validate.notNull(workload, "Workload cannot be null");
         Validate.notNull(workload.getName(), "Workload name cannot be null");
         Validate.notNull(workload.getImage(), "Workload image cannot be null");
 
         // Find a node with sufficient resources
         return nodeOrchestrationService.findAvailableNode(workload.getVcpus(), workload.getMemoryMb(), workload.getDiskSizeMb())
-                .thenCompose(node -> {
+                .compose(node -> {
                     if (node == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalStateException("No available node with sufficient resources to deploy workload"));
                     }
 
@@ -47,125 +47,120 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
 
                     // Persist the workload and update node resource allocation
                     return workloadService.saveSync(workload)
-                            .toCompletionStage().toCompletableFuture()
-                            .thenCompose(savedWorkload -> {
+                            .compose(savedWorkload -> {
                                 node.setAllocatedCpus(node.getAllocatedCpus() + savedWorkload.getVcpus());
                                 node.setAllocatedMemoryMb(node.getAllocatedMemoryMb() + savedWorkload.getMemoryMb());
                                 node.setAllocatedDiskMb(node.getAllocatedDiskMb() + savedWorkload.getDiskSizeMb());
                                 return vmNodeService.saveSync(node)
-                                        .toCompletionStage().toCompletableFuture()
-                                        .thenApply(updatedNode -> savedWorkload);
+                                        .map(savedWorkload);
                             })
-                            .thenCompose(savedWorkload ->
+                            .compose(savedWorkload ->
                                 // Dispatch to the VmManager on the selected node
                                 vmManagerProxy.startWorkload(node.getId(), savedWorkload)
-                                        .thenCompose(startedWorkload -> {
+                                        .compose(startedWorkload -> {
                                             // VmManager started the workload, mark as RUNNING
                                             startedWorkload.setStatus(WorkloadStatus.RUNNING);
-                                            return workloadService.saveSync(startedWorkload).toCompletionStage().toCompletableFuture();
+                                            return workloadService.saveSync(startedWorkload);
                                         })
-                                        .exceptionallyCompose(error -> {
+                                        .recover(error -> {
                                             log.error("Failed to start workload {} on node {}",
                                                       savedWorkload.getId(), node.getId(), error);
                                             savedWorkload.setStatus(WorkloadStatus.FAILED);
                                             return workloadService.saveSync(savedWorkload)
-                                                    .toCompletionStage().toCompletableFuture()
-                                                    .thenCompose(failed -> CompletableFuture.failedFuture(error));
+                                                    .compose(failed -> Future.failedFuture(error));
                                         })
                             );
                 });
     }
 
     @Override
-    public CompletableFuture<Workload> restartWorkload(String workloadId) {
+    public Future<Workload> restartWorkload(String workloadId) {
         Validate.notNull(workloadId, "Workload id cannot be null");
 
         return workloadService.findById(workloadId)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(workload -> {
+                .compose(workload -> {
                     if (workload == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Workload not found: " + workloadId));
                     }
                     if (workload.getStatus() != WorkloadStatus.STOPPED) {
-                        return CompletableFuture.failedFuture(new IllegalStateException(
+                        return Future.failedFuture(new IllegalStateException(
                                 "Workload " + workloadId + " is not stopped (status: " + workload.getStatus() + ")"));
                     }
 
                     workload.setStatus(WorkloadStatus.STARTING);
-                    return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
+                    return workloadService.saveSync(workload);
                 })
-                .thenCompose(workload ->
+                .compose(workload ->
                     vmManagerProxy.restartWorkload(workload.getNodeId(), workloadId)
-                            .thenCompose(restarted -> {
+                            .compose(restarted -> {
                                 restarted.setStatus(WorkloadStatus.RUNNING);
-                                return workloadService.saveSync(restarted).toCompletionStage().toCompletableFuture();
+                                return workloadService.saveSync(restarted);
                             })
-                            .exceptionallyCompose(error -> {
+                            .recover(error -> {
                                 log.error("Failed to restart workload {} on node {}",
                                           workloadId, workload.getNodeId(), error);
                                 workload.setStatus(WorkloadStatus.FAILED);
                                 return workloadService.saveSync(workload)
-                                        .toCompletionStage().toCompletableFuture()
-                                        .thenCompose(failed -> CompletableFuture.failedFuture(error));
+                                        .compose(failed -> Future.failedFuture(error));
                             })
                 );
     }
 
     @Override
-    public CompletableFuture<Void> stopWorkload(String workloadId) {
+    public Future<Void> stopWorkload(String workloadId) {
         Validate.notNull(workloadId, "Workload id cannot be null");
 
         return workloadService.findById(workloadId)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(workload -> {
+                .compose(workload -> {
                     if (workload == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Workload not found: " + workloadId));
                     }
 
                     workload.setStatus(WorkloadStatus.STOPPING);
-                    return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
+                    return workloadService.saveSync(workload);
                 })
-                .thenCompose(workload ->
+                .compose(workload ->
                     vmManagerProxy.stopWorkload(workload.getNodeId(), workloadId)
-                            .thenCompose(v -> {
+                            .compose(v -> {
                                 workload.setStatus(WorkloadStatus.STOPPED);
-                                return workloadService.saveSync(workload).toCompletionStage().toCompletableFuture();
+                                return workloadService.saveSync(workload);
                             })
                 )
-                .thenApply(workload -> null);
+                .mapEmpty();
     }
 
     @Override
-    public CompletableFuture<Void> destroyWorkload(String workloadId) {
+    public Future<Void> destroyWorkload(String workloadId) {
         Validate.notNull(workloadId, "Workload id cannot be null");
 
         return workloadService.findById(workloadId)
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(workload -> {
+                .compose(workload -> {
                     if (workload == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("Workload not found: " + workloadId));
                     }
 
                     // Dispatch destroy to the VmManager on the workload's node
                     return vmManagerProxy.destroyWorkload(workload.getNodeId(), workloadId)
-                            .thenCompose(v ->
+                            .compose(v ->
                                 // Free allocated resources on the node
                                 vmNodeService.findById(workload.getNodeId())
-                                        .toCompletionStage().toCompletableFuture()
-                                        .thenCompose(node -> {
+                                        .compose(node -> {
+                                            Future<VmNode> ret;
                                             if (node != null) {
                                                 node.setAllocatedCpus(Math.max(0, node.getAllocatedCpus() - workload.getVcpus()));
                                                 node.setAllocatedMemoryMb(Math.max(0, node.getAllocatedMemoryMb() - workload.getMemoryMb()));
                                                 node.setAllocatedDiskMb(Math.max(0, node.getAllocatedDiskMb() - workload.getDiskSizeMb()));
-                                                return vmNodeService.saveSync(node).toCompletionStage().toCompletableFuture();
+                                                ret = vmNodeService.saveSync(node);
+                                            } else {
+                                                ret = Future.succeededFuture(node);
                                             }
-                                            return CompletableFuture.completedFuture(node);
+                                            return ret;
                                         })
                             )
-                            .thenCompose(node -> workloadService.deleteById(workloadId).toCompletionStage().toCompletableFuture());
+                            .compose(node -> workloadService.deleteById(workloadId));
                 });
     }
 }

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultWorkloadService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultWorkloadService.java
@@ -1,17 +1,17 @@
 package org.kinotic.orchestrator.internal.api.services;
 
-import org.kinotic.domain.internal.api.services.AbstractCrudService;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
+import org.kinotic.domain.internal.api.services.AbstractCrudService;
 import org.kinotic.orchestrator.api.model.workload.Workload;
-import org.kinotic.orchestrator.internal.api.repositories.WorkloadRepository;
 import org.kinotic.orchestrator.api.services.WorkloadService;
+import org.kinotic.orchestrator.internal.api.repositories.WorkloadRepository;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultWorkloadService extends AbstractCrudService<Workload> implements WorkloadService {
@@ -24,17 +24,17 @@ public class DefaultWorkloadService extends AbstractCrudService<Workload> implem
     }
 
     @Override
-    public CompletableFuture<Page<Workload>> findAllForNode(String nodeId, Pageable pageable) {
+    public Future<Page<Workload>> findAllForNode(String nodeId, Pageable pageable) {
         return workloadRepository.findAllForNode(nodeId, pageable);
     }
 
     @Override
-    public CompletableFuture<Long> countForNode(String nodeId) {
+    public Future<Long> countForNode(String nodeId) {
         return workloadRepository.countForNode(nodeId);
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(Workload entity) {
+    protected Future<Void> beforeSave(Workload entity) {
         Validate.notNull(entity, "Workload cannot be null");
         Validate.notNull(entity.getName(), "Workload name cannot be null");
         Validate.notNull(entity.getImage(), "Workload image cannot be null");
@@ -46,7 +46,7 @@ public class DefaultWorkloadService extends AbstractCrudService<Workload> implem
         if (entity.getCreated() == null) {
             entity.setCreated(new Date());
         }
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
 }

--- a/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/StubJobRunService.java
+++ b/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/StubJobRunService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.grind;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.orchestrator.api.model.grind.JobOwner;
@@ -8,7 +9,6 @@ import org.kinotic.orchestrator.api.services.JobRunService;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * In-memory stand-in for the Elasticsearch backed {@link JobRunService}, capturing what the
@@ -19,69 +19,69 @@ public class StubJobRunService implements JobRunService {
     public final Map<String, JobRun> saved = new LinkedHashMap<>();
 
     @Override
-    public CompletableFuture<JobRun> save(JobRun entity) {
+    public Future<JobRun> save(JobRun entity) {
         saved.put(entity.getId(), entity);
-        return CompletableFuture.completedFuture(entity);
+        return Future.succeededFuture(entity);
     }
 
     @Override
-    public CompletableFuture<JobRun> saveSync(JobRun entity) {
+    public Future<JobRun> saveSync(JobRun entity) {
         return save(entity);
     }
 
     @Override
-    public CompletableFuture<JobRun> create(JobRun entity) {
+    public Future<JobRun> create(JobRun entity) {
         return save(entity);
     }
 
     @Override
-    public CompletableFuture<JobRun> createSync(JobRun entity) {
+    public Future<JobRun> createSync(JobRun entity) {
         return save(entity);
     }
 
     @Override
-    public CompletableFuture<JobRun> findById(String id) {
-        return CompletableFuture.completedFuture(saved.get(id));
+    public Future<JobRun> findById(String id) {
+        return Future.succeededFuture(saved.get(id));
     }
 
     @Override
-    public CompletableFuture<Long> count() {
-        return CompletableFuture.completedFuture((long) saved.size());
+    public Future<Long> count() {
+        return Future.succeededFuture((long) saved.size());
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String id) {
+    public Future<Void> deleteById(String id) {
         saved.remove(id);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Void> deleteByIdSync(String id) {
+    public Future<Void> deleteByIdSync(String id) {
         return deleteById(id);
     }
 
     @Override
-    public CompletableFuture<Page<JobRun>> findAll(Pageable pageable) {
+    public Future<Page<JobRun>> findAll(Pageable pageable) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public CompletableFuture<Page<JobRun>> search(String searchText, Pageable pageable) {
+    public Future<Page<JobRun>> search(String searchText, Pageable pageable) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public CompletableFuture<Void> syncIndex() {
-        return CompletableFuture.completedFuture(null);
+    public Future<Void> syncIndex() {
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Page<JobRun>> findByName(String name, Pageable pageable) {
+    public Future<Page<JobRun>> findByName(String name, Pageable pageable) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public CompletableFuture<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable) {
+    public Future<Page<JobRun>> findAllForOwner(JobOwner owner, Pageable pageable) {
         throw new UnsupportedOperationException();
     }
 }

--- a/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/StubTaskRecordService.java
+++ b/kinotic-orchestrator/src/test/java/org/kinotic/orchestrator/internal/api/grind/StubTaskRecordService.java
@@ -1,5 +1,6 @@
 package org.kinotic.orchestrator.internal.api.grind;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.OffsetPageable;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -9,7 +10,6 @@ import org.kinotic.orchestrator.api.services.TaskRecordService;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * In-memory stand-in for the Elasticsearch backed {@link TaskRecordService}, capturing what the
@@ -30,68 +30,68 @@ public class StubTaskRecordService implements TaskRecordService {
     }
 
     @Override
-    public CompletableFuture<TaskRecord> save(TaskRecord entity) {
+    public Future<TaskRecord> save(TaskRecord entity) {
         saved.put(entity.getId(), entity);
-        return CompletableFuture.completedFuture(entity);
+        return Future.succeededFuture(entity);
     }
 
     @Override
-    public CompletableFuture<TaskRecord> saveSync(TaskRecord entity) {
+    public Future<TaskRecord> saveSync(TaskRecord entity) {
         return save(entity);
     }
 
     @Override
-    public CompletableFuture<TaskRecord> create(TaskRecord entity) {
+    public Future<TaskRecord> create(TaskRecord entity) {
         return save(entity);
     }
 
     @Override
-    public CompletableFuture<TaskRecord> createSync(TaskRecord entity) {
+    public Future<TaskRecord> createSync(TaskRecord entity) {
         return save(entity);
     }
 
     @Override
-    public CompletableFuture<TaskRecord> findById(String id) {
-        return CompletableFuture.completedFuture(saved.get(id));
+    public Future<TaskRecord> findById(String id) {
+        return Future.succeededFuture(saved.get(id));
     }
 
     @Override
-    public CompletableFuture<Long> count() {
-        return CompletableFuture.completedFuture((long) saved.size());
+    public Future<Long> count() {
+        return Future.succeededFuture((long) saved.size());
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String id) {
+    public Future<Void> deleteById(String id) {
         saved.remove(id);
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Void> deleteByIdSync(String id) {
+    public Future<Void> deleteByIdSync(String id) {
         return deleteById(id);
     }
 
     @Override
-    public CompletableFuture<Page<TaskRecord>> findAll(Pageable pageable) {
+    public Future<Page<TaskRecord>> findAll(Pageable pageable) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public CompletableFuture<Page<TaskRecord>> search(String searchText, Pageable pageable) {
+    public Future<Page<TaskRecord>> search(String searchText, Pageable pageable) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public CompletableFuture<Void> syncIndex() {
-        return CompletableFuture.completedFuture(null);
+    public Future<Void> syncIndex() {
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable) {
+    public Future<Page<TaskRecord>> findAllForJobRun(String jobRunId, Pageable pageable) {
         List<TaskRecord> matching = forRun(jobRunId);
         int pageNumber = ((OffsetPageable) pageable).getPageNumber();
         int from = Math.min(pageNumber * pageable.getPageSize(), matching.size());
         int to = Math.min(from + pageable.getPageSize(), matching.size());
-        return CompletableFuture.completedFuture(new Page<>(matching.subList(from, to), (long) matching.size()));
+        return Future.succeededFuture(new Page<>(matching.subList(from, to), (long) matching.size()));
     }
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ApplicationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ApplicationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.domain.api.model.Application;
@@ -7,7 +8,6 @@ import org.kinotic.domain.api.model.security.OidcConfiguration;
 import org.kinotic.idl.api.annotations.McpTool;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Manages {@link Application}s. An application's id is derived from its slugified name at
@@ -23,10 +23,10 @@ public interface ApplicationService extends IdentifiableCrudService<Application,
      * The organization id is derived from the authenticated participant.
      * @param name the name of the application to create
      * @param description the description of the application to create
-     * @return {@link CompletableFuture} emitting the created application, or the existing
+     * @return {@link Future} emitting the created application, or the existing
      *         application whose id matches the slugified name
      */
-    CompletableFuture<Application> createApplicationIfNotExist(String name, String description);
+    Future<Application> createApplicationIfNotExist(String name, String description);
 
     /**
      * Returns the enabled OIDC configurations registered on the given application.
@@ -35,7 +35,7 @@ public interface ApplicationService extends IdentifiableCrudService<Application,
      * @return the enabled configurations, or an empty list if the application is not
      *         found or has no configurations attached
      */
-    CompletableFuture<List<OidcConfiguration>> getOidcConfigurations(String applicationId);
+    Future<List<OidcConfiguration>> getOidcConfigurations(String applicationId);
 
 }
 

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/InviteEmailTemplateService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/InviteEmailTemplateService.java
@@ -1,10 +1,9 @@
 package org.kinotic.os.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.domain.api.model.InviteEmailTemplate;
 import org.kinotic.domain.api.services.ApplicationScopedCrudService;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * CRUD service for an application's customized invitation email — at most one
@@ -19,6 +18,6 @@ public interface InviteEmailTemplateService extends ApplicationScopedCrudService
      * Finds the application's invitation template, or {@code null} when the application
      * uses the built-in email.
      */
-    CompletableFuture<InviteEmailTemplate> findByApplication(String applicationId);
+    Future<InviteEmailTemplate> findByApplication(String applicationId);
 
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/KinoticClusterInfoService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/KinoticClusterInfoService.java
@@ -1,11 +1,10 @@
 package org.kinotic.os.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.api.model.cluster.KinoticClusterInfo;
 import org.kinotic.domain.api.utils.DomainUtil;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provides information about the ignite Kinotic cluster.
@@ -19,6 +18,6 @@ public interface KinoticClusterInfoService {
      * 
      * @return the information about the ignite structures cluster
      */
-    CompletableFuture<KinoticClusterInfo> getClusterInfo();
+    Future<KinoticClusterInfo> getClusterInfo();
 
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/LogService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/LogService.java
@@ -1,11 +1,10 @@
 package org.kinotic.os.api.services;
 
+import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.domain.api.model.log.LogQuery;
 import reactor.core.publisher.Flux;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Streams and queries the logs of workloads the authenticated participant may view: an
@@ -28,7 +27,7 @@ public interface LogService {
      * Returns a workload's historical logs for the given time range.
      *
      * @param query the {@link LogQuery} naming the workload, time range, and limit
-     * @return a {@link CompletableFuture} emitting the raw Loki {@code query_range} response
+     * @return a {@link Future} emitting the raw Loki {@code query_range} response
      */
-    CompletableFuture<Buffer> history(LogQuery query);
+    Future<Buffer> history(LogQuery query);
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ProjectService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ProjectService.java
@@ -1,12 +1,12 @@
 package org.kinotic.os.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.domain.api.services.ApplicationScopedCrudService;
 import org.kinotic.domain.api.model.Project;
 import org.kinotic.idl.api.annotations.McpTool;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * CRUD service for {@link Project} entities, with application-scoped queries
@@ -22,9 +22,9 @@ public interface ProjectService extends ApplicationScopedCrudService<Project, St
      *
      * @param project the project to create; the id is auto-derived from the application id
      *                and slugified name if not set
-     * @return a {@link CompletableFuture} emitting the created or existing project
+     * @return a {@link Future} emitting the created or existing project
      */
-    CompletableFuture<Project> createProjectIfNotExist(Project project);
+    Future<Project> createProjectIfNotExist(Project project);
 
     /**
      * Looks up projects in the current participant's organization whose backing GitHub repo
@@ -32,7 +32,7 @@ public interface ProjectService extends ApplicationScopedCrudService<Project, St
      * that organization is backed by the repo.
      */
     @McpTool(title = "Find by GitHub Repo", readOnlyHint = true)
-    CompletableFuture<List<Project>> findByRepoFullName(String repoFullName);
+    Future<List<Project>> findByRepoFullName(String repoFullName);
 
     /**
      * Re-runs repository initialization for a project left
@@ -42,10 +42,10 @@ public interface ProjectService extends ApplicationScopedCrudService<Project, St
      * baseline is committed.
      *
      * @param projectId id of the project to retry
-     * @return a {@link CompletableFuture} emitting the updated project
+     * @return a {@link Future} emitting the updated project
      * @throws IllegalStateException when the project is not awaiting an initialization retry
      */
     @McpTool(openWorldHint = true)
-    CompletableFuture<Project> retryRepoInitialization(String projectId);
+    Future<Project> retryRepoInitialization(String projectId);
 
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/SystemOrganizationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/SystemOrganizationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.core.api.crud.Page;
@@ -10,8 +11,6 @@ import org.kinotic.domain.api.model.Project;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
 import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.os.api.model.security.PendingInviteSummary;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Cross-organization reads for platform operators. Published in the system zone, which only
@@ -28,7 +27,7 @@ public interface SystemOrganizationService {
      * @param pageable the page settings to use
      * @return a page of {@link Organization}s
      */
-    CompletableFuture<Page<Organization>> findOrganizations(Pageable pageable);
+    Future<Page<Organization>> findOrganizations(Pageable pageable);
 
     /**
      * Searches every organization on the platform.
@@ -37,7 +36,7 @@ public interface SystemOrganizationService {
      * @param pageable the page settings to use
      * @return a page of matching {@link Organization}s
      */
-    CompletableFuture<Page<Organization>> searchOrganizations(String searchText, Pageable pageable);
+    Future<Page<Organization>> searchOrganizations(String searchText, Pageable pageable);
 
     /**
      * Returns the organization with the given id, or null if none exists.
@@ -45,14 +44,14 @@ public interface SystemOrganizationService {
      * @param organizationId the id of the organization to return
      * @return the {@link Organization}, or null when not found
      */
-    CompletableFuture<Organization> findOrganizationById(String organizationId);
+    Future<Organization> findOrganizationById(String organizationId);
 
     /**
      * Counts every organization on the platform.
      *
      * @return the number of organizations
      */
-    CompletableFuture<Long> countOrganizations();
+    Future<Long> countOrganizations();
 
     /**
      * Returns the applications owned by the given organization.
@@ -61,7 +60,7 @@ public interface SystemOrganizationService {
      * @param pageable the page settings to use
      * @return a page of the organization's {@link Application}s
      */
-    CompletableFuture<Page<Application>> findApplications(String organizationId, Pageable pageable);
+    Future<Page<Application>> findApplications(String organizationId, Pageable pageable);
 
     /**
      * Returns the projects owned by the given organization, across all of its applications.
@@ -70,7 +69,7 @@ public interface SystemOrganizationService {
      * @param pageable the page settings to use
      * @return a page of the organization's {@link Project}s
      */
-    CompletableFuture<Page<Project>> findProjects(String organizationId, Pageable pageable);
+    Future<Page<Project>> findProjects(String organizationId, Pageable pageable);
 
     /**
      * Returns the given organization's members, or one application's members when
@@ -81,7 +80,7 @@ public interface SystemOrganizationService {
      * @param pageable the page settings to use
      * @return a page of matching {@link UserParticipantIdentity}s
      */
-    CompletableFuture<Page<UserParticipantIdentity>> findMembers(String organizationId,
+    Future<Page<UserParticipantIdentity>> findMembers(String organizationId,
                                                                  String applicationId,
                                                                  Pageable pageable);
 
@@ -95,7 +94,7 @@ public interface SystemOrganizationService {
      * @param pageable the page settings to use
      * @return a page of matching {@link UserParticipantIdentity}s
      */
-    CompletableFuture<Page<UserParticipantIdentity>> searchMembers(String searchText,
+    Future<Page<UserParticipantIdentity>> searchMembers(String searchText,
                                                                    String organizationId,
                                                                    String applicationId,
                                                                    Pageable pageable);
@@ -109,7 +108,7 @@ public interface SystemOrganizationService {
      * @param pageable the page settings to use
      * @return a page of {@link PendingInviteSummary}s
      */
-    CompletableFuture<Page<PendingInviteSummary>> findPendingInvites(String organizationId,
+    Future<Page<PendingInviteSummary>> findPendingInvites(String organizationId,
                                                                      String applicationId,
                                                                      Pageable pageable);
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/DelegateService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/DelegateService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -8,7 +9,6 @@ import org.kinotic.domain.api.model.security.DelegateSession;
 import org.kinotic.domain.api.model.security.DelegatingParticipantIdentity;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The signed-in user's view of the clients authorized to act on their behalf — CLI installs
@@ -23,7 +23,7 @@ public interface DelegateService {
      * Lists the delegates authorized on the calling user's behalf, revoked ones included
      * (disabled entries show as revoked until re-approved).
      */
-    CompletableFuture<Page<DelegatingParticipantIdentity>> findMyDelegates(Pageable pageable, Participant participant);
+    Future<Page<DelegatingParticipantIdentity>> findMyDelegates(Pageable pageable, Participant participant);
 
     /**
      * Lists the live sessions of one of the calling user's delegates — one entry per
@@ -31,7 +31,7 @@ public interface DelegateService {
      *
      * @param delegateId a delegate owned by the calling user
      */
-    CompletableFuture<List<DelegateSession>> findSessions(String delegateId, Participant participant);
+    Future<List<DelegateSession>> findSessions(String delegateId, Participant participant);
 
     /**
      * Ends a single session of one of the calling user's delegates. The session's tokens can
@@ -40,7 +40,7 @@ public interface DelegateService {
      * @param delegateId a delegate owned by the calling user
      * @param familyId   the session to end, from {@link #findSessions}
      */
-    CompletableFuture<Void> revokeSession(String delegateId, String familyId, Participant participant);
+    Future<Void> revokeSession(String delegateId, String familyId, Participant participant);
 
     /**
      * Revokes one of the calling user's delegates entirely: the client is cut off on its next
@@ -49,5 +49,5 @@ public interface DelegateService {
      *
      * @param delegateId a delegate owned by the calling user
      */
-    CompletableFuture<Void> revokeDelegate(String delegateId, Participant participant);
+    Future<Void> revokeDelegate(String delegateId, Participant participant);
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/MachineService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/MachineService.java
@@ -1,12 +1,11 @@
 package org.kinotic.os.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.security.MachineParticipantIdentity;
 import org.kinotic.domain.api.model.security.MachineProvisionResult;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Machine-identity management for the applications of the caller's organization, used by the
@@ -29,10 +28,10 @@ public interface MachineService {
      * @param applicationId the application whose API the machine calls; must belong to the
      *                      caller's organization
      */
-    CompletableFuture<MachineProvisionResult> createMachine(String displayName, String applicationId);
+    Future<MachineProvisionResult> createMachine(String displayName, String applicationId);
 
     /** Lists the machines of the given application of the caller's organization, disabled ones included. */
-    CompletableFuture<Page<MachineParticipantIdentity>> findMachines(String applicationId, Pageable pageable);
+    Future<Page<MachineParticipantIdentity>> findMachines(String applicationId, Pageable pageable);
 
     /**
      * Replaces the client secret of one of the caller's organization's machines, returning the
@@ -41,7 +40,7 @@ public interface MachineService {
      *
      * @param machineId a machine belonging to the caller's organization
      */
-    CompletableFuture<String> rotateSecret(String machineId);
+    Future<String> rotateSecret(String machineId);
 
     /**
      * Enables or disables one of the caller's organization's machines. A disabled machine is
@@ -50,7 +49,7 @@ public interface MachineService {
      *
      * @param machineId a machine belonging to the caller's organization
      */
-    CompletableFuture<Void> setMachineEnabled(String machineId, boolean enabled);
+    Future<Void> setMachineEnabled(String machineId, boolean enabled);
 
     /**
      * Permanently removes one of the caller's organization's machines, including its stored
@@ -58,5 +57,5 @@ public interface MachineService {
      *
      * @param machineId a machine belonging to the caller's organization
      */
-    CompletableFuture<Void> removeMachine(String machineId);
+    Future<Void> removeMachine(String machineId);
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/MemberService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/MemberService.java
@@ -1,12 +1,11 @@
 package org.kinotic.os.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
 import org.kinotic.os.api.model.security.PendingInviteSummary;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Member management for the caller's organization and its applications, used by the web app. Every
@@ -19,13 +18,13 @@ import java.util.concurrent.CompletableFuture;
 public interface MemberService {
 
     /** Lists the members of the scope. */
-    CompletableFuture<Page<UserParticipantIdentity>> findMembers(String applicationId, Pageable pageable);
+    Future<Page<UserParticipantIdentity>> findMembers(String applicationId, Pageable pageable);
 
     /**
      * Searches the scope's members by free text over email and display name. Blank
      * {@code searchText} is equivalent to {@link #findMembers}.
      */
-    CompletableFuture<Page<UserParticipantIdentity>> searchMembers(String searchText, String applicationId, Pageable pageable);
+    Future<Page<UserParticipantIdentity>> searchMembers(String searchText, String applicationId, Pageable pageable);
 
     /**
      * Invites someone into the scope by email. Sends the invitation email and returns the
@@ -36,23 +35,23 @@ public interface MemberService {
      * @param displayName optional display name for the invitee
      * @param applicationId the application to invite into, or null for an org-member invite
      */
-    CompletableFuture<PendingInviteSummary> inviteMember(String email, String displayName, String applicationId);
+    Future<PendingInviteSummary> inviteMember(String email, String displayName, String applicationId);
 
     /**
      * Enables or disables a member of the caller's organization. Disabling gates future
      * logins; established sessions last until they expire. Callers cannot disable themselves.
      */
-    CompletableFuture<Void> setMemberEnabled(String identityId, boolean enabled);
+    Future<Void> setMemberEnabled(String identityId, boolean enabled);
 
     /**
      * Permanently removes a member of the caller's organization, including any stored
      * credential. Callers cannot remove themselves.
      */
-    CompletableFuture<Void> removeMember(String identityId);
+    Future<Void> removeMember(String identityId);
 
     /** Lists the scope's live (unexpired) pending invitations. */
-    CompletableFuture<Page<PendingInviteSummary>> findPendingInvites(String applicationId, Pageable pageable);
+    Future<Page<PendingInviteSummary>> findPendingInvites(String applicationId, Pageable pageable);
 
     /** Cancels a pending invitation belonging to the caller's organization. */
-    CompletableFuture<Void> cancelInvite(String inviteId);
+    Future<Void> cancelInvite(String inviteId);
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/OAuthApprovalService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/OAuthApprovalService.java
@@ -1,10 +1,9 @@
 package org.kinotic.os.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.domain.api.model.security.PendingOAuthAuthorization;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Browser-invoked service for the OAuth 2.1 consent step. The SPA consent page describes the
@@ -19,26 +18,26 @@ public interface OAuthApprovalService {
      * Describes the authorization request awaiting consent, for display before the user decides.
      *
      * @param requestId the request id from the consent page URL
-     * @return a {@link CompletableFuture} emitting the pending request, failing if it is
+     * @return a {@link Future} emitting the pending request, failing if it is
      *         unknown, expired, or already decided
      */
-    CompletableFuture<PendingOAuthAuthorization> describe(String requestId);
+    Future<PendingOAuthAuthorization> describe(String requestId);
 
     /**
      * Approves the authorization request as the calling participant's user.
      *
      * @param requestId the request id from the consent page URL
-     * @return a {@link CompletableFuture} emitting the redirect URL carrying the authorization code
+     * @return a {@link Future} emitting the redirect URL carrying the authorization code
      */
-    CompletableFuture<String> approve(String requestId, Participant participant);
+    Future<String> approve(String requestId, Participant participant);
 
     /**
      * Denies the authorization request.
      *
      * @param requestId the request id from the consent page URL
-     * @return a {@link CompletableFuture} emitting the redirect URL carrying {@code error=access_denied}
+     * @return a {@link Future} emitting the redirect URL carrying {@code error=access_denied}
      */
-    CompletableFuture<String> deny(String requestId);
+    Future<String> deny(String requestId);
 
     /**
      * Approves the pending RFC 8628 device grant identified by {@code userCode} as the calling
@@ -46,5 +45,5 @@ public interface OAuthApprovalService {
      *
      * @param userCode the code the user confirmed on the device page
      */
-    CompletableFuture<Void> approveDevice(String userCode, Participant participant);
+    Future<Void> approveDevice(String userCode, Participant participant);
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/ProfileService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/ProfileService.java
@@ -1,10 +1,9 @@
 package org.kinotic.os.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.domain.api.model.security.UserParticipantIdentity;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The signed-in user's own account details, read and edited from the web app's account
@@ -15,7 +14,7 @@ import java.util.concurrent.CompletableFuture;
 public interface ProfileService {
 
     /** Returns the calling user's identity. */
-    CompletableFuture<UserParticipantIdentity> findMyProfile(Participant participant);
+    Future<UserParticipantIdentity> findMyProfile(Participant participant);
 
     /**
      * Sets the calling user's display name, the name shown wherever they appear in the
@@ -23,5 +22,5 @@ public interface ProfileService {
      *
      * @param displayName the name to show, required
      */
-    CompletableFuture<UserParticipantIdentity> updateDisplayName(String displayName, Participant participant);
+    Future<UserParticipantIdentity> updateDisplayName(String displayName, Participant participant);
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultApplicationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultApplicationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.exceptions.AlreadyExistsException;
 import org.kinotic.core.api.security.SecurityContext;
@@ -16,7 +17,6 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultApplicationService extends AbstractOrganizationScopedService<Application> implements ApplicationService {
@@ -34,13 +34,13 @@ public class DefaultApplicationService extends AbstractOrganizationScopedService
     }
 
     @Override
-    public CompletableFuture<Application> createApplicationIfNotExist(String name, String description) {
+    public Future<Application> createApplicationIfNotExist(String name, String description) {
         String applicationId = DomainUtil.slugifyId(name);
         String organizationId = requireOrganizationId();
         return findById(applicationId)
-                .thenCompose(application -> {
+                .compose(application -> {
                     if(application != null){
-                        return CompletableFuture.completedFuture(application);
+                        return Future.succeededFuture(application);
                     }else{
                         Application newApplication = new Application(name, description);
                         newApplication.setOrganizationId(organizationId);
@@ -50,38 +50,39 @@ public class DefaultApplicationService extends AbstractOrganizationScopedService
     }
 
     @Override
-    public CompletableFuture<Application> create(Application entity) {
+    public Future<Application> create(Application entity) {
         // Force the id to derive from the name; beforeSave mints it from the slug.
         entity.setId(null);
         return failOnDuplicateName(super.create(entity), entity);
     }
 
     @Override
-    public CompletableFuture<Application> createSync(Application entity) {
+    public Future<Application> createSync(Application entity) {
         entity.setId(null);
         return failOnDuplicateName(super.createSync(entity), entity);
     }
 
     // The caller supplied a name, not the derived id an AlreadyExistsException would reference
-    private static CompletableFuture<Application> failOnDuplicateName(CompletableFuture<Application> created,
-                                                                      Application entity) {
-        return created.exceptionallyCompose(ex -> AlreadyExistsException.isCause(ex)
-                ? CompletableFuture.failedFuture(new AlreadyExistsException(
+    private static Future<Application> failOnDuplicateName(Future<Application> created,
+                                                           Application entity) {
+        return created.recover(ex -> AlreadyExistsException.isCause(ex)
+                ? Future.failedFuture(new AlreadyExistsException(
                         "An application named '" + entity.getName() + "' already exists"))
-                : CompletableFuture.failedFuture(ex));
+                : Future.failedFuture(ex));
     }
 
     @Override
-    protected CompletableFuture<Void> beforeDelete(String id) {
-        return projectService.countForApplication(id).thenAccept(count -> {
+    protected Future<Void> beforeDelete(String id) {
+        return projectService.countForApplication(id).compose(count -> {
             if(count > 0){
                 throw new IllegalStateException("Cannot delete an application with projects in it.");
             }
+            return Future.succeededFuture();
         });
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(Application entity) {
+    protected Future<Void> beforeSave(Application entity) {
         Validate.notNull(entity.getName(), "Application name cannot be null");
 
         if (entity.getId() == null) {
@@ -90,18 +91,18 @@ public class DefaultApplicationService extends AbstractOrganizationScopedService
         // Validate only; re-minting an update's id would silently write a new document
         DomainUtil.validateApplicationId(entity.getId());
         entity.setUpdated(new Date());
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<List<OidcConfiguration>> getOidcConfigurations(String applicationId) {
+    public Future<List<OidcConfiguration>> getOidcConfigurations(String applicationId) {
         Validate.notNull(applicationId, "applicationId cannot be null");
         return findById(applicationId)
-                .thenCompose(application -> {
+                .compose(application -> {
                     Validate.notNull(application, "Application not found: %s", applicationId);
                     List<String> ids = application.getOidcConfigurationIds();
                     if (ids == null || ids.isEmpty()) {
-                        return CompletableFuture.completedFuture(Collections.emptyList());
+                        return Future.succeededFuture(Collections.emptyList());
                     }
                     return oidcConfigurationService.findEnabledByIds(ids, application.getOrganizationId());
                 });

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultInviteEmailTemplateService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultInviteEmailTemplateService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.domain.api.model.InviteEmailTemplate;
@@ -12,7 +13,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class DefaultInviteEmailTemplateService extends AbstractApplicationScopedService<InviteEmailTemplate>
@@ -33,13 +33,13 @@ public class DefaultInviteEmailTemplateService extends AbstractApplicationScoped
     }
 
     @Override
-    public CompletableFuture<InviteEmailTemplate> findByApplication(String applicationId) {
+    public Future<InviteEmailTemplate> findByApplication(String applicationId) {
         Validate.notBlank(applicationId, "applicationId is required");
         return inviteEmailTemplateRepository.findByApplication(applicationId, requireOrganizationId());
     }
 
     @Override
-    public CompletableFuture<InviteEmailTemplate> save(InviteEmailTemplate entity) {
+    public Future<InviteEmailTemplate> save(InviteEmailTemplate entity) {
         Validate.notBlank(entity.getApplicationId(), "applicationId is required");
         Validate.notBlank(entity.getSubject(), "subject is required");
         Validate.notBlank(entity.getHtmlBody(), "htmlBody is required");
@@ -51,21 +51,15 @@ public class DefaultInviteEmailTemplateService extends AbstractApplicationScoped
         // Fails at save rather than at the next send.
         emailService.validateInviteTemplate(entity.getSubject(), entity.getHtmlBody(), entity.getTextBody());
 
-        return applicationRepository.findById(entity.getApplicationId(), organizationId)
-                .thenCompose(app -> {
-                    if (app == null) {
-                        return CompletableFuture.<InviteEmailTemplate>failedFuture(
-                                new IllegalArgumentException("Application not found: " + entity.getApplicationId()));
-                    }
-                    return inviteEmailTemplateRepository.findByApplication(entity.getApplicationId(), organizationId);
-                })
-                .thenCompose(existing -> {
+        return applicationRepository.requireById(entity.getApplicationId(), organizationId)
+                .compose(_ -> inviteEmailTemplateRepository.findByApplication(entity.getApplicationId(), organizationId))
+                .compose(existing -> {
                     // At most one template per application: a new save adopts the existing row's
                     // id so edits update in place instead of creating a duplicate.
                     if (entity.getId() == null) {
                         entity.setId(existing != null ? existing.getId() : UUID.randomUUID().toString());
                     } else if (existing != null && !existing.getId().equals(entity.getId())) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException(
+                        return Future.failedFuture(new IllegalArgumentException(
                                 "A template already exists for this application."));
                     }
                     Date now = new Date();

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultKinoticClusterInfoService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultKinoticClusterInfoService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.cluster.ClusterGroup;
@@ -12,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -27,7 +27,7 @@ public class DefaultKinoticClusterInfoService implements KinoticClusterInfoServi
     }
 
     @Override
-    public CompletableFuture<KinoticClusterInfo> getClusterInfo() {
+    public Future<KinoticClusterInfo> getClusterInfo() {
         if (ignite != null) {
             // Get cluster group for all server nodes
             ClusterGroup servers = ignite.cluster().forServers();
@@ -62,10 +62,10 @@ public class DefaultKinoticClusterInfoService implements KinoticClusterInfoServi
             }
 
             log.trace("Returning cluster info: {}", clusterInfoBuilder.build());
-            return CompletableFuture.completedFuture(clusterInfoBuilder.build());
+            return Future.succeededFuture(clusterInfoBuilder.build());
         } else {
             log.trace("Clustering disabled, returning static cluster info");
-            return CompletableFuture.completedFuture(KinoticClusterInfo.builder()
+            return Future.succeededFuture(KinoticClusterInfo.builder()
                                                                        .clusteringEnabled(false)
                                                                        .localNodeId("")
                                                                        .serverNodeCount(0)

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultLogService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultLogService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services;
 
+import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +18,6 @@ import org.kinotic.os.api.services.LogService;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Default {@link LogService} that authorizes access through the workload record — an
@@ -44,31 +43,29 @@ public class DefaultLogService implements LogService {
     @Override
     public Flux<Buffer> tail(String workloadId) {
         // Authorization starts before subscription: SecurityContext reads the calling Vert.x context
-        CompletableFuture<Workload> authorized = authorizedWorkload(workloadId);
-        return Mono.fromFuture(authorized)
+        Future<Workload> authorized = authorizedWorkload(workloadId);
+        return Mono.fromCompletionStage(authorized.toCompletionStage())
                    .flatMapMany(workload -> lokiClient.tail(tenantFor(workload), logQlFor(workload)));
     }
 
     @Override
-    public CompletableFuture<Buffer> history(LogQuery query) {
+    public Future<Buffer> history(LogQuery query) {
         Validate.notNull(query, "LogQuery cannot be null");
         return authorizedWorkload(query.getWorkloadId())
-                .thenCompose(workload -> lokiClient.queryRange(tenantFor(workload),
-                                                               logQlFor(workload),
-                                                               query.getStart(),
-                                                               query.getEnd(),
-                                                               query.getLimit())
-                                                   .toCompletionStage()
-                                                   .toCompletableFuture());
+                .compose(workload -> lokiClient.queryRange(tenantFor(workload),
+                                                           logQlFor(workload),
+                                                           query.getStart(),
+                                                           query.getEnd(),
+                                                           query.getLimit()));
     }
 
-    private CompletableFuture<Workload> authorizedWorkload(String workloadId) {
+    private Future<Workload> authorizedWorkload(String workloadId) {
         Validate.notBlank(workloadId, "workloadId cannot be blank");
         Participant participant = securityContext.currentParticipant();
         if (participant == null) {
             throw new IllegalStateException("No Participant is bound to the current Vert.x context");
         }
-        return workloadService.findById(workloadId).toCompletionStage().toCompletableFuture().thenApply(workload -> {
+        return workloadService.findById(workloadId).map(workload -> {
             if (workload == null) {
                 throw new IllegalArgumentException("Workload not found: " + workloadId);
             }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultLogService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultLogService.java
@@ -68,7 +68,7 @@ public class DefaultLogService implements LogService {
         if (participant == null) {
             throw new IllegalStateException("No Participant is bound to the current Vert.x context");
         }
-        return workloadService.findById(workloadId).thenApply(workload -> {
+        return workloadService.findById(workloadId).toCompletionStage().toCompletableFuture().thenApply(workload -> {
             if (workload == null) {
                 throw new IllegalArgumentException("Workload not found: " + workloadId);
             }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultProjectService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultProjectService.java
@@ -1,6 +1,7 @@
 package org.kinotic.os.internal.api.services;
 
 import com.github.slugify.Slugify;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.exceptions.AlreadyExistsException;
 import org.kinotic.core.api.security.SecurityContext;
@@ -15,7 +16,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 @Component
@@ -35,29 +35,29 @@ public class DefaultProjectService extends AbstractApplicationScopedService<Proj
     }
 
     @Override
-    public CompletableFuture<Project> create(Project project) {
+    public Future<Project> create(Project project) {
         return provisionAndWrite(project, super::create);
     }
 
     @Override
-    public CompletableFuture<Project> createSync(Project project) {
+    public Future<Project> createSync(Project project) {
         return provisionAndWrite(project, super::createSync);
     }
 
     @Override
-    public CompletableFuture<Project> createProjectIfNotExist(Project project) {
+    public Future<Project> createProjectIfNotExist(Project project) {
         validateAndDeriveId(project);
         return findById(project.getId())
-                .thenCompose(existing -> {
+                .compose(existing -> {
                     if (existing != null) {
-                        return CompletableFuture.completedFuture(existing);
+                        return Future.succeededFuture(existing);
                     }
-                    return repoProvisioner.provision(project).thenCompose(this::save);
+                    return repoProvisioner.provision(project).compose(this::save);
                 });
     }
 
     @Override
-    protected CompletableFuture<Void> beforeSave(Project project) {
+    protected Future<Void> beforeSave(Project project) {
         Validate.notNull(project, "Project cannot be null");
         Validate.notNull(project.getApplicationId(), "Project applicationId cannot be null");
         Validate.notNull(project.getName(), "Project name cannot be null");
@@ -66,50 +66,50 @@ public class DefaultProjectService extends AbstractApplicationScopedService<Proj
             project.setId(deriveId(project));
         }
         project.setUpdated(new Date());
-        return CompletableFuture.completedFuture(null);
+        return Future.succeededFuture();
     }
 
     @Override
-    public CompletableFuture<List<Project>> findByRepoFullName(String repoFullName) {
+    public Future<List<Project>> findByRepoFullName(String repoFullName) {
         Validate.notBlank(repoFullName, "repoFullName must not be blank");
         return projectRepository.findByRepoFullName(repoFullName, requireOrganizationId());
     }
 
     @Override
-    public CompletableFuture<Project> retryRepoInitialization(String projectId) {
+    public Future<Project> retryRepoInitialization(String projectId) {
         Validate.notBlank(projectId, "projectId must not be blank");
-        return findById(projectId).thenCompose(project -> {
+        return findById(projectId).compose(project -> {
             if (project == null) {
-                return CompletableFuture.failedFuture(new IllegalArgumentException(
+                return Future.failedFuture(new IllegalArgumentException(
                         "Project for id " + projectId + " does not exist"));
             }
             if (project.getRepoConnectionStatus() != RepositoryConnectionStatus.INITIALIZATION_FAILED) {
-                return CompletableFuture.failedFuture(new IllegalStateException(
+                return Future.failedFuture(new IllegalStateException(
                         "Project " + projectId + " is not awaiting initialization retry (status "
                         + project.getRepoConnectionStatus() + ")"));
             }
-            return repoProvisioner.reinitialize(project).thenCompose(this::saveSync);
+            return repoProvisioner.reinitialize(project).compose(this::saveSync);
         });
     }
 
-    private CompletableFuture<Project> provisionAndWrite(Project project,
-                                                         Function<Project, CompletableFuture<Project>> write) {
+    private Future<Project> provisionAndWrite(Project project,
+                                              Function<Project, Future<Project>> write) {
         validateAndDeriveId(project);
         // Fail fast on a known duplicate before provisioning a repo; the atomic write
         // catches the race where another create lands between this check and it.
         return findById(project.getId())
-                .thenCompose(existing -> {
+                .compose(existing -> {
                     if (existing != null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException(
+                        return Future.failedFuture(new IllegalArgumentException(
                                 "Project for id " + project.getId() + " already exists"));
                     }
                     return repoProvisioner.provision(project)
-                                          .thenCompose(write);
+                                          .compose(write);
                 })
-                .exceptionallyCompose(ex -> AlreadyExistsException.isCause(ex)
-                        ? CompletableFuture.failedFuture(new IllegalArgumentException(
+                .recover(ex -> AlreadyExistsException.isCause(ex)
+                        ? Future.failedFuture(new IllegalArgumentException(
                                 "Project for id " + project.getId() + " already exists"))
-                        : CompletableFuture.failedFuture(ex));
+                        : Future.failedFuture(ex));
     }
 
     private void validateAndDeriveId(Project project) {

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultSystemOrganizationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultSystemOrganizationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -16,8 +17,6 @@ import org.kinotic.os.api.model.security.PendingInviteSummary;
 import org.kinotic.os.api.services.SystemOrganizationService;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Component
 @RequiredArgsConstructor
 public class DefaultSystemOrganizationService implements SystemOrganizationService {
@@ -29,57 +28,55 @@ public class DefaultSystemOrganizationService implements SystemOrganizationServi
     private final OrganizationService organizationService;
 
     @Override
-    public CompletableFuture<Page<Organization>> findOrganizations(Pageable pageable) {
-        return organizationService.findAll(pageable).toCompletionStage().toCompletableFuture();
+    public Future<Page<Organization>> findOrganizations(Pageable pageable) {
+        return organizationService.findAll(pageable);
     }
 
     @Override
-    public CompletableFuture<Page<Organization>> searchOrganizations(String searchText, Pageable pageable) {
-        return organizationService.search(searchText, pageable).toCompletionStage().toCompletableFuture();
+    public Future<Page<Organization>> searchOrganizations(String searchText, Pageable pageable) {
+        return organizationService.search(searchText, pageable);
     }
 
     @Override
-    public CompletableFuture<Organization> findOrganizationById(String organizationId) {
-        return organizationService.findById(organizationId).toCompletionStage().toCompletableFuture();
+    public Future<Organization> findOrganizationById(String organizationId) {
+        return organizationService.findById(organizationId);
     }
 
     @Override
-    public CompletableFuture<Long> countOrganizations() {
-        return organizationService.count().toCompletionStage().toCompletableFuture();
+    public Future<Long> countOrganizations() {
+        return organizationService.count();
     }
 
     @Override
-    public CompletableFuture<Page<Application>> findApplications(String organizationId, Pageable pageable) {
-        return applicationRepository.findAll(organizationId, pageable).toCompletionStage().toCompletableFuture();
+    public Future<Page<Application>> findApplications(String organizationId, Pageable pageable) {
+        return applicationRepository.findAll(organizationId, pageable);
     }
 
     @Override
-    public CompletableFuture<Page<Project>> findProjects(String organizationId, Pageable pageable) {
-        return projectRepository.findAll(organizationId, pageable).toCompletionStage().toCompletableFuture();
+    public Future<Page<Project>> findProjects(String organizationId, Pageable pageable) {
+        return projectRepository.findAll(organizationId, pageable);
     }
 
     @Override
-    public CompletableFuture<Page<UserParticipantIdentity>> findMembers(String organizationId,
-                                                                        String applicationId,
-                                                                        Pageable pageable) {
-        return identityService.findUsersByScope(organizationId, applicationId, pageable)
-                              .toCompletionStage().toCompletableFuture();
+    public Future<Page<UserParticipantIdentity>> findMembers(String organizationId,
+                                                             String applicationId,
+                                                             Pageable pageable) {
+        return identityService.findUsersByScope(organizationId, applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<Page<UserParticipantIdentity>> searchMembers(String searchText,
-                                                                          String organizationId,
-                                                                          String applicationId,
-                                                                          Pageable pageable) {
-        return identityService.searchUsersByScope(searchText, organizationId, applicationId, pageable)
-                              .toCompletionStage().toCompletableFuture();
+    public Future<Page<UserParticipantIdentity>> searchMembers(String searchText,
+                                                               String organizationId,
+                                                               String applicationId,
+                                                               Pageable pageable) {
+        return identityService.searchUsersByScope(searchText, organizationId, applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<Page<PendingInviteSummary>> findPendingInvites(String organizationId,
-                                                                            String applicationId,
-                                                                            Pageable pageable) {
+    public Future<Page<PendingInviteSummary>> findPendingInvites(String organizationId,
+                                                                 String applicationId,
+                                                                 Pageable pageable) {
         return inviteService.findPendingInvites(organizationId, applicationId, pageable)
-                            .thenApply(page -> page.map(PendingInviteSummary::from));
+                            .map(page -> page.map(PendingInviteSummary::from));
     }
 }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultSystemOrganizationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultSystemOrganizationService.java
@@ -30,39 +30,40 @@ public class DefaultSystemOrganizationService implements SystemOrganizationServi
 
     @Override
     public CompletableFuture<Page<Organization>> findOrganizations(Pageable pageable) {
-        return organizationService.findAll(pageable);
+        return organizationService.findAll(pageable).toCompletionStage().toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Page<Organization>> searchOrganizations(String searchText, Pageable pageable) {
-        return organizationService.search(searchText, pageable);
+        return organizationService.search(searchText, pageable).toCompletionStage().toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Organization> findOrganizationById(String organizationId) {
-        return organizationService.findById(organizationId);
+        return organizationService.findById(organizationId).toCompletionStage().toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Long> countOrganizations() {
-        return organizationService.count();
+        return organizationService.count().toCompletionStage().toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Page<Application>> findApplications(String organizationId, Pageable pageable) {
-        return applicationRepository.findAll(organizationId, pageable);
+        return applicationRepository.findAll(organizationId, pageable).toCompletionStage().toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Page<Project>> findProjects(String organizationId, Pageable pageable) {
-        return projectRepository.findAll(organizationId, pageable);
+        return projectRepository.findAll(organizationId, pageable).toCompletionStage().toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<Page<UserParticipantIdentity>> findMembers(String organizationId,
                                                                         String applicationId,
                                                                         Pageable pageable) {
-        return identityService.findUsersByScope(organizationId, applicationId, pageable);
+        return identityService.findUsersByScope(organizationId, applicationId, pageable)
+                              .toCompletionStage().toCompletableFuture();
     }
 
     @Override
@@ -70,7 +71,8 @@ public class DefaultSystemOrganizationService implements SystemOrganizationServi
                                                                           String organizationId,
                                                                           String applicationId,
                                                                           Pageable pageable) {
-        return identityService.searchUsersByScope(searchText, organizationId, applicationId, pageable);
+        return identityService.searchUsersByScope(searchText, organizationId, applicationId, pageable)
+                              .toCompletionStage().toCompletableFuture();
     }
 
     @Override

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultDelegateService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultDelegateService.java
@@ -26,7 +26,8 @@ public class DefaultDelegateService implements DelegateService {
     @Override
     public CompletableFuture<Page<DelegatingParticipantIdentity>> findMyDelegates(Pageable pageable, Participant participant) {
         DomainUtil.requireUserParticipant(participant);
-        return identityService.findDelegatesByOwner(participant.getId(), pageable);
+        return identityService.findDelegatesByOwner(participant.getId(), pageable)
+                              .toCompletionStage().toCompletableFuture();
     }
 
     @Override
@@ -45,7 +46,8 @@ public class DefaultDelegateService implements DelegateService {
     @Override
     public CompletableFuture<Void> revokeDelegate(String delegateId, Participant participant) {
         return loadOwnedDelegate(delegateId, participant)
-                .thenCompose(delegate -> identityService.saveSync(delegate.setEnabled(false)))
+                .thenCompose(delegate -> identityService.saveSync(delegate.setEnabled(false))
+                                                        .toCompletionStage().toCompletableFuture())
                 // authentication already rejects a disabled delegate; ending its sessions too
                 // keeps the session list truthful and stops rotations at the token endpoint
                 .thenCompose(saved -> refreshTokenService.revokeAllFor(delegateId));
@@ -56,6 +58,7 @@ public class DefaultDelegateService implements DelegateService {
         DomainUtil.requireUserParticipant(participant);
         Validate.notBlank(delegateId, "delegateId is required");
         return identityService.findById(delegateId)
+                .toCompletionStage().toCompletableFuture()
                 .thenApply(identity -> DomainUtil.requireOwned(identity, DelegatingParticipantIdentity.class,
                         delegate -> participant.getId().equals(delegate.getOwnerId()),
                         "Delegate not found."));

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultDelegateService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultDelegateService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
@@ -14,7 +15,6 @@ import org.kinotic.os.api.services.security.DelegateService;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 @RequiredArgsConstructor
@@ -24,42 +24,39 @@ public class DefaultDelegateService implements DelegateService {
     private final RefreshTokenService refreshTokenService;
 
     @Override
-    public CompletableFuture<Page<DelegatingParticipantIdentity>> findMyDelegates(Pageable pageable, Participant participant) {
+    public Future<Page<DelegatingParticipantIdentity>> findMyDelegates(Pageable pageable, Participant participant) {
         DomainUtil.requireUserParticipant(participant);
-        return identityService.findDelegatesByOwner(participant.getId(), pageable)
-                              .toCompletionStage().toCompletableFuture();
+        return identityService.findDelegatesByOwner(participant.getId(), pageable);
     }
 
     @Override
-    public CompletableFuture<List<DelegateSession>> findSessions(String delegateId, Participant participant) {
+    public Future<List<DelegateSession>> findSessions(String delegateId, Participant participant) {
         return loadOwnedDelegate(delegateId, participant)
-                .thenCompose(delegate -> refreshTokenService.findActiveSessions(delegate.getId()));
+                .compose(delegate -> refreshTokenService.findActiveSessions(delegate.getId()));
     }
 
     @Override
-    public CompletableFuture<Void> revokeSession(String delegateId, String familyId, Participant participant) {
+    public Future<Void> revokeSession(String delegateId, String familyId, Participant participant) {
         Validate.notBlank(familyId, "familyId is required");
         return loadOwnedDelegate(delegateId, participant)
-                .thenCompose(delegate -> refreshTokenService.revokeFamily(delegate.getId(), familyId));
+                .compose(delegate -> refreshTokenService.revokeFamily(delegate.getId(), familyId));
     }
 
     @Override
-    public CompletableFuture<Void> revokeDelegate(String delegateId, Participant participant) {
+    public Future<Void> revokeDelegate(String delegateId, Participant participant) {
         return loadOwnedDelegate(delegateId, participant)
-                .thenCompose(delegate -> identityService.saveSync(delegate.setEnabled(false))
-                                                        .toCompletionStage().toCompletableFuture())
+                .compose(delegate -> identityService.saveSync(delegate.setEnabled(false)))
                 // authentication already rejects a disabled delegate; ending its sessions too
                 // keeps the session list truthful and stops rotations at the token endpoint
-                .thenCompose(saved -> refreshTokenService.revokeAllFor(delegateId));
+                .compose(saved -> refreshTokenService.revokeAllFor(delegateId));
     }
 
     /** Loads a delegate of the calling user for inspection or mutation. */
-    private CompletableFuture<DelegatingParticipantIdentity> loadOwnedDelegate(String delegateId, Participant participant) {
+    private Future<DelegatingParticipantIdentity> loadOwnedDelegate(String delegateId, Participant participant) {
         DomainUtil.requireUserParticipant(participant);
         Validate.notBlank(delegateId, "delegateId is required");
         return identityService.findById(delegateId)
-                .toCompletionStage().toCompletableFuture()
-                .thenApply(identity -> DomainUtil.requireOwned(identity, DelegatingParticipantIdentity.class,
+                .map(identity -> DomainUtil.requireOwned(identity, DelegatingParticipantIdentity.class,
                         delegate -> participant.getId().equals(delegate.getOwnerId()),
                         "Delegate not found."));
     }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMachineService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMachineService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
@@ -14,8 +15,6 @@ import org.kinotic.domain.internal.api.repositories.ApplicationRepository;
 import org.kinotic.os.api.services.security.MachineService;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Component
 @RequiredArgsConstructor
 public class DefaultMachineService implements MachineService {
@@ -25,56 +24,50 @@ public class DefaultMachineService implements MachineService {
     private final ApplicationRepository applicationRepository;
 
     @Override
-    public CompletableFuture<MachineProvisionResult> createMachine(String displayName, String applicationId) {
+    public Future<MachineProvisionResult> createMachine(String displayName, String applicationId) {
         Validate.notBlank(displayName, "displayName is required");
         OrganizationParticipant participant = requireOrgParticipant();
         return applicationRepository.requireById(applicationId, participant.getOrganizationId())
-                .toCompletionStage().toCompletableFuture()
-                .thenCompose(app -> {
+                .compose(app -> {
                     MachineParticipantIdentity machine = new MachineParticipantIdentity();
                     machine.setDisplayName(displayName)
                            .setOrganizationId(participant.getOrganizationId())
                            .setApplicationId(applicationId);
-                    return identityService.createMachine(machine)
-                                          .toCompletionStage().toCompletableFuture();
+                    return identityService.createMachine(machine);
                 });
     }
 
     @Override
-    public CompletableFuture<Page<MachineParticipantIdentity>> findMachines(String applicationId, Pageable pageable) {
+    public Future<Page<MachineParticipantIdentity>> findMachines(String applicationId, Pageable pageable) {
         Validate.notBlank(applicationId, "applicationId is required");
         OrganizationParticipant participant = requireOrgParticipant();
         // scope-composed query: a foreign or unknown application matches nothing
-        return identityService.findMachinesByScope(participant.getOrganizationId(), applicationId, pageable)
-                              .toCompletionStage().toCompletableFuture();
+        return identityService.findMachinesByScope(participant.getOrganizationId(), applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<String> rotateSecret(String machineId) {
+    public Future<String> rotateSecret(String machineId) {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMachine(machineId, participant)
-                .thenCompose(machine -> identityService.rotateMachineSecret(machine.getId())
-                                                       .toCompletionStage().toCompletableFuture());
+                .compose(machine -> identityService.rotateMachineSecret(machine.getId()));
     }
 
     @Override
-    public CompletableFuture<Void> setMachineEnabled(String machineId, boolean enabled) {
+    public Future<Void> setMachineEnabled(String machineId, boolean enabled) {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMachine(machineId, participant)
                 // saveSync so the console's immediate re-query sees the change
-                .thenCompose(machine -> identityService.saveSync(machine.setEnabled(enabled))
-                                                       .toCompletionStage().toCompletableFuture())
-                .thenApply(m -> null);
+                .compose(machine -> identityService.saveSync(machine.setEnabled(enabled)))
+                .mapEmpty();
     }
 
     @Override
-    public CompletableFuture<Void> removeMachine(String machineId) {
+    public Future<Void> removeMachine(String machineId) {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMachine(machineId, participant)
                 // Cascades the IdentityCredential; sync so the console's immediate re-query
                 // no longer shows the machine.
-                .thenCompose(machine -> identityService.deleteByIdSync(machine.getId())
-                                                       .toCompletionStage().toCompletableFuture());
+                .compose(machine -> identityService.deleteByIdSync(machine.getId()));
     }
 
     private OrganizationParticipant requireOrgParticipant() {
@@ -83,11 +76,10 @@ public class DefaultMachineService implements MachineService {
     }
 
     /** Loads a machine of the participant's organization for inspection or mutation. */
-    private CompletableFuture<MachineParticipantIdentity> loadOwnedMachine(String machineId, OrganizationParticipant participant) {
+    private Future<MachineParticipantIdentity> loadOwnedMachine(String machineId, OrganizationParticipant participant) {
         Validate.notBlank(machineId, "machineId is required");
         return identityService.findById(machineId)
-                .toCompletionStage().toCompletableFuture()
-                .thenApply(identity -> DomainUtil.requireOwned(identity, MachineParticipantIdentity.class,
+                .map(identity -> DomainUtil.requireOwned(identity, MachineParticipantIdentity.class,
                         machine -> participant.getOrganizationId().equals(machine.getOrganizationId()),
                         "Machine not found."));
     }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMachineService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMachineService.java
@@ -29,12 +29,14 @@ public class DefaultMachineService implements MachineService {
         Validate.notBlank(displayName, "displayName is required");
         OrganizationParticipant participant = requireOrgParticipant();
         return applicationRepository.requireById(applicationId, participant.getOrganizationId())
+                .toCompletionStage().toCompletableFuture()
                 .thenCompose(app -> {
                     MachineParticipantIdentity machine = new MachineParticipantIdentity();
                     machine.setDisplayName(displayName)
                            .setOrganizationId(participant.getOrganizationId())
                            .setApplicationId(applicationId);
-                    return identityService.createMachine(machine);
+                    return identityService.createMachine(machine)
+                                          .toCompletionStage().toCompletableFuture();
                 });
     }
 
@@ -43,14 +45,16 @@ public class DefaultMachineService implements MachineService {
         Validate.notBlank(applicationId, "applicationId is required");
         OrganizationParticipant participant = requireOrgParticipant();
         // scope-composed query: a foreign or unknown application matches nothing
-        return identityService.findMachinesByScope(participant.getOrganizationId(), applicationId, pageable);
+        return identityService.findMachinesByScope(participant.getOrganizationId(), applicationId, pageable)
+                              .toCompletionStage().toCompletableFuture();
     }
 
     @Override
     public CompletableFuture<String> rotateSecret(String machineId) {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMachine(machineId, participant)
-                .thenCompose(machine -> identityService.rotateMachineSecret(machine.getId()));
+                .thenCompose(machine -> identityService.rotateMachineSecret(machine.getId())
+                                                       .toCompletionStage().toCompletableFuture());
     }
 
     @Override
@@ -58,7 +62,8 @@ public class DefaultMachineService implements MachineService {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMachine(machineId, participant)
                 // saveSync so the console's immediate re-query sees the change
-                .thenCompose(machine -> identityService.saveSync(machine.setEnabled(enabled)))
+                .thenCompose(machine -> identityService.saveSync(machine.setEnabled(enabled))
+                                                       .toCompletionStage().toCompletableFuture())
                 .thenApply(m -> null);
     }
 
@@ -68,7 +73,8 @@ public class DefaultMachineService implements MachineService {
         return loadOwnedMachine(machineId, participant)
                 // Cascades the IdentityCredential; sync so the console's immediate re-query
                 // no longer shows the machine.
-                .thenCompose(machine -> identityService.deleteByIdSync(machine.getId()));
+                .thenCompose(machine -> identityService.deleteByIdSync(machine.getId())
+                                                       .toCompletionStage().toCompletableFuture());
     }
 
     private OrganizationParticipant requireOrgParticipant() {
@@ -80,6 +86,7 @@ public class DefaultMachineService implements MachineService {
     private CompletableFuture<MachineParticipantIdentity> loadOwnedMachine(String machineId, OrganizationParticipant participant) {
         Validate.notBlank(machineId, "machineId is required");
         return identityService.findById(machineId)
+                .toCompletionStage().toCompletableFuture()
                 .thenApply(identity -> DomainUtil.requireOwned(identity, MachineParticipantIdentity.class,
                         machine -> participant.getOrganizationId().equals(machine.getOrganizationId()),
                         "Machine not found."));

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMemberService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMemberService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
@@ -17,8 +18,6 @@ import org.kinotic.os.api.model.security.PendingInviteSummary;
 import org.kinotic.os.api.services.security.MemberService;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Component
 @RequiredArgsConstructor
 public class DefaultMemberService implements MemberService {
@@ -29,29 +28,27 @@ public class DefaultMemberService implements MemberService {
     private final ApplicationRepository applicationRepository;
 
     @Override
-    public CompletableFuture<Page<UserParticipantIdentity>> findMembers(String applicationId, Pageable pageable) {
+    public Future<Page<UserParticipantIdentity>> findMembers(String applicationId, Pageable pageable) {
         OrganizationParticipant participant = requireOrgParticipant();
         // scope-composed query: a foreign or unknown application matches nothing
-        return identityService.findUsersByScope(participant.getOrganizationId(), applicationId, pageable)
-                              .toCompletionStage().toCompletableFuture();
+        return identityService.findUsersByScope(participant.getOrganizationId(), applicationId, pageable);
     }
 
     @Override
-    public CompletableFuture<Page<UserParticipantIdentity>> searchMembers(String searchText, String applicationId, Pageable pageable) {
+    public Future<Page<UserParticipantIdentity>> searchMembers(String searchText, String applicationId, Pageable pageable) {
         OrganizationParticipant participant = requireOrgParticipant();
         return identityService.searchUsersByScope(searchText,
                                                   participant.getOrganizationId(),
                                                   applicationId,
-                                                  pageable)
-                              .toCompletionStage().toCompletableFuture();
+                                                  pageable);
     }
 
     @Override
-    public CompletableFuture<PendingInviteSummary> inviteMember(String email, String displayName, String applicationId) {
+    public Future<PendingInviteSummary> inviteMember(String email, String displayName, String applicationId) {
         Validate.notBlank(email, "email is required");
         OrganizationParticipant participant = requireOrgParticipant();
         return requireOwnedApplication(applicationId, participant.getOrganizationId())
-                .thenCompose(app -> {
+                .compose(app -> {
                     PendingInvite invite = new PendingInvite()
                             .setEmail(email)
                             .setDisplayName(displayName)
@@ -61,43 +58,41 @@ public class DefaultMemberService implements MemberService {
                             .setInvitedByName(participantDisplayName(participant));
                     return inviteService.createInvite(invite);
                 })
-                .thenApply(PendingInviteSummary::from);
+                .map(PendingInviteSummary::from);
     }
 
     @Override
-    public CompletableFuture<Void> setMemberEnabled(String identityId, boolean enabled) {
+    public Future<Void> setMemberEnabled(String identityId, boolean enabled) {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMember(identityId, participant)
                 // saveSync so the console's immediate re-query sees the change
-                .thenCompose(user -> identityService.saveSync(user.setEnabled(enabled))
-                                                    .toCompletionStage().toCompletableFuture())
-                .thenApply(u -> null);
+                .compose(user -> identityService.saveSync(user.setEnabled(enabled)))
+                .mapEmpty();
     }
 
     @Override
-    public CompletableFuture<Void> removeMember(String identityId) {
+    public Future<Void> removeMember(String identityId) {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMember(identityId, participant)
                 // Cascades the IdentityCredential; sync so the console's immediate re-query
                 // no longer shows the member.
-                .thenCompose(user -> identityService.deleteByIdSync(user.getId())
-                                                    .toCompletionStage().toCompletableFuture());
+                .compose(user -> identityService.deleteByIdSync(user.getId()));
     }
 
     @Override
-    public CompletableFuture<Page<PendingInviteSummary>> findPendingInvites(String applicationId, Pageable pageable) {
+    public Future<Page<PendingInviteSummary>> findPendingInvites(String applicationId, Pageable pageable) {
         OrganizationParticipant participant = requireOrgParticipant();
         return inviteService.findPendingInvites(participant.getOrganizationId(),
                                                 applicationId,
                                                 pageable)
-                .thenApply(page -> new Page<>(page.getContent().stream()
-                                                  .map(PendingInviteSummary::from)
-                                                  .toList(),
-                                              page.getTotalElements()));
+                .map(page -> new Page<>(page.getContent().stream()
+                                            .map(PendingInviteSummary::from)
+                                            .toList(),
+                                        page.getTotalElements()));
     }
 
     @Override
-    public CompletableFuture<Void> cancelInvite(String inviteId) {
+    public Future<Void> cancelInvite(String inviteId) {
         OrganizationParticipant participant = requireOrgParticipant();
         return inviteService.cancelInvite(inviteId, participant.getOrganizationId());
     }
@@ -112,13 +107,12 @@ public class DefaultMemberService implements MemberService {
      * application must exist in the participant's org. Completes with null for an org-member
      * invite (no applicationId).
      */
-    private CompletableFuture<Application> requireOwnedApplication(String applicationId, String organizationId) {
-        CompletableFuture<Application> ret;
+    private Future<Application> requireOwnedApplication(String applicationId, String organizationId) {
+        Future<Application> ret;
         if (applicationId == null) {
-            ret = CompletableFuture.completedFuture(null);
+            ret = Future.succeededFuture();
         } else {
-            ret = applicationRepository.requireById(applicationId, organizationId)
-                                       .toCompletionStage().toCompletableFuture();
+            ret = applicationRepository.requireById(applicationId, organizationId);
         }
         return ret;
     }
@@ -127,17 +121,16 @@ public class DefaultMemberService implements MemberService {
      * Loads a member of the participant's organization for mutation. Rejects acting on the
      * caller's own account, so an admin can't disable or remove themselves out of the org.
      */
-    private CompletableFuture<UserParticipantIdentity> loadOwnedMember(String identityId, OrganizationParticipant participant) {
+    private Future<UserParticipantIdentity> loadOwnedMember(String identityId, OrganizationParticipant participant) {
         Validate.notBlank(identityId, "identityId is required");
         if (identityId.equals(participant.getId())) {
-            return CompletableFuture.failedFuture(
+            return Future.failedFuture(
                     new IllegalArgumentException("You cannot perform this action on your own account."));
         }
         return identityService.findById(identityId)
-                .toCompletionStage().toCompletableFuture()
                 // a delegate id gets the same not-found as a foreign one — member management
                 // operates on people; delegates are managed by their owner's revocation flow
-                .thenApply(identity -> DomainUtil.requireOwned(identity, UserParticipantIdentity.class,
+                .map(identity -> DomainUtil.requireOwned(identity, UserParticipantIdentity.class,
                         user -> participant.getOrganizationId().equals(user.getOrganizationId()),
                         "Member not found."));
     }

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMemberService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultMemberService.java
@@ -32,7 +32,8 @@ public class DefaultMemberService implements MemberService {
     public CompletableFuture<Page<UserParticipantIdentity>> findMembers(String applicationId, Pageable pageable) {
         OrganizationParticipant participant = requireOrgParticipant();
         // scope-composed query: a foreign or unknown application matches nothing
-        return identityService.findUsersByScope(participant.getOrganizationId(), applicationId, pageable);
+        return identityService.findUsersByScope(participant.getOrganizationId(), applicationId, pageable)
+                              .toCompletionStage().toCompletableFuture();
     }
 
     @Override
@@ -41,7 +42,8 @@ public class DefaultMemberService implements MemberService {
         return identityService.searchUsersByScope(searchText,
                                                   participant.getOrganizationId(),
                                                   applicationId,
-                                                  pageable);
+                                                  pageable)
+                              .toCompletionStage().toCompletableFuture();
     }
 
     @Override
@@ -67,7 +69,8 @@ public class DefaultMemberService implements MemberService {
         OrganizationParticipant participant = requireOrgParticipant();
         return loadOwnedMember(identityId, participant)
                 // saveSync so the console's immediate re-query sees the change
-                .thenCompose(user -> identityService.saveSync(user.setEnabled(enabled)))
+                .thenCompose(user -> identityService.saveSync(user.setEnabled(enabled))
+                                                    .toCompletionStage().toCompletableFuture())
                 .thenApply(u -> null);
     }
 
@@ -77,7 +80,8 @@ public class DefaultMemberService implements MemberService {
         return loadOwnedMember(identityId, participant)
                 // Cascades the IdentityCredential; sync so the console's immediate re-query
                 // no longer shows the member.
-                .thenCompose(user -> identityService.deleteByIdSync(user.getId()));
+                .thenCompose(user -> identityService.deleteByIdSync(user.getId())
+                                                    .toCompletionStage().toCompletableFuture());
     }
 
     @Override
@@ -113,7 +117,8 @@ public class DefaultMemberService implements MemberService {
         if (applicationId == null) {
             ret = CompletableFuture.completedFuture(null);
         } else {
-            ret = applicationRepository.requireById(applicationId, organizationId);
+            ret = applicationRepository.requireById(applicationId, organizationId)
+                                       .toCompletionStage().toCompletableFuture();
         }
         return ret;
     }
@@ -129,6 +134,7 @@ public class DefaultMemberService implements MemberService {
                     new IllegalArgumentException("You cannot perform this action on your own account."));
         }
         return identityService.findById(identityId)
+                .toCompletionStage().toCompletableFuture()
                 // a delegate id gets the same not-found as a foreign one — member management
                 // operates on people; delegates are managed by their owner's revocation flow
                 .thenApply(identity -> DomainUtil.requireOwned(identity, UserParticipantIdentity.class,

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultOAuthApprovalService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultOAuthApprovalService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.domain.api.model.security.PendingOAuthAuthorization;
@@ -9,8 +10,6 @@ import org.kinotic.domain.api.services.security.OAuthAuthorizationService;
 import org.kinotic.os.api.services.security.OAuthApprovalService;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Component
 @RequiredArgsConstructor
 public class DefaultOAuthApprovalService implements OAuthApprovalService {
@@ -19,23 +18,23 @@ public class DefaultOAuthApprovalService implements OAuthApprovalService {
     private final DeviceCodeGrantService deviceCodeGrantService;
 
     @Override
-    public CompletableFuture<PendingOAuthAuthorization> describe(String requestId) {
+    public Future<PendingOAuthAuthorization> describe(String requestId) {
         return oauthAuthorizationService.findPending(requestId);
     }
 
     @Override
-    public CompletableFuture<String> approve(String requestId, Participant participant) {
+    public Future<String> approve(String requestId, Participant participant) {
         DomainUtil.requireUserParticipant(participant);
         return oauthAuthorizationService.approve(requestId, participant.getId());
     }
 
     @Override
-    public CompletableFuture<String> deny(String requestId) {
+    public Future<String> deny(String requestId) {
         return oauthAuthorizationService.deny(requestId);
     }
 
     @Override
-    public CompletableFuture<Void> approveDevice(String userCode, Participant participant) {
+    public Future<Void> approveDevice(String userCode, Participant participant) {
         // consent must come from a person: a delegate approving grants could mint itself
         // further delegates on the user's behalf without the user ever seeing a consent screen
         DomainUtil.requireUserParticipant(participant);

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultProfileService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultProfileService.java
@@ -26,7 +26,8 @@ public class DefaultProfileService implements ProfileService {
     public CompletableFuture<UserParticipantIdentity> updateDisplayName(String displayName, Participant participant) {
         Validate.notBlank(displayName, "displayName is required");
         return loadCallingUser(participant)
-                .thenCompose(user -> identityService.save(user.setDisplayName(displayName)))
+                .thenCompose(user -> identityService.save(user.setDisplayName(displayName))
+                                                    .toCompletionStage().toCompletableFuture())
                 .thenApply(UserParticipantIdentity.class::cast);
     }
 
@@ -34,6 +35,7 @@ public class DefaultProfileService implements ProfileService {
     private CompletableFuture<UserParticipantIdentity> loadCallingUser(Participant participant) {
         DomainUtil.requireUserParticipant(participant);
         return identityService.findById(participant.getId())
+                              .toCompletionStage().toCompletableFuture()
                               .thenApply(identity -> {
                                   // a session outlives its row when an admin removes the member mid-session
                                   if (!(identity instanceof UserParticipantIdentity user)) {

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultProfileService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/security/DefaultProfileService.java
@@ -1,5 +1,6 @@
 package org.kinotic.os.internal.api.services.security;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.security.Participant;
@@ -9,8 +10,6 @@ import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.os.api.services.security.ProfileService;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Component
 @RequiredArgsConstructor
 public class DefaultProfileService implements ProfileService {
@@ -18,25 +17,23 @@ public class DefaultProfileService implements ProfileService {
     private final ParticipantIdentityService identityService;
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> findMyProfile(Participant participant) {
+    public Future<UserParticipantIdentity> findMyProfile(Participant participant) {
         return loadCallingUser(participant);
     }
 
     @Override
-    public CompletableFuture<UserParticipantIdentity> updateDisplayName(String displayName, Participant participant) {
+    public Future<UserParticipantIdentity> updateDisplayName(String displayName, Participant participant) {
         Validate.notBlank(displayName, "displayName is required");
         return loadCallingUser(participant)
-                .thenCompose(user -> identityService.save(user.setDisplayName(displayName))
-                                                    .toCompletionStage().toCompletableFuture())
-                .thenApply(UserParticipantIdentity.class::cast);
+                .compose(user -> identityService.save(user.setDisplayName(displayName)))
+                .map(UserParticipantIdentity.class::cast);
     }
 
     /** Loads the identity behind the calling participant. */
-    private CompletableFuture<UserParticipantIdentity> loadCallingUser(Participant participant) {
+    private Future<UserParticipantIdentity> loadCallingUser(Participant participant) {
         DomainUtil.requireUserParticipant(participant);
         return identityService.findById(participant.getId())
-                              .toCompletionStage().toCompletableFuture()
-                              .thenApply(identity -> {
+                              .map(identity -> {
                                   // a session outlives its row when an admin removes the member mid-session
                                   if (!(identity instanceof UserParticipantIdentity user)) {
                                       throw new IllegalArgumentException("Profile not found.");

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
@@ -31,10 +31,14 @@ import org.kinotic.idl.internal.directory.jdk.ShortTypeConverter;
 import org.kinotic.idl.internal.directory.jdk.StringTypeConverter;
 import org.kinotic.idl.internal.directory.jdk.URITypeConverter;
 import org.kinotic.idl.internal.directory.jdk.VoidTypeConverter;
+import io.vertx.core.Future;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.core.ReactiveTypeDescriptor;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Verifies every MCP-exposed os-api service converts to a ServiceDefinition with the same converter set
@@ -162,16 +166,23 @@ public class McpServiceSchemaTest {
                                                            new URITypeConverter(),
                                                            new VoidTypeConverter(),
                                                            new TokenBufferTypeConverter(),
-                                                           new ReactiveTypeConverter(sharedRegistryProvider()));
+                                                           new ReactiveTypeConverter(registryProvider()));
         return new DefaultSchemaFactory(new DefaultResolvableTypeConverter(converters));
     }
 
-    // resolves to the shared ReactiveAdapterRegistry, as ReactiveTypeConverter falls back to outside a Spring context
-    private static ObjectProvider<ReactiveAdapterRegistry> sharedRegistryProvider() {
+    // a registry carrying the Vert.x Future adapter DefaultKinotic registers at startup, so the
+    // converter set here matches what the server wires — the shared registry alone cannot convert
+    // the Future returns the CRUD interfaces declare
+    private static ObjectProvider<ReactiveAdapterRegistry> registryProvider() {
+        ReactiveAdapterRegistry registry = new ReactiveAdapterRegistry();
+        registry.registerReactiveType(ReactiveTypeDescriptor.singleOptionalValue(Future.class,
+                                                                                 (Supplier<Future<?>>) Future::succeededFuture),
+                                      source -> Mono.fromCompletionStage(((Future<?>) source).toCompletionStage()),
+                                      publisher -> Future.fromCompletionStage(Mono.from(publisher).toFuture()));
         return new ObjectProvider<>() {
             @Override
             public ReactiveAdapterRegistry getIfAvailable() {
-                return null;
+                return registry;
             }
         };
     }

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultApplicationServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultApplicationServiceTest.java
@@ -24,7 +24,7 @@ class DefaultApplicationServiceTest {
     void mintsIdFromSlugifiedName() {
         Application application = new Application("Orders App", "desc");
 
-        service.beforeSave(application).join();
+        service.beforeSave(application).await();
 
         assertEquals("orders-app", application.getId());
         assertNotNull(application.getUpdated());
@@ -35,7 +35,7 @@ class DefaultApplicationServiceTest {
         Application application = new Application("Orders App", "desc");
         application.setId("orders-app-v2");
 
-        service.beforeSave(application).join();
+        service.beforeSave(application).await();
 
         assertEquals("orders-app-v2", application.getId());
     }

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
@@ -24,8 +24,6 @@ import reactor.core.publisher.Flux;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -112,7 +110,8 @@ class DefaultLogServiceTest {
 
     @Test
     void tailResolvesTheWorkloadTenantAndQuery() throws Throwable {
-        callAs(ACME_USER, () -> service.tail("wl-acme").collectList().toFuture());
+        callAs(ACME_USER, () -> Future.fromCompletionStage(service.tail("wl-acme").collectList().toFuture(),
+                                                           vertx.getOrCreateContext()));
 
         assertEquals("acme", lokiClient.tenant);
         assertEquals("{workload_id=\"wl-acme\"}", lokiClient.query);
@@ -130,33 +129,22 @@ class DefaultLogServiceTest {
      * Runs the call on a Vert.x context with the given participant bound, mirroring how the
      * gateway invokes published services.
      */
-    private <T> T callAs(Participant participant, Supplier<CompletableFuture<T>> call) throws Throwable {
-        CompletableFuture<T> result = new CompletableFuture<>();
+    private <T> T callAs(Participant participant, Supplier<Future<T>> call) throws Throwable {
+        Promise<T> result = Promise.promise();
         Context context = vertx.getOrCreateContext();
         context.runOnContext(unused -> {
             securityContext.setParticipant(context, participant);
             try {
-                call.get().whenComplete((value, error) -> {
-                    if (error != null) {
-                        result.completeExceptionally(error);
-                    } else {
-                        result.complete(value);
-                    }
-                });
+                call.get().onComplete(result);
             } catch (Throwable error) {
-                result.completeExceptionally(error);
+                result.fail(error);
             }
         });
-        try {
-            return result.get(10, TimeUnit.SECONDS);
-        } catch (ExecutionException e) {
-            // get() already peels the single CompletionException layer minted by
-            // DefaultLogService's internal CF chain, so the cause is the raw failure
-            throw e.getCause();
-        }
+        // await rethrows a failed future's raw cause, so failureOf sees the unwrapped exception
+        return result.future().await(10, TimeUnit.SECONDS);
     }
 
-    private <T> Throwable failureOf(Participant participant, Supplier<CompletableFuture<T>> call) {
+    private <T> Throwable failureOf(Participant participant, Supplier<Future<T>> call) {
         try {
             callAs(participant, call);
             return null;

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
@@ -2,6 +2,7 @@ package org.kinotic.os.internal.api.services;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import org.junit.jupiter.api.AfterAll;
@@ -24,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -150,7 +150,9 @@ class DefaultLogServiceTest {
         try {
             return result.get(10, TimeUnit.SECONDS);
         } catch (ExecutionException e) {
-            throw unwrap(e.getCause());
+            // get() already peels the single CompletionException layer minted by
+            // DefaultLogService's internal CF chain, so the cause is the raw failure
+            throw e.getCause();
         }
     }
 
@@ -161,13 +163,6 @@ class DefaultLogServiceTest {
         } catch (Throwable error) {
             return error;
         }
-    }
-
-    private static Throwable unwrap(Throwable error) {
-        while (error instanceof CompletionException && error.getCause() != null) {
-            error = error.getCause();
-        }
-        return error;
     }
 
     private static class RecordingLokiClient implements LokiClient {
@@ -210,69 +205,71 @@ class DefaultLogServiceTest {
         }
 
         @Override
-        public CompletableFuture<Workload> findById(String id) {
+        public Future<Workload> findById(String id) {
             // Completes on another thread like the real ES-backed service, so any
             // SecurityContext read after this hop loses the Vert.x context and fails
-            return CompletableFuture.supplyAsync(() -> workloads.get(id));
+            Promise<Workload> promise = Promise.promise();
+            new Thread(() -> promise.complete(workloads.get(id))).start();
+            return promise.future();
         }
 
         @Override
-        public CompletableFuture<Page<Workload>> findAllForNode(String nodeId, Pageable pageable) {
+        public Future<Page<Workload>> findAllForNode(String nodeId, Pageable pageable) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Long> countForNode(String nodeId) {
+        public Future<Long> countForNode(String nodeId) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Workload> create(Workload entity) {
+        public Future<Workload> create(Workload entity) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Workload> createSync(Workload entity) {
+        public Future<Workload> createSync(Workload entity) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Workload> save(Workload entity) {
+        public Future<Workload> save(Workload entity) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Workload> saveSync(Workload entity) {
+        public Future<Workload> saveSync(Workload entity) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Long> count() {
+        public Future<Long> count() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Void> deleteById(String id) {
+        public Future<Void> deleteById(String id) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Void> deleteByIdSync(String id) {
+        public Future<Void> deleteByIdSync(String id) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Page<Workload>> findAll(Pageable pageable) {
+        public Future<Page<Workload>> findAll(Pageable pageable) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Page<Workload>> search(String searchText, Pageable pageable) {
+        public Future<Page<Workload>> search(String searchText, Pageable pageable) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public CompletableFuture<Void> syncIndex() {
+        public Future<Void> syncIndex() {
             throw new UnsupportedOperationException();
         }
     }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/AdminJsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/AdminJsonEntitiesRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.domain.api.model.RawJson;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -11,7 +12,6 @@ import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.domain.api.model.security.ApplicationParticipant;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provides Admin access to entities for a given {@link EntityDefinition}.
@@ -28,9 +28,9 @@ public interface AdminJsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to count
      * @param tenantSelection the list of tenants to use when retrieving the entity records
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting the number of entities.
+     * @return {@link Future} emitting the number of entities.
      */
-    CompletableFuture<Long> count(String entityDefinitionId, List<String> tenantSelection, ApplicationParticipant participant);
+    Future<Long> count(String entityDefinitionId, List<String> tenantSelection, ApplicationParticipant participant);
 
     /**
      * Returns the number of entities available for the given query.
@@ -39,9 +39,9 @@ public interface AdminJsonEntitiesRepository {
      * @param query       the query used to limit result
      * @param tenantSelection the list of tenants to use when retrieving the entity records
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting the number of entities.
+     * @return {@link Future} emitting the number of entities.
      */
-    CompletableFuture<Long> countByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ApplicationParticipant participant);
+    Future<Long> countByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ApplicationParticipant participant);
 
     /**
      * Deletes the entity with the given id.
@@ -49,9 +49,9 @@ public interface AdminJsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to delete the entity for
      * @param id          must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant);
+    Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant);
 
     /**
      * Deletes any entities that match the given query.
@@ -60,9 +60,9 @@ public interface AdminJsonEntitiesRepository {
      * @param query       the query used to filter records to delete, must not be {@literal null}
      * @param tenantSelection the list of tenants to use when deleting entities by the given query
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ApplicationParticipant participant);
+    Future<Void> deleteByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ApplicationParticipant participant);
 
     /**
      * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
@@ -73,7 +73,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return a page of entities
      */
-    CompletableFuture<Page<FastestType>> findAll(String entityDefinitionId, List<String> tenantSelection, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> findAll(String entityDefinitionId, List<String> tenantSelection, Pageable pageable, ApplicationParticipant participant);
 
     /**
      * Retrieves an entity by its id.
@@ -81,9 +81,9 @@ public interface AdminJsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to find the entity for
      * @param id          must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} with the entity with the given id or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} with the entity with the given id or {@link Future} emitting null if none found
      */
-    CompletableFuture<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant);
+    Future<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant);
 
     /**
      * Retrieves a list of entities by their id.
@@ -91,9 +91,9 @@ public interface AdminJsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to find the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param ids         must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} with the list of matched entities with the given ids or {@link CompletableFuture} emitting an empty list if none found
+     * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting an empty list if none found
      */
-    CompletableFuture<List<FastestType>> findByIds(String entityDefinitionId, List<TenantSpecificId> ids, ApplicationParticipant participant);
+    Future<List<FastestType>> findByIds(String entityDefinitionId, List<TenantSpecificId> ids, ApplicationParticipant participant);
 
     /**
      * Executes a named query.
@@ -103,13 +103,13 @@ public interface AdminJsonEntitiesRepository {
      * @param queryParameters the parameters to pass to the query
      * @param tenantSelection the list of tenants to use when retrieving the entity records
      * @param participant     the participant of the logged-in user
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    CompletableFuture<List<RawJson>> namedQuery(String entityDefinitionId,
-                                                String queryName,
-                                                List<QueryParameter> queryParameters,
-                                                List<String> tenantSelection,
-                                                ApplicationParticipant participant);
+    Future<List<RawJson>> namedQuery(String entityDefinitionId,
+                                     String queryName,
+                                     List<QueryParameter> queryParameters,
+                                     List<String> tenantSelection,
+                                     ApplicationParticipant participant);
 
     /**
      * Executes a named query and returns a {@link Page} of results.
@@ -120,14 +120,14 @@ public interface AdminJsonEntitiesRepository {
      * @param tenantSelection the list of tenants to use when retrieving the entity records
      * @param pageable        the page settings to be useds
      * @param participant     the participant of the logged-in user
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    CompletableFuture<Page<RawJson>> namedQueryPage(String entityDefinitionId,
-                                                    String queryName,
-                                                    List<QueryParameter> queryParameters,
-                                                    List<String> tenantSelection,
-                                                    Pageable pageable,
-                                                    ApplicationParticipant participant);
+    Future<Page<RawJson>> namedQueryPage(String entityDefinitionId,
+                                         String queryName,
+                                         List<QueryParameter> queryParameters,
+                                         List<String> tenantSelection,
+                                         Pageable pageable,
+                                         ApplicationParticipant participant);
 
     /**
      * Returns a {@link Page} of entities matching the search text and paging restriction provided in the {@code Pageable} object.
@@ -139,8 +139,8 @@ public interface AdminJsonEntitiesRepository {
      * @param tenantSelection the list of tenants to use when retrieving the entity records
      * @param pageable    the page settings to be used
      * @param participant the participant of the logged-in user
-     * @return a {@link CompletableFuture} of a page of entities
+     * @return a {@link Future} of a page of entities
      */
-    CompletableFuture<Page<FastestType>> search(String entityDefinitionId, String searchText, List<String> tenantSelection, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> search(String entityDefinitionId, String searchText, List<String> tenantSelection, Pageable pageable, ApplicationParticipant participant);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/EntityDefinitionService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/EntityDefinitionService.java
@@ -1,13 +1,12 @@
 
 package org.kinotic.persistence.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.services.ProjectScopedCrudService;
 import org.kinotic.persistence.api.model.EntityDefinition;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Public service for managing {@link EntityDefinition} lifecycle: creation, publication,
@@ -23,53 +22,53 @@ public interface EntityDefinitionService extends ProjectScopedCrudService<Entity
      * {@link #publish(String)} is called.
      *
      * @param entityDefinition the definition to create
-     * @return a {@link CompletableFuture} emitting the saved definition with system-managed
+     * @return a {@link Future} emitting the saved definition with system-managed
      *         fields populated (id, created, itemIndex, etc.)
      */
-    CompletableFuture<EntityDefinition> create(EntityDefinition entityDefinition);
+    Future<EntityDefinition> create(EntityDefinition entityDefinition);
 
     /**
      * Finds all published {@link EntityDefinition}s for the given application.
      *
      * @param applicationId the application to find definitions for
      * @param pageable      the paging parameters
-     * @return a {@link CompletableFuture} emitting a page of published definitions
+     * @return a {@link Future} emitting a page of published definitions
      */
-    CompletableFuture<Page<EntityDefinition>> findAllPublishedForApplication(String applicationId, Pageable pageable);
+    Future<Page<EntityDefinition>> findAllPublishedForApplication(String applicationId, Pageable pageable);
 
     /**
      * Publishes the {@link EntityDefinition} with the given id, making it available for
      * data read and write operations.
      *
      * @param entityDefinitionId the id of the definition to publish
-     * @return a {@link CompletableFuture} that completes when the definition has been published
+     * @return a {@link Future} that completes when the definition has been published
      */
-    CompletableFuture<Void> publish(String entityDefinitionId);
+    Future<Void> publish(String entityDefinitionId);
 
     /**
      * Forces an immediate Elasticsearch index refresh so recent writes to the entity
      * definition index are searchable. Reserved for test and batch-load scenarios.
      *
-     * @return a {@link CompletableFuture} that completes when the refresh is done
+     * @return a {@link Future} that completes when the refresh is done
      */
-    CompletableFuture<Void> syncIndex();
+    Future<Void> syncIndex();
 
     /**
      * Un-publishes the {@link EntityDefinition} with the given id, removing the
      * underlying data index and making the definition unavailable for data operations.
      *
      * @param entityDefinitionId the id of the definition to un-publish
-     * @return a {@link CompletableFuture} that completes when the definition has been un-published
+     * @return a {@link Future} that completes when the definition has been un-published
      */
-    CompletableFuture<Void> unPublish(String entityDefinitionId);
+    Future<Void> unPublish(String entityDefinitionId);
 
     /**
      * Saves the given {@link EntityDefinition} with {@code refresh=wait_for} semantics,
      * guaranteeing the write is searchable before the future completes.
      *
      * @param entity the definition to save
-     * @return a {@link CompletableFuture} emitting the saved definition
+     * @return a {@link Future} emitting the saved definition
      */
-    CompletableFuture<EntityDefinition> saveSync(EntityDefinition entity);
+    Future<EntityDefinition> saveSync(EntityDefinition entity);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/JsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/JsonEntitiesRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.idl.api.schema.FunctionDefinition;
@@ -14,7 +15,6 @@ import org.kinotic.domain.api.model.security.ApplicationParticipant;
 import tools.jackson.databind.util.TokenBuffer;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provides access to entities for a given EntityDefinition.
@@ -30,9 +30,9 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to save the entities for
      * @param entities    all the entities to save
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} that will complete when all entities have been saved
+     * @return {@link Future} that will complete when all entities have been saved
      */
-    CompletableFuture<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant);
+    Future<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant);
 
     /**
      * Saves all given entities.
@@ -40,18 +40,18 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to update the entities for
      * @param entities    all the entities to save
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} that will complete when all entities have been saved
+     * @return {@link Future} that will complete when all entities have been saved
      */
-    CompletableFuture<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant);
+    Future<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant);
 
     /**
      * Returns the number of entities available.
      *
      * @param entityDefinitionId the id of the {@link EntityDefinition} to count
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting the number of entities.
+     * @return {@link Future} emitting the number of entities.
      */
-    CompletableFuture<Long> count(String entityDefinitionId, ApplicationParticipant participant);
+    Future<Long> count(String entityDefinitionId, ApplicationParticipant participant);
 
     /**
      * Returns the number of entities available for the given query.
@@ -59,9 +59,9 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to count. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param query       the query used to limit results
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting the number of entities.
+     * @return {@link Future} emitting the number of entities.
      */
-    CompletableFuture<Long> countByQuery(String entityDefinitionId, String query, ApplicationParticipant participant);
+    Future<Long> countByQuery(String entityDefinitionId, String query, ApplicationParticipant participant);
 
     /**
      * Deletes the entity with the given id.
@@ -69,9 +69,9 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to delete the entity for
      * @param id          must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteById(String entityDefinitionId, String id, ApplicationParticipant participant);
+    Future<Void> deleteById(String entityDefinitionId, String id, ApplicationParticipant participant);
 
     /**
      * Deletes any entities that match the given query.
@@ -79,9 +79,9 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to delete the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param query       the query used to filter records to delete, must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteByQuery(String entityDefinitionId, String query, ApplicationParticipant participant);
+    Future<Void> deleteByQuery(String entityDefinitionId, String query, ApplicationParticipant participant);
 
     /**
      * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
@@ -91,7 +91,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return a page of entities
      */
-    CompletableFuture<Page<FastestType>> findAll(String entityDefinitionId, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> findAll(String entityDefinitionId, Pageable pageable, ApplicationParticipant participant);
 
     /**
      * Retrieves an entity by its id.
@@ -99,9 +99,9 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to find the entity for
      * @param id          must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} with the entity with the given id or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} with the entity with the given id or {@link Future} emitting null if none found
      */
-    CompletableFuture<FastestType> findById(String entityDefinitionId, String id, ApplicationParticipant participant);
+    Future<FastestType> findById(String entityDefinitionId, String id, ApplicationParticipant participant);
 
     /**
      * Retrieves a list of entities by their id.
@@ -109,9 +109,9 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to find the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param ids         must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} with the list of matched entities with the given ids or {@link CompletableFuture} emitting an empty list if none found
+     * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting an empty list if none found
      */
-    CompletableFuture<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ApplicationParticipant participant);
+    Future<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ApplicationParticipant participant);
 
     /**
      * Executes a named query.
@@ -120,12 +120,12 @@ public interface JsonEntitiesRepository {
      * @param queryName       the name of {@link FunctionDefinition} that defines the query
      * @param queryParameters the parameters to pass to the query
      * @param participant     the participant of the logged-in user
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    CompletableFuture<List<RawJson>> namedQuery(String entityDefinitionId,
-                                                String queryName,
-                                                List<QueryParameter> queryParameters,
-                                                ApplicationParticipant participant);
+    Future<List<RawJson>> namedQuery(String entityDefinitionId,
+                                     String queryName,
+                                     List<QueryParameter> queryParameters,
+                                     ApplicationParticipant participant);
 
     /**
      * Executes a named query and returns a {@link Page} of results.
@@ -135,13 +135,13 @@ public interface JsonEntitiesRepository {
      * @param queryParameters the parameters to pass to the query
      * @param pageable        the page settings to be useds
      * @param participant     the participant of the logged-in user
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    CompletableFuture<Page<RawJson>> namedQueryPage(String entityDefinitionId,
-                                                    String queryName,
-                                                    List<QueryParameter> queryParameters,
-                                                    Pageable pageable,
-                                                    ApplicationParticipant participant);
+    Future<Page<RawJson>> namedQueryPage(String entityDefinitionId,
+                                         String queryName,
+                                         List<QueryParameter> queryParameters,
+                                         Pageable pageable,
+                                         ApplicationParticipant participant);
 
     /**
      * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
@@ -150,9 +150,9 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to save the entity for
      * @param entity      must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting the saved entity
+     * @return {@link Future} emitting the saved entity
      */
-    CompletableFuture<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant);
+    Future<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant);
 
     /**
      * Returns a {@link Page} of entities matching the search text and paging restriction provided in the {@code Pageable} object.
@@ -163,17 +163,17 @@ public interface JsonEntitiesRepository {
      * @param searchText  the text to search for entities for
      * @param pageable    the page settings to be used
      * @param participant the participant of the logged-in user
-     * @return a {@link CompletableFuture} of a page of entities
+     * @return a {@link Future} of a page of entities
      */
-    CompletableFuture<Page<FastestType>> search(String entityDefinitionId, String searchText, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> search(String entityDefinitionId, String searchText, Pageable pageable, ApplicationParticipant participant);
 
     /**
      * This operation makes all the recent writes immediately available for search.
      * @param entityDefinitionId the id of the {@link EntityDefinition} to sync the index for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param participant     the participant of the logged-in user
-     * @return a {@link CompletableFuture} that will complete when the operation is complete
+     * @return a {@link Future} that will complete when the operation is complete
      */
-    CompletableFuture<Void> syncIndex(String entityDefinitionId, ApplicationParticipant participant);
+    Future<Void> syncIndex(String entityDefinitionId, ApplicationParticipant participant);
 
     /**
      * Updates a given entity. This will only override the fields that are present in the given entity.
@@ -183,8 +183,8 @@ public interface JsonEntitiesRepository {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to update the entity for
      * @param entity      must not be {@literal null}
      * @param participant the participant of the logged-in user
-     * @return {@link CompletableFuture} emitting the saved entity
+     * @return {@link Future} emitting the saved entity
      */
-    CompletableFuture<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant);
+    Future<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/MigrationService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/MigrationService.java
@@ -1,10 +1,9 @@
 package org.kinotic.persistence.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.model.MigrationRequest;
 import org.kinotic.persistence.api.model.MigrationResult;
 import org.kinotic.core.api.annotations.Publish;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service for executing project-specific migrations through the Persistence API.
@@ -15,27 +14,27 @@ public interface MigrationService {
 
     /**
      * Executes migrations for a specific project.
-     * 
+     *
      * @param migrationRequest the request containing migrations and project information
      * @return a future that completes with the migration result
      */
-    CompletableFuture<MigrationResult> executeMigrations(MigrationRequest migrationRequest);
+    Future<MigrationResult> executeMigrations(MigrationRequest migrationRequest);
 
     /**
      * Gets the highest migration version that has been applied to a project.
      * This allows clients to determine where to start applying new migrations.
-     * 
+     *
      * @param projectId the project identifier
      * @return a future that completes with the highest applied migration version, or null if no migrations have been applied
      */
-    CompletableFuture<Integer> getLastAppliedMigrationVersion(String projectId);
+    Future<Integer> getLastAppliedMigrationVersion(String projectId);
 
     /**
      * Checks if a specific migration version has been applied to a project.
-     * 
+     *
      * @param projectId the project identifier
      * @param version the migration version to check
      * @return a future that completes with true if the migration has been applied, false otherwise
      */
-    CompletableFuture<Boolean> isMigrationApplied(String projectId, String version);
+    Future<Boolean> isMigrationApplied(String projectId, String version);
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/NamedQueriesDefinitionService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/NamedQueriesDefinitionService.java
@@ -1,11 +1,10 @@
 package org.kinotic.persistence.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.domain.api.services.ProjectScopedCrudService;
 import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.persistence.api.model.NamedQueriesDefinition;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪on 4/23/24.
@@ -17,8 +16,8 @@ public interface NamedQueriesDefinitionService extends ProjectScopedCrudService<
      * Finds all {@link NamedQueriesDefinition} for a given application and {@link EntityDefinition}.
      * @param applicationId the id of the application that the {@link EntityDefinition} belongs to
      * @param entityDefinitionName the name of the {@link EntityDefinition} that this {@link NamedQueriesDefinition} is defined for
-     * @return {@link CompletableFuture} with the {@link NamedQueriesDefinition} or null if not found
+     * @return {@link Future} with the {@link NamedQueriesDefinition} or null if not found
      */
-    CompletableFuture<NamedQueriesDefinition> findByApplicationAndEntityDefinition(String applicationId, String entityDefinitionName);
+    Future<NamedQueriesDefinition> findByApplicationAndEntityDefinition(String applicationId, String entityDefinitionName);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/NamedQueriesService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/NamedQueriesService.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.api.utils.DomainUtil;
@@ -11,7 +12,6 @@ import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.persistence.api.model.ParameterHolder;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/23/24.
@@ -28,13 +28,13 @@ public interface NamedQueriesService {
      * @param parameterHolder the parameters to pass to the query
      * @param type            the type of the entity
      * @param context         the context for this operation
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    <T> CompletableFuture<List<T>> executeNamedQuery(EntityDefinition entityDefinition,
-                                                     String queryName,
-                                                     ParameterHolder parameterHolder,
-                                                     Class<T> type,
-                                                     EntityContext context);
+    <T> Future<List<T>> executeNamedQuery(EntityDefinition entityDefinition,
+                                          String queryName,
+                                          ParameterHolder parameterHolder,
+                                          Class<T> type,
+                                          EntityContext context);
 
     /**
      * Executes a named query and returns a {@link Page} of results.
@@ -45,13 +45,13 @@ public interface NamedQueriesService {
      * @param pageable        the page settings to be used
      * @param type            the type of the entity
      * @param context         the context for this operation
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    <T> CompletableFuture<Page<T>> executeNamedQueryPage(EntityDefinition entityDefinition,
-                                                         String queryName,
-                                                         ParameterHolder parameterHolder,
-                                                         Pageable pageable,
-                                                         Class<T> type,
-                                                         EntityContext context);
+    <T> Future<Page<T>> executeNamedQueryPage(EntityDefinition entityDefinition,
+                                              String queryName,
+                                              ParameterHolder parameterHolder,
+                                              Pageable pageable,
+                                              Class<T> type,
+                                              EntityContext context);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/AuthorizationService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/AuthorizationService.java
@@ -1,8 +1,7 @@
 package org.kinotic.persistence.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.model.EntityContext;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The {@link AuthorizationService} is responsible for authorizing a given action
@@ -11,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface AuthorizationService<T> {
 
-    CompletableFuture<Void> authorize(T operationIdentifier,
-                                      EntityContext entityContext);
+    Future<Void> authorize(T operationIdentifier,
+                           EntityContext entityContext);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/AuthorizationServiceFactory.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/AuthorizationServiceFactory.java
@@ -1,11 +1,10 @@
 package org.kinotic.persistence.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.persistence.api.model.NamedQueryOperation;
 import org.kinotic.persistence.api.model.EntityOperation;
-
-import java.util.concurrent.CompletableFuture;
 
 
 /**
@@ -17,15 +16,15 @@ public interface AuthorizationServiceFactory {
     /**
      * Creates an AuthorizationService for the given EntityDefinition
      * @param entityDefinition to create the AuthorizationService for
-     * @return a CompletableFuture that will complete with the AuthorizationService
+     * @return a Future that will complete with the AuthorizationService
      */
-    CompletableFuture<AuthorizationService<EntityOperation>> createEntityDefinitionAuthorizationService(EntityDefinition entityDefinition);
+    Future<AuthorizationService<EntityOperation>> createEntityDefinitionAuthorizationService(EntityDefinition entityDefinition);
 
     /**
      * Creates an AuthorizationService for the given named query
      * @param namedQuery to create the AuthorizationService for
-     * @return a CompletableFuture that will complete with the AuthorizationService
+     * @return a Future that will complete with the AuthorizationService
      */
-    CompletableFuture<AuthorizationService<NamedQueryOperation>> createNamedQueryAuthorizationService(FunctionDefinition namedQuery);
+    Future<AuthorizationService<NamedQueryOperation>> createNamedQueryAuthorizationService(FunctionDefinition namedQuery);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/EntityDefinitionPolicyAuthorizationService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/EntityDefinitionPolicyAuthorizationService.java
@@ -1,11 +1,6 @@
 package org.kinotic.persistence.api.services.security.graphos;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-
+import io.vertx.core.Future;
 import org.kinotic.core.api.exceptions.AuthorizationException;
 import org.kinotic.idl.api.schema.ObjectC3Type;
 import org.kinotic.persistence.api.model.*;
@@ -19,6 +14,11 @@ import org.kinotic.persistence.internal.api.services.security.graphos.PolicyEval
 import org.kinotic.persistence.internal.api.services.security.graphos.PolicyEvaluatorWithoutOperation;
 import org.kinotic.persistence.internal.api.services.security.graphos.SharedPolicyManager;
 import org.kinotic.persistence.internal.utils.PersistenceUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class EntityDefinitionPolicyAuthorizationService implements AuthorizationService<EntityOperation> {
 
@@ -66,7 +66,7 @@ public class EntityDefinitionPolicyAuthorizationService implements Authorization
     }
 
     @Override
-    public CompletableFuture<Void> authorize(EntityOperation operation, EntityContext entityContext) {
+    public Future<Void> authorize(EntityOperation operation, EntityContext entityContext) {
         try {
             PolicyEvaluator evaluator = operationEvaluators.get(operation);
             // if no operation policy use the
@@ -74,16 +74,17 @@ public class EntityDefinitionPolicyAuthorizationService implements Authorization
                 evaluator = sharedEvaluator;
             }
 
-            return evaluator.evaluatePolicies(entityContext).thenCompose(result -> {
+            return evaluator.evaluatePolicies(entityContext).compose(result -> {
 
+                Future<Void> ret;
                 // Check if the operation is allowed i.e. findAll, save
                 if(!result.operationAllowed()){
 
-                    return CompletableFuture.failedFuture(new AuthorizationException("Operation %s not allowed.".formatted(operation)));
+                    ret = Future.failedFuture(new AuthorizationException("Operation %s not allowed.".formatted(operation)));
 
                 } else if (!result.entityAllowed()) { // Check if access to the entity is allowed
 
-                    return CompletableFuture.failedFuture(new AuthorizationException("%s Entity access not allowed.".formatted(
+                    ret = Future.failedFuture(new AuthorizationException("%s Entity access not allowed.".formatted(
                             entityDefinitionId)));
 
                 } else { // Check if access to the individual fields are allowed
@@ -95,17 +96,18 @@ public class EntityDefinitionPolicyAuthorizationService implements Authorization
                         }
                     }
                     if(!deniedFields.isEmpty()){
-                        return CompletableFuture.failedFuture(new AuthorizationException("%s Fields %s access not allowed.".formatted(
+                        ret = Future.failedFuture(new AuthorizationException("%s Fields %s access not allowed.".formatted(
                                 entityDefinitionId, deniedFields)));
                     }else{
-                        return CompletableFuture.completedFuture(null);
+                        ret = Future.succeededFuture();
                     }
 
                 }
+                return ret;
             });
 
         } catch (Exception e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
     }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/NamedQueryPolicyAuthorizationService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/NamedQueryPolicyAuthorizationService.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.api.services.security.graphos;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.exceptions.AuthorizationException;
 import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.persistence.api.model.EntityContext;
@@ -11,7 +12,6 @@ import org.kinotic.persistence.internal.api.services.security.graphos.PolicyExpr
 import org.kinotic.persistence.internal.api.services.security.graphos.PolicyExpressionUtil;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +43,7 @@ public class NamedQueryPolicyAuthorizationService implements AuthorizationServic
 
 
     @Override
-    public CompletableFuture<Void> authorize(NamedQueryOperation operationIdentifier, EntityContext entityContext) {
+    public Future<Void> authorize(NamedQueryOperation operationIdentifier, EntityContext entityContext) {
 
         Map<String, PolicyAuthorizationRequest> policyRequests = allPolicies.stream()
                                                                             .collect(Collectors.toMap(policy -> policy, DefaultPolicyAuthorizationRequest::new));
@@ -51,15 +51,17 @@ public class NamedQueryPolicyAuthorizationService implements AuthorizationServic
         List<PolicyAuthorizationRequest> requests = new ArrayList<>(policyRequests.values());
 
         return policyAuthorizer.authorize(requests, entityContext)
-                               .thenCompose(ignored -> {
+                               .compose(ignored -> {
 
+                                   Future<Void> ret;
                                    boolean queryAllowed = this.policyExpression.evaluate(policyRequests);
                                    if(queryAllowed){
-                                       return CompletableFuture.completedFuture(null);
+                                       ret = Future.succeededFuture();
                                    }else{
-                                       return CompletableFuture.failedFuture(new AuthorizationException("The Named Query is not authorized"));
+                                       ret = Future.failedFuture(new AuthorizationException("The Named Query is not authorized"));
 
                                    }
+                                   return ret;
                                });
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/PolicyAuthorizationServiceFactory.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/PolicyAuthorizationServiceFactory.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.api.services.security.graphos;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.persistence.api.model.EntityDefinition;
@@ -9,8 +10,6 @@ import org.kinotic.persistence.api.model.idl.decorators.PolicyDecorator;
 import org.kinotic.persistence.api.services.security.AuthorizationService;
 import org.kinotic.persistence.api.services.security.AuthorizationServiceFactory;
 import org.kinotic.persistence.internal.api.services.security.NoopAuthorizationService;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created By Navíd Mitchell 🤪on 12/31/24
@@ -22,16 +21,18 @@ public class PolicyAuthorizationServiceFactory implements AuthorizationServiceFa
     private final NoopAuthorizationService<NamedQueryOperation> noopAuthorizationService = new NoopAuthorizationService<>();
 
     @Override
-    public CompletableFuture<AuthorizationService<EntityOperation>> createEntityDefinitionAuthorizationService(EntityDefinition entityDefinition) {
-        return CompletableFuture.completedFuture(new EntityDefinitionPolicyAuthorizationService(entityDefinition, policyAuthorizer));
+    public Future<AuthorizationService<EntityOperation>> createEntityDefinitionAuthorizationService(EntityDefinition entityDefinition) {
+        return Future.succeededFuture(new EntityDefinitionPolicyAuthorizationService(entityDefinition, policyAuthorizer));
     }
 
     @Override
-    public CompletableFuture<AuthorizationService<NamedQueryOperation>> createNamedQueryAuthorizationService(FunctionDefinition namedQuery) {
+    public Future<AuthorizationService<NamedQueryOperation>> createNamedQueryAuthorizationService(FunctionDefinition namedQuery) {
+        Future<AuthorizationService<NamedQueryOperation>> ret;
         if(namedQuery.containsDecorator(PolicyDecorator.class)) {
-            return CompletableFuture.completedFuture(new NamedQueryPolicyAuthorizationService(namedQuery, policyAuthorizer));
+            ret = Future.succeededFuture(new NamedQueryPolicyAuthorizationService(namedQuery, policyAuthorizer));
         }else {
-            return CompletableFuture.completedFuture(noopAuthorizationService);
+            ret = Future.succeededFuture(noopAuthorizationService);
         }
+        return ret;
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/PolicyAuthorizer.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/security/graphos/PolicyAuthorizer.java
@@ -1,15 +1,15 @@
 package org.kinotic.persistence.api.services.security.graphos;
 
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.model.EntityContext;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The {@link PolicyAuthorizer} is responsible for authorizing a list of {@link PolicyAuthorizationRequest}s
  */
 public interface PolicyAuthorizer {
 
-    CompletableFuture<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext);
+    Future<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/DelegatingUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/DelegatingUpsertPreProcessor.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.hooks;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.persistence.api.config.PersistenceProperties;
 import org.kinotic.persistence.api.model.EntityDefinition;
@@ -16,7 +17,6 @@ import org.kinotic.persistence.internal.api.services.EntityHolder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 6/7/23.
@@ -51,7 +51,7 @@ public class DelegatingUpsertPreProcessor implements UpsertPreProcessor<Object, 
 
     @SuppressWarnings("unchecked")
     @Override
-    public CompletableFuture<EntityHolder<Object>> process(Object entity, EntityContext context) {
+    public Future<EntityHolder<Object>> process(Object entity, EntityContext context) {
         Validate.notNull(entity, "entity must not be null");
         Object ret;
         if(entity instanceof TokenBuffer) {
@@ -63,12 +63,12 @@ public class DelegatingUpsertPreProcessor implements UpsertPreProcessor<Object, 
         } else {
             ret = pojoUpsertPreProcessor.process(entity, context);
         }
-        return (CompletableFuture<EntityHolder<Object>>) ret;
+        return (Future<EntityHolder<Object>>) ret;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public CompletableFuture<List<EntityHolder<Object>>> processArray(Object entities, EntityContext context) {
+    public Future<List<EntityHolder<Object>>> processArray(Object entities, EntityContext context) {
         Validate.notNull(entities, "entities must not be null");
 
         Object ret;
@@ -85,11 +85,11 @@ public class DelegatingUpsertPreProcessor implements UpsertPreProcessor<Object, 
                     ret = pojoUpsertPreProcessor.processArray((List<Object>) entities, context);
                 }
             }else{
-                ret = CompletableFuture.completedFuture(new ArrayList<>());
+                ret = Future.succeededFuture(new ArrayList<>());
             }
         }else {
             throw new IllegalArgumentException("Unsupported type: " + entities.getClass().getName());
         }
-        return (CompletableFuture<List<EntityHolder<Object>>>) ret;
+        return (Future<List<EntityHolder<Object>>>) ret;
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/UpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/UpsertPreProcessor.java
@@ -1,10 +1,10 @@
 package org.kinotic.persistence.internal.api.hooks;
 
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.model.EntityContext;
 import org.kinotic.persistence.internal.api.services.EntityHolder;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Performs logic on Entity Objects before they are upserted.
@@ -18,17 +18,17 @@ public interface UpsertPreProcessor<T, ARRAY_TYPE, ENTITY_TYPE> {
      * This applies all decorator logic to fields that have decorators.
      * @param entity to process
      * @param context the context for this operation
-     * @return {@link CompletableFuture} emitting the processed entity
+     * @return {@link Future} emitting the processed entity
      */
-    CompletableFuture<EntityHolder<ENTITY_TYPE>> process(T entity, EntityContext context);
+    Future<EntityHolder<ENTITY_TYPE>> process(T entity, EntityContext context);
 
     /**
      * Processes an array of entities before they are upserted.
      * This applies all decorator logic to fields that have decorators.
      * @param entities to process
      * @param context the context for this operation
-     * @return {@link CompletableFuture} emitting the processed entities
+     * @return {@link Future} emitting the processed entities
      */
-    CompletableFuture<List<EntityHolder<ENTITY_TYPE>>> processArray(ARRAY_TYPE entities, EntityContext context);
+    Future<List<EntityHolder<ENTITY_TYPE>>> processArray(ARRAY_TYPE entities, EntityContext context);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/AbstractJsonUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/AbstractJsonUpsertPreProcessor.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.hooks.impl;
 
+import io.vertx.core.Future;
 import org.kinotic.idl.api.schema.decorators.C3Decorator;
 import org.kinotic.persistence.api.config.PersistenceProperties;
 import org.kinotic.persistence.api.model.idl.decorators.MultiTenancyType;
@@ -21,7 +22,6 @@ import org.kinotic.persistence.internal.api.services.EntityHolder;
 import org.kinotic.persistence.internal.api.services.json.JsonStreamProcessor;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * This class was created to make the extraction of needed data as performant as possible
@@ -54,8 +54,8 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
     }
 
     @Override
-    public CompletableFuture<EntityHolder<RawJson>> process(T entity, EntityContext context) {
-        return doProcess(entity, context, false).thenApply(list -> {
+    public Future<EntityHolder<RawJson>> process(T entity, EntityContext context) {
+        return doProcess(entity, context, false).map(list -> {
             if(list.size() != 1){
                 throw new IllegalStateException("Expected exactly one entity to be returned, got " + list.size());
             }
@@ -64,7 +64,7 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
     }
 
     @Override
-    public CompletableFuture<List<EntityHolder<RawJson>>> processArray(T entities, EntityContext context) {
+    public Future<List<EntityHolder<RawJson>>> processArray(T entities, EntityContext context) {
         return doProcess(entities, context, true);
     }
 
@@ -77,7 +77,7 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
      * @param context the context of the entity
      * @return a new {@link RawJson} with the appropriate decorators applied
      */
-    private CompletableFuture<List<EntityHolder<RawJson>>> doProcess(T json, EntityContext context, boolean processArray){
+    private Future<List<EntityHolder<RawJson>>> doProcess(T json, EntityContext context, boolean processArray){
         Deque<String> jsonPathStack = new ArrayDeque<>();
         List<EntityHolder<RawJson>> ret = new ArrayList<>();
         List<String> tenantsSelected = new ArrayList<>();
@@ -264,10 +264,10 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
                 context.setTenantSelection(tenantsSelected);
             }
 
-            return CompletableFuture.completedFuture(ret);
+            return Future.succeededFuture(ret);
 
         } catch (Exception e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
     }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/MapUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/MapUpsertPreProcessor.java
@@ -1,6 +1,7 @@
 package org.kinotic.persistence.internal.api.hooks.impl;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kinotic.idl.api.schema.decorators.C3Decorator;
 import org.kinotic.persistence.api.config.PersistenceProperties;
@@ -18,7 +19,6 @@ import org.kinotic.persistence.internal.api.services.EntityHolder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 6/7/23.
@@ -53,8 +53,8 @@ public class MapUpsertPreProcessor implements UpsertPreProcessor<Map<Object, Obj
 
     @WithSpan
     @Override
-    public CompletableFuture<EntityHolder<Map<Object, Object>>> process(Map<Object, Object> entity,
-                                                                        EntityContext context) {
+    public Future<EntityHolder<Map<Object, Object>>> process(Map<Object, Object> entity,
+                                                             EntityContext context) {
         try {
             // We always blow away tenant selection on save/update since the only tenants that mater are the ones in the data
             // This is a sanity check, in case somehow it was already provided. We want to make sure auth services see the correct list.
@@ -62,17 +62,17 @@ public class MapUpsertPreProcessor implements UpsertPreProcessor<Map<Object, Obj
                 context.setTenantSelection(new ArrayList<>());
             }
 
-            return CompletableFuture.completedFuture(preProcessData(entity, context));
+            return Future.succeededFuture(preProcessData(entity, context));
 
         } catch (Exception e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<List<EntityHolder<Map<Object, Object>>>> processArray(List<Map<Object, Object>> entities,
-                                                                                   EntityContext context) {
+    public Future<List<EntityHolder<Map<Object, Object>>>> processArray(List<Map<Object, Object>> entities,
+                                                                        EntityContext context) {
         try {
             // We always blow away tenant selection on save/update since the only tenants that mater are the ones in the data
             // This is a sanity check, in case somehow it was already provided. We want to make sure auth services see the correct list.
@@ -84,9 +84,9 @@ public class MapUpsertPreProcessor implements UpsertPreProcessor<Map<Object, Obj
             for(Map<Object, Object> entity : entities) {
                 entityHolders.add(preProcessData(entity, context));
             }
-            return CompletableFuture.completedFuture(entityHolders);
+            return Future.succeededFuture(entityHolders);
         } catch (Exception e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
     }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/PojoUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/PojoUpsertPreProcessor.java
@@ -1,12 +1,12 @@
 package org.kinotic.persistence.internal.api.hooks.impl;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.NotImplementedException;
 import org.kinotic.persistence.api.model.EntityContext;
 import org.kinotic.persistence.internal.api.hooks.UpsertPreProcessor;
 import org.kinotic.persistence.internal.api.services.EntityHolder;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 6/7/23.
@@ -14,12 +14,12 @@ import java.util.concurrent.CompletableFuture;
 public class PojoUpsertPreProcessor implements UpsertPreProcessor<Object, List<Object>, Object> {
 
     @Override
-    public CompletableFuture<EntityHolder<Object>> process(Object entity, EntityContext context) {
+    public Future<EntityHolder<Object>> process(Object entity, EntityContext context) {
         throw new NotImplementedException("Pojo upsert is not implemented yet");
     }
 
     @Override
-    public CompletableFuture<List<EntityHolder<Object>>> processArray(List<Object> entities, EntityContext context) {
+    public Future<List<EntityHolder<Object>>> processArray(List<Object> entities, EntityContext context) {
         throw new NotImplementedException("Pojo upsert is not implemented yet");
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/RawJsonUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/RawJsonUpsertPreProcessor.java
@@ -1,6 +1,7 @@
 package org.kinotic.persistence.internal.api.hooks.impl;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.json.JsonMapper;
 import org.kinotic.persistence.api.config.PersistenceProperties;
@@ -12,7 +13,6 @@ import org.kinotic.persistence.internal.api.services.EntityHolder;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 2/10/25.
@@ -35,13 +35,13 @@ public class RawJsonUpsertPreProcessor extends AbstractJsonUpsertPreProcessor<Ra
 
     @WithSpan
     @Override
-    public CompletableFuture<EntityHolder<RawJson>> process(RawJson entity, EntityContext context) {
+    public Future<EntityHolder<RawJson>> process(RawJson entity, EntityContext context) {
         return super.process(entity, context);
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<List<EntityHolder<RawJson>>> processArray(RawJson entities, EntityContext context) {
+    public Future<List<EntityHolder<RawJson>>> processArray(RawJson entities, EntityContext context) {
         return super.processArray(entities, context);
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/TokenBufferUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/TokenBufferUpsertPreProcessor.java
@@ -1,6 +1,7 @@
 package org.kinotic.persistence.internal.api.hooks.impl;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.config.PersistenceProperties;
 import org.kinotic.persistence.api.model.EntityContext;
 import org.kinotic.domain.api.model.RawJson;
@@ -13,7 +14,6 @@ import tools.jackson.core.JsonParser;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 2/10/25.
@@ -35,13 +35,13 @@ public class TokenBufferUpsertPreProcessor extends AbstractJsonUpsertPreProcesso
 
     @WithSpan
     @Override
-    public CompletableFuture<EntityHolder<RawJson>> process(TokenBuffer entity, EntityContext context) {
+    public Future<EntityHolder<RawJson>> process(TokenBuffer entity, EntityContext context) {
         return super.process(entity, context);
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<List<EntityHolder<RawJson>>> processArray(TokenBuffer entities, EntityContext context) {
+    public Future<List<EntityHolder<RawJson>>> processArray(TokenBuffer entities, EntityContext context) {
         return super.processArray(entities, context);
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/EntityDefinitionRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/EntityDefinitionRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -8,8 +9,6 @@ import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.kinotic.persistence.api.model.EntityDefinition;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.CompletableFuture;
-
 @Component
 public class EntityDefinitionRepository extends AbstractProjectScopedRepository<EntityDefinition> {
 
@@ -17,9 +16,9 @@ public class EntityDefinitionRepository extends AbstractProjectScopedRepository<
         super("kinotic_entity_definition", EntityDefinition.class, crudServiceTemplate);
     }
 
-    public CompletableFuture<Page<EntityDefinition>> findAllPublishedForApplication(String applicationId,
-                                                                                    String orgId,
-                                                                                    Pageable pageable) {
+    public Future<Page<EntityDefinition>> findAllPublishedForApplication(String applicationId,
+                                                                         String orgId,
+                                                                         Pageable pageable) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return findAll(pageable,
                        b -> b.routing(orgId).query(composeOrgFilter(orgId,

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/NamedQueriesDefinitionRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/NamedQueriesDefinitionRepository.java
@@ -1,12 +1,11 @@
 package org.kinotic.persistence.internal.api.repositories;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.domain.internal.api.repositories.AbstractProjectScopedRepository;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.kinotic.persistence.api.model.NamedQueriesDefinition;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 @Component
 public class NamedQueriesDefinitionRepository extends AbstractProjectScopedRepository<NamedQueriesDefinition> {
@@ -17,9 +16,9 @@ public class NamedQueriesDefinitionRepository extends AbstractProjectScopedRepos
               crudServiceTemplate);
     }
 
-    public CompletableFuture<NamedQueriesDefinition> findByApplicationAndEntityDefinition(String applicationId,
-                                                                                          String entityDefinitionName,
-                                                                                          String orgId) {
+    public Future<NamedQueriesDefinition> findByApplicationAndEntityDefinition(String applicationId,
+                                                                               String entityDefinitionName,
+                                                                               String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         return findFirst(b -> b.routing(orgId).query(composeOrgFilter(orgId,
                                                                       applicationIdFilter(applicationId),

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultAdminJsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultAdminJsonEntitiesRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.domain.api.model.security.ApplicationParticipant;
 import org.kinotic.core.api.crud.Page;
@@ -14,7 +15,6 @@ import org.kinotic.persistence.internal.api.services.sql.ListParameterHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created By Navíd Mitchell 🤪on 2/18/25
@@ -26,17 +26,17 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     private final EntitiesService entitiesService;
 
     @Override
-    public CompletableFuture<Long> count(String entityDefinitionId, List<String> tenantSelection, ApplicationParticipant participant) {
+    public Future<Long> count(String entityDefinitionId, List<String> tenantSelection, ApplicationParticipant participant) {
         return entitiesService.count(entityDefinitionId,
                                      new DefaultEntityContext(participant)
                                              .setTenantSelection(tenantSelection));
     }
 
     @Override
-    public CompletableFuture<Long> countByQuery(String entityDefinitionId,
-                                                String query,
-                                                List<String> tenantSelection,
-                                                ApplicationParticipant participant) {
+    public Future<Long> countByQuery(String entityDefinitionId,
+                                     String query,
+                                     List<String> tenantSelection,
+                                     ApplicationParticipant participant) {
         return entitiesService.countByQuery(entityDefinitionId,
                                             query,
                                             new DefaultEntityContext(participant)
@@ -44,17 +44,17 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant) {
+    public Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant) {
         return entitiesService.deleteById(entityDefinitionId,
                                           id,
                                           new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Void> deleteByQuery(String entityDefinitionId,
-                                                 String query,
-                                                 List<String> tenantSelection,
-                                                 ApplicationParticipant participant) {
+    public Future<Void> deleteByQuery(String entityDefinitionId,
+                                      String query,
+                                      List<String> tenantSelection,
+                                      ApplicationParticipant participant) {
         return entitiesService.deleteByQuery(entityDefinitionId,
                                              query,
                                              new DefaultEntityContext(participant)
@@ -62,10 +62,10 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public CompletableFuture<Page<FastestType>> findAll(String entityDefinitionId,
-                                                        List<String> tenantSelection,
-                                                        Pageable pageable,
-                                                        ApplicationParticipant participant) {
+    public Future<Page<FastestType>> findAll(String entityDefinitionId,
+                                             List<String> tenantSelection,
+                                             Pageable pageable,
+                                             ApplicationParticipant participant) {
         return entitiesService.findAll(entityDefinitionId,
                                        pageable,
                                        FastestType.class,
@@ -74,7 +74,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public CompletableFuture<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant) {
+    public Future<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant) {
         return entitiesService.findById(entityDefinitionId,
                                         id,
                                         FastestType.class,
@@ -82,9 +82,9 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public CompletableFuture<List<FastestType>> findByIds(String entityDefinitionId,
-                                                          List<TenantSpecificId> ids,
-                                                          ApplicationParticipant participant) {
+    public Future<List<FastestType>> findByIds(String entityDefinitionId,
+                                               List<TenantSpecificId> ids,
+                                               ApplicationParticipant participant) {
         return entitiesService.findByIdsWithTenant(entityDefinitionId,
                                                    ids,
                                                    FastestType.class,
@@ -92,11 +92,11 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public CompletableFuture<List<RawJson>> namedQuery(String entityDefinitionId,
-                                                       String queryName,
-                                                       List<QueryParameter> queryParameters,
-                                                       List<String> tenantSelection,
-                                                       ApplicationParticipant participant) {
+    public Future<List<RawJson>> namedQuery(String entityDefinitionId,
+                                            String queryName,
+                                            List<QueryParameter> queryParameters,
+                                            List<String> tenantSelection,
+                                            ApplicationParticipant participant) {
         return entitiesService.namedQuery(entityDefinitionId,
                                           queryName,
                                           new ListParameterHolder(queryParameters),
@@ -106,12 +106,12 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public CompletableFuture<Page<RawJson>> namedQueryPage(String entityDefinitionId,
-                                                           String queryName,
-                                                           List<QueryParameter> queryParameters,
-                                                           List<String> tenantSelection,
-                                                           Pageable pageable,
-                                                           ApplicationParticipant participant) {
+    public Future<Page<RawJson>> namedQueryPage(String entityDefinitionId,
+                                                String queryName,
+                                                List<QueryParameter> queryParameters,
+                                                List<String> tenantSelection,
+                                                Pageable pageable,
+                                                ApplicationParticipant participant) {
         return entitiesService.namedQueryPage(entityDefinitionId,
                                               queryName,
                                               new ListParameterHolder(queryParameters),
@@ -122,11 +122,11 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public CompletableFuture<Page<FastestType>> search(String entityDefinitionId,
-                                                       String searchText,
-                                                       List<String> tenantSelection,
-                                                       Pageable pageable,
-                                                       ApplicationParticipant participant) {
+    public Future<Page<FastestType>> search(String entityDefinitionId,
+                                            String searchText,
+                                            List<String> tenantSelection,
+                                            Pageable pageable,
+                                            ApplicationParticipant participant) {
         return entitiesService.search(entityDefinitionId,
                                       searchText,
                                       pageable,

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntitiesService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntitiesService.java
@@ -2,6 +2,7 @@ package org.kinotic.persistence.internal.api.services;
 
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 
 import org.kinotic.core.api.crud.Page;
@@ -16,7 +17,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪on 5/10/23.
@@ -39,11 +39,11 @@ public class DefaultEntitiesService implements EntitiesService {
     public void handleEntityDefinitionCacheEviction(CacheEvictionEvent event) {
 
         try {
-                
+
             if(event.getEvictionSourceType() == EvictionSourceType.ENTITY_DEFINITION){
                 this.entityServiceCache.evict(event.getOrganizationId(), event.getEntityDefinitionId());
             }
-                    
+
         } catch (Exception e) {
             log.error("failed to handle EntityDefinition cache eviction (source: {})",
                      event.getEvictionSource().getDisplayName(), e);
@@ -52,169 +52,169 @@ public class DefaultEntitiesService implements EntitiesService {
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Void> bulkSave(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                T entities,
-                                                EntityContext context) {
+    public <T> Future<Void> bulkSave(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                     T entities,
+                                     EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.bulkSave(entities, context));
+                .compose(entityService -> entityService.bulkSave(entities, context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Void> bulkUpdate(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                  T entities,
-                                                  EntityContext context) {
+    public <T> Future<Void> bulkUpdate(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                       T entities,
+                                       EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.bulkUpdate(entities, context));
+                .compose(entityService -> entityService.bulkUpdate(entities, context));
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Long> count(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+    public Future<Long> count(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                              EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.count(context));
+    }
+
+    @WithSpan
+    @Override
+    public Future<Long> countByQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                     String query,
+                                     EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.countByQuery(query, context));
+    }
+
+    @WithSpan
+    @Override
+    public Future<Void> deleteById(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                   String id,
+                                   EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.deleteById(id, context));
+    }
+
+    @Override
+    public Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.deleteById(id, context));
+    }
+
+    @WithSpan
+    @Override
+    public Future<Void> deleteByQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                      String query,
+                                      EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.deleteByQuery(query, context));
+    }
+
+    @WithSpan
+    @Override
+    public <T> Future<Page<T>> findAll(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                       Pageable pageable,
+                                       Class<T> type,
+                                       EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.findAll(pageable, type, context));
+    }
+
+    @WithSpan
+    @Override
+    public <T> Future<T> findById(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                  String id,
+                                  Class<T> type,
+                                  EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.findById(id, type, context));
+    }
+
+    @Override
+    public <T> Future<T> findById(String entityDefinitionId, TenantSpecificId id, Class<T> type, EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.findById(id, type, context));
+    }
+
+    @WithSpan
+    @Override
+    public <T> Future<List<T>> findByIds(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                         List<String> ids,
+                                         Class<T> type,
                                          EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.count(context));
+                .compose(entityService -> entityService.findByIds(ids, type, context));
     }
 
-    @WithSpan
     @Override
-    public CompletableFuture<Long> countByQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                String query,
-                                                EntityContext context) {
+    public <T> Future<List<T>> findByIdsWithTenant(String entityDefinitionId,
+                                                   List<TenantSpecificId> ids,
+                                                   Class<T> type,
+                                                   EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.countByQuery(query, context));
+                .compose(entityService -> entityService.findByIdsWithTenant(ids, type, context));
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> deleteById(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                              String id,
+    public <T> Future<List<T>> namedQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                          @SpanAttribute("queryName") String queryName,
+                                          ParameterHolder parameterHolder,
+                                          Class<T> type,
+                                          EntityContext context) {
+        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+                .compose(entityService -> entityService.namedQuery(queryName, parameterHolder, type, context));
+    }
+
+    @WithSpan
+    @Override
+    public <T> Future<Page<T>> namedQueryPage(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                              @SpanAttribute("queryName") String queryName,
+                                              ParameterHolder parameterHolder,
+                                              Pageable pageable,
+                                              Class<T> type,
                                               EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.deleteById(id, context));
+                .compose(entityService -> entityService.namedQueryPage(queryName,
+                                                                       parameterHolder,
+                                                                       pageable,
+                                                                       type,
+                                                                       context));
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String entityDefinitionId, TenantSpecificId id, EntityContext context) {
+    public Future<Void> syncIndex(String entityDefinitionId,
+                                  EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.deleteById(id, context));
-    }
-
-    @WithSpan
-    @Override
-    public CompletableFuture<Void> deleteByQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                 String query,
-                                                 EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.deleteByQuery(query, context));
+                .compose(entityService -> entityService.syncIndex(context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Page<T>> findAll(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                  Pageable pageable,
-                                                  Class<T> type,
-                                                  EntityContext context) {
+    public <T> Future<T> save(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                              T entity,
+                              EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.findAll(pageable, type, context));
+                .compose(entityService -> entityService.save(entity, context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<T> findById(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                             String id,
-                                             Class<T> type,
-                                             EntityContext context) {
+    public <T> Future<Page<T>> search(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                      String searchText,
+                                      Pageable pageable,
+                                      Class<T> type,
+                                      EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.findById(id, type, context));
-    }
-
-    @Override
-    public <T> CompletableFuture<T> findById(String entityDefinitionId, TenantSpecificId id, Class<T> type, EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.findById(id, type, context));
+                .compose(entityService -> entityService.search(searchText, pageable, type, context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<List<T>> findByIds(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                    List<String> ids,
-                                                    Class<T> type,
-                                                    EntityContext context) {
+    public <T> Future<T> update(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
+                                T entity,
+                                EntityContext context) {
         return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.findByIds(ids, type, context));
-    }
-
-    @Override
-    public <T> CompletableFuture<List<T>> findByIdsWithTenant(String entityDefinitionId,
-                                                              List<TenantSpecificId> ids,
-                                                              Class<T> type,
-                                                              EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.findByIdsWithTenant(ids, type, context));
-    }
-
-    @WithSpan
-    @Override
-    public <T> CompletableFuture<List<T>> namedQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                     @SpanAttribute("queryName") String queryName,
-                                                     ParameterHolder parameterHolder,
-                                                     Class<T> type,
-                                                     EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.namedQuery(queryName, parameterHolder, type, context));
-    }
-
-    @WithSpan
-    @Override
-    public <T> CompletableFuture<Page<T>> namedQueryPage(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                         @SpanAttribute("queryName") String queryName,
-                                                         ParameterHolder parameterHolder,
-                                                         Pageable pageable,
-                                                         Class<T> type,
-                                                         EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.namedQueryPage(queryName,
-                                                                           parameterHolder,
-                                                                           pageable,
-                                                                           type,
-                                                                           context));
-    }
-
-    @Override
-    public CompletableFuture<Void> syncIndex(String entityDefinitionId,
-                                             EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.syncIndex(context));
-    }
-
-    @WithSpan
-    @Override
-    public <T> CompletableFuture<T> save(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                         T entity,
-                                         EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.save(entity, context));
-    }
-
-    @WithSpan
-    @Override
-    public <T> CompletableFuture<Page<T>> search(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                                 String searchText,
-                                                 Pageable pageable,
-                                                 Class<T> type,
-                                                 EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.search(searchText, pageable, type, context));
-    }
-
-    @WithSpan
-    @Override
-    public <T> CompletableFuture<T> update(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
-                                           T entity,
-                                           EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
-                .thenCompose(entityService -> entityService.update(entity, context));
+                .compose(entityService -> entityService.update(entity, context));
     }
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityDefinitionService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityDefinitionService.java
@@ -4,6 +4,7 @@ import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch.indices.DataStreamVisibility;
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -23,7 +24,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 
@@ -53,19 +53,19 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
 
     @WithSpan
     @Override
-    public CompletableFuture<EntityDefinition> create(@SpanAttribute("entityDefinition") EntityDefinition entityDefinition) {
+    public Future<EntityDefinition> create(@SpanAttribute("entityDefinition") EntityDefinition entityDefinition) {
         return validateAndCreate(entityDefinition, super::create);
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<EntityDefinition> createSync(@SpanAttribute("entityDefinition") EntityDefinition entityDefinition) {
+    public Future<EntityDefinition> createSync(@SpanAttribute("entityDefinition") EntityDefinition entityDefinition) {
         return validateAndCreate(entityDefinition, super::createSync);
     }
 
-    private CompletableFuture<EntityDefinition> validateAndCreate(EntityDefinition entityDefinition,
-                                                                  Function<EntityDefinition,
-                                                                          CompletableFuture<EntityDefinition>> createOp) {
+    private Future<EntityDefinition> validateAndCreate(EntityDefinition entityDefinition,
+                                                       Function<EntityDefinition,
+                                                               Future<EntityDefinition>> createOp) {
         try {
             // will throw an exception if invalid
             PersistenceUtil.validateEntityDefinition(entityDefinition);
@@ -78,7 +78,7 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
                                                                                entityDefinition.getName());
 
             if (logicalIndexName.length() > 255) {
-                return CompletableFuture.failedFuture(new IllegalArgumentException(
+                return Future.failedFuture(new IllegalArgumentException(
                         "EntityDefinition Id is too long, 'applicationId.name' must be less than 256 characters"));
             }
 
@@ -101,42 +101,42 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
             entityDefinition.setTimeReferenceFieldName(result.timeReferenceFieldName());
 
         } catch (Exception e) {
-            // never throw synchronously from a CompletableFuture-returning method: it strands callers.
-            return CompletableFuture.failedFuture(e);
+            // never throw synchronously from a Future-returning method: it strands callers.
+            return Future.failedFuture(e);
         }
 
         // The base create uses the ES create op-type, so the uniqueness check is atomic at
         // the shard — a concurrent duplicate fails instead of overwriting.
         return createOp.apply(entityDefinition)
-                       .exceptionallyCompose(ex -> AlreadyExistsException.isCause(ex)
-                               ? CompletableFuture.failedFuture(new IllegalArgumentException(
+                       .recover(ex -> AlreadyExistsException.isCause(ex)
+                               ? Future.failedFuture(new IllegalArgumentException(
                                "EntityDefinition Application+Name must be unique, '" + entityDefinition.getId() + "' already exists."))
-                               : CompletableFuture.failedFuture(ex));
+                               : Future.failedFuture(ex));
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> deleteById(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
+    public Future<Void> deleteById(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
         return deleteAndEvict(entityDefinitionId);
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> deleteByIdSync(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
+    public Future<Void> deleteByIdSync(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
         return deleteAndEvict(entityDefinitionId);
     }
 
-    private CompletableFuture<Void> deleteAndEvict(String entityDefinitionId) {
+    private Future<Void> deleteAndEvict(String entityDefinitionId) {
         return findById(entityDefinitionId)
-                .thenCompose(entityDefinition -> {
+                .compose(entityDefinition -> {
 
                     if (entityDefinition == null) {
-                        return CompletableFuture.failedFuture(new IllegalArgumentException(
+                        return Future.failedFuture(new IllegalArgumentException(
                                 "EntityDefinition cannot be found for id: " + entityDefinitionId));
                     }
 
                     if (entityDefinition.isPublished()) {
-                        return CompletableFuture
+                        return Future
                                 .failedFuture(new IllegalStateException("EntityDefinition must be Un-Published before Deleting"));
                     }
 
@@ -144,34 +144,34 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
                     // eviction fires, and the eviction must fire last — either way around,
                     // a concurrent read could re-cache the old row with no eviction behind it.
                     return super.deleteByIdSync(entityDefinitionId)
-                                .thenApply(v -> {
+                                .compose(v -> {
                                     this.eventPublisher.publishEvent(CacheEvictionEvent.localDeletedEntityDefinition(
                                             entityDefinition.getOrganizationId(),
                                             entityDefinition.getApplicationId(),
                                             entityDefinition.getId()));
-                                    return null;
+                                    return Future.succeededFuture();
                                 });
                 });
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Page<EntityDefinition>> findAllPublishedForApplication(@SpanAttribute("applicationId") String applicationId,
-                                                                                    Pageable pageable) {
+    public Future<Page<EntityDefinition>> findAllPublishedForApplication(@SpanAttribute("applicationId") String applicationId,
+                                                                         Pageable pageable) {
         return entityDefinitionRepository.findAllPublishedForApplication(applicationId, requireOrganizationId(), pageable);
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> publish(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
+    public Future<Void> publish(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
         return findById(entityDefinitionId)
-                .thenCompose(entityDefinition -> {
+                .compose(entityDefinition -> {
                     if (entityDefinition == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("EntityDefinition cannot be found for id: " + entityDefinitionId));
                     }
                     if (entityDefinition.isPublished()) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalStateException("EntityDefinition is already published"));
                     }
 
@@ -180,28 +180,28 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
                     String templateName = entityDefinition.getItemIndex() + "_tpl";
                     boolean allowCustomRouting = entityDefinition.getMultiTenancyType() == MultiTenancyType.SHARED;
 
-                    CompletableFuture<Void> creationFuture = entityDefinition.isStream()
+                    Future<Void> creationFuture = entityDefinition.isStream()
                             ? crudServiceTemplate
                               .createIndexTemplate(templateName,
                                                    entityDefinition.getItemIndex() + "*",
                                                    DataStreamVisibility.of(b -> b.allowCustomRouting(allowCustomRouting)),
                                                    mappings)
-                              .thenCompose(v -> crudServiceTemplate.createDataStream(entityDefinition.getItemIndex()))
+                              .compose(v -> crudServiceTemplate.createDataStream(entityDefinition.getItemIndex()))
                             : crudServiceTemplate
                               .createIndex(entityDefinition.getItemIndex(), true, mappings);
 
-                    return creationFuture.thenCompose(v -> {
+                    return creationFuture.compose(v -> {
                         entityDefinition.setPublished(true);
                         entityDefinition.setPublishedTimestamp(new Date());
                         entityDefinition.setUpdated(entityDefinition.getPublishedTimestamp());
                         // saveSync so the published state is searchable before the eviction fires
                         return super.saveSync(entityDefinition)
-                                    .thenApply(entityDefinition1 -> {
+                                    .compose(entityDefinition1 -> {
                                         this.eventPublisher.publishEvent(CacheEvictionEvent.localModifiedEntityDefinition(
                                                 entityDefinition1.getOrganizationId(),
                                                 entityDefinition1.getApplicationId(),
                                                 entityDefinition1.getId()));
-                                        return null;
+                                        return Future.succeededFuture();
                                     });
                     });
                 });
@@ -214,24 +214,24 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
      */
     @WithSpan
     @Override
-    public CompletableFuture<EntityDefinition> saveSync(EntityDefinition entityDefinition) {
+    public Future<EntityDefinition> saveSync(EntityDefinition entityDefinition) {
         return save(entityDefinition);
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<EntityDefinition> save(@SpanAttribute("entityDefinition") EntityDefinition entityDefinition) {
+    public Future<EntityDefinition> save(@SpanAttribute("entityDefinition") EntityDefinition entityDefinition) {
         try {
             Validate.notBlank(entityDefinition.getId(), "EntityDefinition Id Invalid");
             PersistenceUtil.validateEntityDefinition(entityDefinition);
         } catch (IllegalArgumentException e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
 
         return findById(entityDefinition.getId())
-                .thenCompose(existingEntityDefinition -> {
+                .compose(existingEntityDefinition -> {
                     if (existingEntityDefinition == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("EntityDefinition cannot be found for id: " + entityDefinition.getId()));
                     }
 
@@ -259,13 +259,13 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
                                 && entityDefinition.isMultiTenantSelectionEnabled()
                                 && !persistenceProperties.getTenantIdFieldName()
                                                          .equals(entityDefinition.getTenantIdFieldName())) {
-                            return CompletableFuture.failedFuture(
+                            return Future.failedFuture(
                                     new IllegalArgumentException(
                                             "When enabling multi-tenant selection for an existing published EntityDefinition, the tenantId field must be set to: " + persistenceProperties.getTenantIdFieldName()));
                         }
 
                         if (!existingEntityDefinition.isStream() && entityDefinition.isStream()) {
-                            return CompletableFuture.failedFuture(
+                            return Future.failedFuture(
                                     new IllegalArgumentException(
                                             "Cannot change an existing published EntityDefinition from a non-stream to a stream"));
                         }
@@ -277,12 +277,12 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
                         //        Then this could be moved to save the EntityDefinition first with optimistic locking, and if that succeeds then update the mapping
 
 
-                        CompletableFuture<Void> updateFuture;
+                        Future<Void> updateFuture;
                         if (entityDefinition.isStream()) {
                             String templateName = entityDefinition.getItemIndex() + "_tpl";
                             // Update both the template (for future indices) and the data stream's current indices
                             updateFuture = crudServiceTemplate.updateIndexTemplate(templateName, mappings)
-                                                              .thenCompose(v -> crudServiceTemplate.updateIndexMapping(
+                                                              .compose(v -> crudServiceTemplate.updateIndexMapping(
                                                                       entityDefinition.getItemIndex(), mappings));
                         } else {
                             // For regular indices, just update the mappings
@@ -292,9 +292,9 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
                         // saveSync so the new definition is searchable before the eviction
                         // fires — a reload racing the index refresh would re-cache the old
                         // row with no eviction left to clear it.
-                        return updateFuture.thenCompose(
+                        return updateFuture.compose(
                                 v -> super.saveSync(entityDefinition)
-                                          .thenApply(entityDefinition1 -> {
+                                          .map(entityDefinition1 -> {
                                               this.eventPublisher.publishEvent(CacheEvictionEvent.localModifiedEntityDefinition(
                                                       entityDefinition1.getOrganizationId(),
                                                       entityDefinition1.getApplicationId(),
@@ -309,43 +309,43 @@ public class DefaultEntityDefinitionService extends AbstractProjectScopedService
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> unPublish(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
+    public Future<Void> unPublish(@SpanAttribute("entityDefinitionId") String entityDefinitionId) {
         return findById(entityDefinitionId)
-                .thenCompose(entityDefinition -> {
+                .compose(entityDefinition -> {
                     if (entityDefinition == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("EntityDefinition cannot be found for id: " + entityDefinitionId));
                     }
 
                     if (!entityDefinition.isPublished()) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalStateException("EntityDefinition is not published"));
                     }
 
-                    CompletableFuture<Void> deleteStorageFuture;
+                    Future<Void> deleteStorageFuture;
                     if (entityDefinition.isStream()) {
                         String templateName = entityDefinition.getItemIndex() + "_tpl";
                         // Delete the data stream and its template
                         deleteStorageFuture = crudServiceTemplate.deleteDataStream(entityDefinition.getItemIndex())
-                                                                 .thenCompose(v -> crudServiceTemplate.deleteIndexTemplate(
+                                                                 .compose(v -> crudServiceTemplate.deleteIndexTemplate(
                                                                          templateName));
                     } else {
                         // Delete the regular index
                         deleteStorageFuture = crudServiceTemplate.deleteIndex(entityDefinition.getItemIndex());
                     }
 
-                    return deleteStorageFuture.thenCompose(v -> {
+                    return deleteStorageFuture.compose(v -> {
                         entityDefinition.setPublished(false);
                         entityDefinition.setPublishedTimestamp(null);
                         entityDefinition.setUpdated(new Date());
                         // saveSync so the unpublished state is searchable before the eviction fires
                         return super.saveSync(entityDefinition)
-                                    .thenApply(entityDefinition1 -> {
+                                    .compose(entityDefinition1 -> {
                                         this.eventPublisher.publishEvent(CacheEvictionEvent.localModifiedEntityDefinition(
                                                 entityDefinition1.getOrganizationId(),
                                                 entityDefinition1.getApplicationId(),
                                                 entityDefinition1.getId()));
-                                        return null;
+                                        return Future.succeededFuture();
                                     });
                     });
                 });

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityService.java
@@ -10,6 +10,7 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.mget.MultiGetOperation;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.ObjectUtils;
@@ -35,7 +36,6 @@ import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.util.TokenBuffer;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 /**
@@ -58,7 +58,7 @@ public class DefaultEntityService implements EntityService {
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Void> bulkSave(T entities, EntityContext context) {
+    public <T> Future<Void> bulkSave(T entities, EntityContext context) {
         return doPersistBulk(entities,
                              EntityOperation.BULK_SAVE,
                              context,
@@ -97,7 +97,7 @@ public class DefaultEntityService implements EntityService {
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Void> bulkUpdate(T entities, EntityContext context) {
+    public <T> Future<Void> bulkUpdate(T entities, EntityContext context) {
         return doPersistBulk(entities,
                              EntityOperation.BULK_UPDATE,
                              context,
@@ -133,70 +133,70 @@ public class DefaultEntityService implements EntityService {
 
     @WithSpan
     @Override
-    public CompletableFuture<Long> count(EntityContext context) {
+    public Future<Long> count(EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.COUNT, context))
-                .thenCompose(un -> crudServiceTemplate
+                .compose(un -> authService.authorize(EntityOperation.COUNT, context))
+                .compose(un -> crudServiceTemplate
                         .count(entityDefinition.getItemIndex(),
                                builder -> readPreProcessor.beforeCount(entityDefinition, null, builder, context)));
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Long> countByQuery(String query, EntityContext context) {
+    public Future<Long> countByQuery(String query, EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.COUNT_BY_QUERY, context))
-                .thenCompose(un -> crudServiceTemplate
+                .compose(un -> authService.authorize(EntityOperation.COUNT_BY_QUERY, context))
+                .compose(un -> crudServiceTemplate
                         .count(entityDefinition.getItemIndex(),
                                builder -> readPreProcessor.beforeCount(entityDefinition, query, builder, context)));
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> deleteById(String id, EntityContext context) {
+    public Future<Void> deleteById(String id, EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.DELETE_BY_ID, context))
-                .thenApply(un -> composeId(id, context))
-                .thenCompose(composedId -> crudServiceTemplate
+                .compose(un -> authService.authorize(EntityOperation.DELETE_BY_ID, context))
+                .map(un -> composeId(id, context))
+                .compose(composedId -> crudServiceTemplate
                         .deleteById(entityDefinition.getItemIndex(),
                                     composedId,
                                     builder -> readPreProcessor.beforeDelete(entityDefinition, builder, context))
-                        .thenApply(deleteResponse -> null));
+                        .mapEmpty());
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> deleteById(TenantSpecificId id, EntityContext context) {
+    public Future<Void> deleteById(TenantSpecificId id, EntityContext context) {
         // We set the tenant selection so validation below will know that a tenant specific operation is being used
         context.setTenantSelection(List.of(id.tenantId()));
 
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.DELETE_BY_ID, context))
-                .thenApply(un -> composeId(id))
-                .thenCompose(composedId -> crudServiceTemplate
+                .compose(un -> authService.authorize(EntityOperation.DELETE_BY_ID, context))
+                .map(un -> composeId(id))
+                .compose(composedId -> crudServiceTemplate
                         .deleteById(entityDefinition.getItemIndex(),
                                     composedId,
                                     builder -> readPreProcessor.beforeDelete(entityDefinition, builder, context))
-                        .thenApply(deleteResponse -> null));
+                        .mapEmpty());
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> deleteByQuery(String query, EntityContext context) {
+    public Future<Void> deleteByQuery(String query, EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.DELETE_BY_QUERY, context))
-                .thenCompose(un -> crudServiceTemplate
+                .compose(un -> authService.authorize(EntityOperation.DELETE_BY_QUERY, context))
+                .compose(un -> crudServiceTemplate
                         .deleteByQuery(entityDefinition.getItemIndex(),
                                        builder -> readPreProcessor.beforeDeleteByQuery(entityDefinition, query, builder, context))
-                        .thenApply(deleteResponse -> null));
+                        .mapEmpty());
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Page<T>> findAll(Pageable pageable, Class<T> type, EntityContext context) {
+    public <T> Future<Page<T>> findAll(Pageable pageable, Class<T> type, EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.FIND_ALL, context))
-                .thenCompose(un -> {
+                .compose(un -> authService.authorize(EntityOperation.FIND_ALL, context))
+                .compose(un -> {
 
                     if(FastestType.class.isAssignableFrom(type)){
 
@@ -238,87 +238,87 @@ public class DefaultEntityService implements EntityService {
                                             builder -> readPreProcessor.beforeFindAll(entityDefinition, builder, context));
                         }
                     }
-                }).thenApply(createParanoidCheck(context, "FindAll"));
+                }).map(createParanoidCheck(context, "FindAll"));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<T> findById(String id, Class<T> type, EntityContext context) {
+    public <T> Future<T> findById(String id, Class<T> type, EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.FIND_BY_ID, context))
-                .thenApply(un -> composeId(id, context))
-                .thenCompose(composedId -> doFindById(composedId, type, context));
+                .compose(un -> authService.authorize(EntityOperation.FIND_BY_ID, context))
+                .map(un -> composeId(id, context))
+                .compose(composedId -> doFindById(composedId, type, context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<T> findById(TenantSpecificId id, Class<T> type, EntityContext context) {
+    public <T> Future<T> findById(TenantSpecificId id, Class<T> type, EntityContext context) {
         // We set the tenant selection so validation below will know that a tenant specific operation is being used
         context.setTenantSelection(List.of(id.tenantId()));
 
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.FIND_BY_ID, context))
-                .thenApply(un -> composeId(id))
-                .thenCompose(composedId -> doFindById(composedId, type, context));
+                .compose(un -> authService.authorize(EntityOperation.FIND_BY_ID, context))
+                .map(un -> composeId(id))
+                .compose(composedId -> doFindById(composedId, type, context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<List<T>> findByIds(List<String> ids, Class<T> type, EntityContext context) {
+    public <T> Future<List<T>> findByIds(List<String> ids, Class<T> type, EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.FIND_BY_IDS, context))
-                .thenApply(un -> composeIds(ids, context))
-                .thenCompose(composedIds -> doFindByIds(composedIds, type, context));
+                .compose(un -> authService.authorize(EntityOperation.FIND_BY_IDS, context))
+                .map(un -> composeIds(ids, context))
+                .compose(composedIds -> doFindByIds(composedIds, type, context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<List<T>> findByIdsWithTenant(List<TenantSpecificId> ids, Class<T> type, EntityContext context) {
+    public <T> Future<List<T>> findByIdsWithTenant(List<TenantSpecificId> ids, Class<T> type, EntityContext context) {
         return  validate_ComposeIds_AddTenantsToContext(ids, context)
-                .thenCompose(composedIds
+                .compose(composedIds
                                      -> authService.authorize(EntityOperation.FIND_BY_IDS, context)
-                                                   .thenCompose(v -> doFindByIds(composedIds, type, context)));
+                                                   .compose(v -> doFindByIds(composedIds, type, context)));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<List<T>> namedQuery(String queryName,
-                                                     ParameterHolder parameterHolder,
-                                                     Class<T> type,
-                                                     EntityContext context) {
+    public <T> Future<List<T>> namedQuery(String queryName,
+                                          ParameterHolder parameterHolder,
+                                          Class<T> type,
+                                          EntityContext context) {
         // Authorization happens in the QueryExecutor so we don't need an additional cache to hold the NamedQueryAuthorizationService
         return validateContext(context)
-                .thenCompose(unused -> namedQueriesService.executeNamedQuery(entityDefinition,
+                .compose(unused -> namedQueriesService.executeNamedQuery(entityDefinition,
+                                                                         queryName,
+                                                                         parameterHolder,
+                                                                         type,
+                                                                         context));
+    }
+
+    @WithSpan
+    @Override
+    public <T> Future<Page<T>> namedQueryPage(String queryName,
+                                              ParameterHolder parameterHolder,
+                                              Pageable pageable,
+                                              Class<T> type,
+                                              EntityContext context) {
+        // Authorization happens in the QueryExecutor so we don't need an additional cache to hold the NamedQueryAuthorizationService
+        return validateContext(context)
+                .compose(unused -> namedQueriesService.executeNamedQueryPage(entityDefinition,
                                                                              queryName,
                                                                              parameterHolder,
+                                                                             pageable,
                                                                              type,
                                                                              context));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Page<T>> namedQueryPage(String queryName,
-                                                         ParameterHolder parameterHolder,
-                                                         Pageable pageable,
-                                                         Class<T> type,
-                                                         EntityContext context) {
-        // Authorization happens in the QueryExecutor so we don't need an additional cache to hold the NamedQueryAuthorizationService
-        return validateContext(context)
-                .thenCompose(unused -> namedQueriesService.executeNamedQueryPage(entityDefinition,
-                                                                                 queryName,
-                                                                                 parameterHolder,
-                                                                                 pageable,
-                                                                                 type,
-                                                                                 context));
-    }
-
-    @WithSpan
-    @Override
-    public <T> CompletableFuture<T> save(T entity, EntityContext context) {
+    public <T> Future<T> save(T entity, EntityContext context) {
         return doPersist(entity,
                          EntityOperation.SAVE,
                          context,
-                         entityHolder -> esAsyncClient.index(i -> {
+                         entityHolder -> crudServiceTemplate.toFuture(esAsyncClient.index(i -> {
                              i.routing(entityHolder.tenantId())
                               .index(entityDefinition.getItemIndex())
                               .id(entityHolder.getDocumentId())
@@ -344,18 +344,18 @@ public class DefaultEntityService implements EntityService {
                              }
 
                              return i;
-                         }).thenApply(indexResponse -> postProcessSaveOrUpdate(entity,
-                                                                               entityHolder,
-                                                                               indexResponse.primaryTerm(),
-                                                                               indexResponse.seqNo())));
+                         })).map(indexResponse -> postProcessSaveOrUpdate(entity,
+                                                                          entityHolder,
+                                                                          indexResponse.primaryTerm(),
+                                                                          indexResponse.seqNo())));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<Page<T>> search(String searchText, Pageable pageable, Class<T> type, EntityContext context) {
+    public <T> Future<Page<T>> search(String searchText, Pageable pageable, Class<T> type, EntityContext context) {
         return validateContext(context)
-                .thenCompose(un -> authService.authorize(EntityOperation.SEARCH, context))
-                .thenCompose(un -> {
+                .compose(un -> authService.authorize(EntityOperation.SEARCH, context))
+                .compose(un -> {
 
                     if(FastestType.class.isAssignableFrom(type)){
 
@@ -409,21 +409,19 @@ public class DefaultEntityService implements EntityService {
                                                                                      context));
                         }
                     }
-                }).thenApply(createParanoidCheck(context, "Search"));
+                }).map(createParanoidCheck(context, "Search"));
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<Void> syncIndex(EntityContext context) {
+    public Future<Void> syncIndex(EntityContext context) {
         return authService.authorize(EntityOperation.SYNC_INDEX, context)
-                          .thenCompose(un -> esAsyncClient.indices().refresh(
-                                  b -> b.index(entityDefinition.getItemIndex())))
-                          .thenApply(unused -> null);
+                          .compose(un -> crudServiceTemplate.syncIndex(entityDefinition.getItemIndex()));
     }
 
     @WithSpan
     @Override
-    public <T> CompletableFuture<T> update(T entity, EntityContext context) {
+    public <T> Future<T> update(T entity, EntityContext context) {
         return doPersist(entity,
                          EntityOperation.UPDATE,
                          context,
@@ -451,8 +449,8 @@ public class DefaultEntityService implements EntityService {
                                  return u;
                              });
 
-                             return esAsyncClient.update(request, entityHolder.entity().getClass())
-                                                 .thenApply(updateResponse ->
+                             return crudServiceTemplate.toFuture(esAsyncClient.update(request, entityHolder.entity().getClass()))
+                                                       .map(updateResponse ->
                                                                     postProcessSaveOrUpdate(entity,
                                                                                             entityHolder,
                                                                                             updateResponse.primaryTerm(),
@@ -554,7 +552,7 @@ public class DefaultEntityService implements EntityService {
         };
     }
 
-    private <T> CompletableFuture<T> doFindById(String id, Class<T> type, EntityContext context) {
+    private <T> Future<T> doFindById(String id, Class<T> type, EntityContext context) {
         if(FastestType.class.isAssignableFrom(type)){
             if(entityDefinition.isOptimisticLockingEnabled()){
                 return crudServiceTemplate
@@ -596,9 +594,9 @@ public class DefaultEntityService implements EntityService {
         }
     }
 
-    private <T> CompletableFuture<List<T>> doFindByIds(List<MultiGetOperation> composedIds,
-                                                       Class<T> type,
-                                                       EntityContext context) {
+    private <T> Future<List<T>> doFindByIds(List<MultiGetOperation> composedIds,
+                                            Class<T> type,
+                                            EntityContext context) {
         if(FastestType.class.isAssignableFrom(type)){
             if(entityDefinition.isOptimisticLockingEnabled()){
                 return crudServiceTemplate
@@ -637,52 +635,52 @@ public class DefaultEntityService implements EntityService {
         }
     }
 
-    private <T> CompletableFuture<T> doPersist(T entity,
-                                               EntityOperation operation,
-                                               EntityContext context,
-                                               Function<EntityHolder<?>, CompletableFuture<T>> persistLogic){
+    private <T> Future<T> doPersist(T entity,
+                                    EntityOperation operation,
+                                    EntityContext context,
+                                    Function<EntityHolder<?>, Future<T>> persistLogic){
         // We do this since ideally processing data before auth is not ideal
         // However, in the case of Multi-tenant access we must extract tenant ids prior to calling auth
         if(entityDefinition.isMultiTenantSelectionEnabled()){
 
             return validateContext(context)
-                    .thenCompose(un -> delegatingUpsertPreProcessor.process(entity, context))
-                    .thenCompose(entityHolder ->
+                    .compose(un -> delegatingUpsertPreProcessor.process(entity, context))
+                    .compose(entityHolder ->
                                          authService.authorize(operation, context)
-                                                    .thenCompose(un -> persistLogic.apply(entityHolder)));
+                                                    .compose(un -> persistLogic.apply(entityHolder)));
         }else{
             return validateContext(context)
-                    .thenCompose(un -> authService.authorize(operation, context))
-                    .thenCompose(un -> delegatingUpsertPreProcessor.process(entity, context))
-                    .thenCompose(persistLogic);
+                    .compose(un -> authService.authorize(operation, context))
+                    .compose(un -> delegatingUpsertPreProcessor.process(entity, context))
+                    .compose(persistLogic);
         }
     }
 
-    private <T> CompletableFuture<Void> doPersistBulk(T entities,
-                                                      EntityOperation operation,
-                                                      EntityContext context,
-                                                      Function<EntityHolder<?>, BulkOperation> persistLogic){
+    private <T> Future<Void> doPersistBulk(T entities,
+                                           EntityOperation operation,
+                                           EntityContext context,
+                                           Function<EntityHolder<?>, BulkOperation> persistLogic){
         // We do this since ideally processing data before auth is not ideal
         // However, in the case of Multi-tenant access we must extract tenant ids prior to calling auth
         if(entityDefinition.isMultiTenantSelectionEnabled()){
 
             return validateContext(context)
-                    .thenCompose(un -> delegatingUpsertPreProcessor.processArray(entities, context))
-                    .thenCompose(entityList ->
+                    .compose(un -> delegatingUpsertPreProcessor.processArray(entities, context))
+                    .compose(entityList ->
                                          authService.authorize(operation, context)
-                                                    .thenCompose(un -> doPersistBulkLogic(entityList, persistLogic)))
-                    .thenApply(unused -> null);
+                                                    .compose(un -> doPersistBulkLogic(entityList, persistLogic)))
+                    .mapEmpty();
         }else {
             return validateContext(context)
-                    .thenCompose(un -> authService.authorize(operation, context))
-                    .thenCompose(un -> delegatingUpsertPreProcessor.processArray(entities, context))
-                    .thenCompose(list -> doPersistBulkLogic(list, persistLogic))
-                    .thenApply(un -> null);
+                    .compose(un -> authService.authorize(operation, context))
+                    .compose(un -> delegatingUpsertPreProcessor.processArray(entities, context))
+                    .compose(list -> doPersistBulkLogic(list, persistLogic))
+                    .mapEmpty();
         }
     }
 
-    private CompletableFuture<BulkResponse> doPersistBulkLogic(List<EntityHolder<Object>> list,
-                                                               Function<EntityHolder<?>, BulkOperation> persistLogic) {
+    private Future<BulkResponse> doPersistBulkLogic(List<EntityHolder<Object>> list,
+                                                    Function<EntityHolder<?>, BulkOperation> persistLogic) {
 
         BulkRequest.Builder br = new BulkRequest.Builder();
 
@@ -692,12 +690,12 @@ public class DefaultEntityService implements EntityService {
         }
 
         if(bulkOperations.isEmpty()){
-            return CompletableFuture.failedFuture(new IllegalArgumentException("No items found to create bulk request for"));
+            return Future.failedFuture(new IllegalArgumentException("No items found to create bulk request for"));
         }
 
         br.operations(bulkOperations);
 
-        return esAsyncClient.bulk(br.build()).thenCompose(bulkResponse -> {
+        return crudServiceTemplate.toFuture(esAsyncClient.bulk(br.build())).compose(bulkResponse -> {
             if (bulkResponse.errors()) {
                 StringBuilder builder = new StringBuilder();
                 for (BulkResponseItem item : bulkResponse.items()) {
@@ -707,9 +705,9 @@ public class DefaultEntityService implements EntityService {
                     }
                 }
                 String errorMessage = !builder.isEmpty() ? builder.toString() : "Unknown error occurred during bulk operation";
-                return CompletableFuture.failedFuture(new IllegalArgumentException("Bulk save failed with errors:\n" + errorMessage));
+                return Future.failedFuture(new IllegalArgumentException("Bulk save failed with errors:\n" + errorMessage));
             } else {
-                return CompletableFuture.completedFuture(bulkResponse);
+                return Future.succeededFuture(bulkResponse);
             }
         });
     }
@@ -829,7 +827,7 @@ public class DefaultEntityService implements EntityService {
         return entity;
     }
 
-    private CompletableFuture<Void> validateContext(final EntityContext context){
+    private Future<Void> validateContext(final EntityContext context){
         if(entityDefinition.getMultiTenancyType() == MultiTenancyType.SHARED){
             if(context.getParticipant() != null && context.getParticipant().getTenantId() != null) {
 
@@ -837,30 +835,30 @@ public class DefaultEntityService implements EntityService {
                 if (ObjectUtils.isNotEmpty(context.getTenantSelection())
                         && !entityDefinition.isMultiTenantSelectionEnabled()) {
 
-                    return CompletableFuture.failedFuture(
+                    return Future.failedFuture(
                             new IllegalArgumentException("Multi-tenant access for this EntityDefinition %s is not enabled".formatted(
                                     entityDefinition.getName()))
                     );
                 } else {
-                    return CompletableFuture.completedFuture(null);
+                    return Future.succeededFuture();
                 }
             }else{
-                return CompletableFuture.failedFuture(new IllegalArgumentException("Participant with a TenantId is required when MultiTenancyType is SHARED"));
+                return Future.failedFuture(new IllegalArgumentException("Participant with a TenantId is required when MultiTenancyType is SHARED"));
             }
         }else if(ObjectUtils.isNotEmpty(context.getTenantSelection())){
             // This check is here since continuum will allow any published service to be called.
             // So someone could call the admin service even though it is not enabled for this EntityDefinition
             // Multitenant access can only be enabled if MultiTenancyType.SHARED
-            return CompletableFuture.failedFuture(
+            return Future.failedFuture(
                     new IllegalArgumentException("Multi-tenant access for this EntityDefinition %s is not enabled".formatted(
                             entityDefinition.getName()))
             );
         }else{
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
     }
 
-    private CompletableFuture<List<MultiGetOperation>> validate_ComposeIds_AddTenantsToContext(final List<TenantSpecificId> ids, EntityContext entityContext){
+    private Future<List<MultiGetOperation>> validate_ComposeIds_AddTenantsToContext(final List<TenantSpecificId> ids, EntityContext entityContext){
         if(entityDefinition.getMultiTenancyType() == MultiTenancyType.SHARED
                 && entityDefinition.isMultiTenantSelectionEnabled()){
 
@@ -879,13 +877,13 @@ public class DefaultEntityService implements EntityService {
                 }
 
                 entityContext.setTenantSelection(tenants);
-                return CompletableFuture.completedFuture(ret);
+                return Future.succeededFuture(ret);
 
             }else{
-                return CompletableFuture.failedFuture(new IllegalArgumentException("Participant with a TenantId is required when MultiTenancyType is SHARED"));
+                return Future.failedFuture(new IllegalArgumentException("Participant with a TenantId is required when MultiTenancyType is SHARED"));
             }
         }else{
-            return CompletableFuture.failedFuture(
+            return Future.failedFuture(
                     new IllegalArgumentException("Multi-tenant access for this EntityDefinition %s is not enabled".formatted(
                             entityDefinition.getName()))
             );

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultJsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultJsonEntitiesRepository.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services;
 
+import io.vertx.core.Future;
 import tools.jackson.databind.util.TokenBuffer;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.domain.api.model.security.ApplicationParticipant;
@@ -14,7 +15,6 @@ import org.kinotic.persistence.internal.api.services.sql.ListParameterHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Nic Padilla 🤪on 6/18/23.
@@ -26,57 +26,57 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
     private final EntitiesService entitiesService;
 
     @Override
-    public CompletableFuture<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant) {
+    public Future<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant) {
         return entitiesService.bulkSave(entityDefinitionId, entities, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant) {
+    public Future<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant) {
         return entitiesService.bulkUpdate(entityDefinitionId, entities, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Long> count(String entityDefinitionId, ApplicationParticipant participant) {
+    public Future<Long> count(String entityDefinitionId, ApplicationParticipant participant) {
         return entitiesService.count(entityDefinitionId, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Long> countByQuery(String entityDefinitionId, String query, ApplicationParticipant participant) {
+    public Future<Long> countByQuery(String entityDefinitionId, String query, ApplicationParticipant participant) {
         return entitiesService.countByQuery(entityDefinitionId, query, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String entityDefinitionId, String id, ApplicationParticipant participant) {
+    public Future<Void> deleteById(String entityDefinitionId, String id, ApplicationParticipant participant) {
         return entitiesService.deleteById(entityDefinitionId, id, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Void> deleteByQuery(String entityDefinitionId, String query, ApplicationParticipant participant) {
+    public Future<Void> deleteByQuery(String entityDefinitionId, String query, ApplicationParticipant participant) {
         return entitiesService.deleteByQuery(entityDefinitionId, query, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Page<FastestType>> findAll(String entityDefinitionId,
-                                                        Pageable pageable,
-                                                        ApplicationParticipant participant) {
+    public Future<Page<FastestType>> findAll(String entityDefinitionId,
+                                             Pageable pageable,
+                                             ApplicationParticipant participant) {
         return entitiesService.findAll(entityDefinitionId, pageable, FastestType.class, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<FastestType> findById(String entityDefinitionId, String id, ApplicationParticipant participant) {
+    public Future<FastestType> findById(String entityDefinitionId, String id, ApplicationParticipant participant) {
         return entitiesService.findById(entityDefinitionId, id, FastestType.class, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ApplicationParticipant participant) {
+    public Future<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ApplicationParticipant participant) {
         return entitiesService.findByIds(entityDefinitionId, ids, FastestType.class, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<List<RawJson>> namedQuery(String entityDefinitionId,
-                                                       String queryName,
-                                                       List<QueryParameter> queryParameters,
-                                                       ApplicationParticipant participant) {
+    public Future<List<RawJson>> namedQuery(String entityDefinitionId,
+                                            String queryName,
+                                            List<QueryParameter> queryParameters,
+                                            ApplicationParticipant participant) {
         return entitiesService.namedQuery(entityDefinitionId,
                                           queryName,
                                           new ListParameterHolder(queryParameters),
@@ -85,11 +85,11 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
     }
 
     @Override
-    public CompletableFuture<Page<RawJson>> namedQueryPage(String entityDefinitionId,
-                                                           String queryName,
-                                                           List<QueryParameter> queryParameters,
-                                                           Pageable pageable,
-                                                           ApplicationParticipant participant) {
+    public Future<Page<RawJson>> namedQueryPage(String entityDefinitionId,
+                                                String queryName,
+                                                List<QueryParameter> queryParameters,
+                                                Pageable pageable,
+                                                ApplicationParticipant participant) {
         return entitiesService.namedQueryPage(entityDefinitionId,
                                               queryName,
                                               new ListParameterHolder(queryParameters),
@@ -99,25 +99,25 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
     }
 
     @Override
-    public CompletableFuture<Void> syncIndex(String entityDefinitionId, ApplicationParticipant participant) {
+    public Future<Void> syncIndex(String entityDefinitionId, ApplicationParticipant participant) {
         return entitiesService.syncIndex(entityDefinitionId, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant) {
+    public Future<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant) {
         return entitiesService.save(entityDefinitionId, entity, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<Page<FastestType>> search(String entityDefinitionId,
-                                                       String searchText,
-                                                       Pageable pageable,
-                                                       ApplicationParticipant participant) {
+    public Future<Page<FastestType>> search(String entityDefinitionId,
+                                            String searchText,
+                                            Pageable pageable,
+                                            ApplicationParticipant participant) {
         return entitiesService.search(entityDefinitionId, searchText, pageable, FastestType.class, new DefaultEntityContext(participant));
     }
 
     @Override
-    public CompletableFuture<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant) {
+    public Future<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant) {
         return entitiesService.update(entityDefinitionId, entity, new DefaultEntityContext(participant));
     }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultMigrationService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultMigrationService.java
@@ -1,9 +1,9 @@
 package org.kinotic.persistence.internal.api.services;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
+import io.vertx.core.Future;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
+import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.kinotic.persistence.api.model.MigrationDefinition;
 import org.kinotic.persistence.api.model.MigrationRequest;
 import org.kinotic.persistence.api.model.MigrationResult;
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 
 /**
  * Implementation of MigrationService that allows external clients to execute migrations
@@ -25,69 +25,70 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class DefaultMigrationService implements MigrationService {
-    
+
     private static final Logger log = LoggerFactory.getLogger(DefaultMigrationService.class);
-    
+
+    private final CrudServiceTemplate crudServiceTemplate;
     private final MigrationExecutor migrationExecutor;
     private final MigrationParser migrationParser;
 
     @Override
-    public CompletableFuture<MigrationResult> executeMigrations(MigrationRequest migrationRequest) {
+    public Future<MigrationResult> executeMigrations(MigrationRequest migrationRequest) {
         Validate.isTrue(!migrationRequest.projectId().equals(MigrationExecutor.SYSTEM_PROJECT),
                         "Project ID %s is not allowed", MigrationExecutor.SYSTEM_PROJECT);
 
-        log.debug("Executing {} migrations for project {}", 
-                migrationRequest.migrations().size(), 
+        log.debug("Executing {} migrations for project {}",
+                migrationRequest.migrations().size(),
                 migrationRequest.projectId());
-        
+
         try {
             // Convert API migration definitions to internal Migration objects
             List<Migration> migrations = convertToInternalMigrations(migrationRequest.migrations());
-            
-            return migrationExecutor.executeProjectMigrations(migrations, migrationRequest.projectId())
-                .thenApply(result -> {
-                    log.debug("Successfully executed {} migrations for project {}", 
-                            migrations.size(), 
+
+            return crudServiceTemplate.toFuture(migrationExecutor.executeProjectMigrations(migrations, migrationRequest.projectId()))
+                .map(result -> {
+                    log.debug("Successfully executed {} migrations for project {}",
+                            migrations.size(),
                             migrationRequest.projectId());
-                    
+
                     return MigrationResult.success(
-                        migrationRequest.projectId(), 
+                        migrationRequest.projectId(),
                         migrations.size()
                     );
                 })
-                .exceptionally(throwable -> {
-                    log.debug("Failed to execute migrations for project {}: {}", 
+                .otherwise(throwable -> {
+                    log.debug("Failed to execute migrations for project {}: {}",
                              migrationRequest.projectId(), throwable.getMessage(), throwable);
                     return MigrationResult.failure(migrationRequest.projectId(), throwable.getMessage());
                 });
-            
+
         } catch (Exception e) {
-            log.debug("Failed to execute migrations for project {}: {}", 
+            log.debug("Failed to execute migrations for project {}: {}",
                      migrationRequest.projectId(), e.getMessage(), e);
-            return CompletableFuture.completedFuture(
+            return Future.succeededFuture(
                 MigrationResult.failure(migrationRequest.projectId(), e.getMessage())
             );
         }
     }
 
     @Override
-    public CompletableFuture<Integer> getLastAppliedMigrationVersion(String projectId) {
+    public Future<Integer> getLastAppliedMigrationVersion(String projectId) {
         Validate.notNull(projectId, "Project ID cannot be null");
         Validate.isTrue(!projectId.equals(MigrationExecutor.SYSTEM_PROJECT),
                         "Project ID %s is not allowed", MigrationExecutor.SYSTEM_PROJECT);
         // Query Elasticsearch for the highest migration version applied to this project
-        return migrationExecutor.getLastAppliedMigrationVersion(projectId);
+        return crudServiceTemplate.toFuture(migrationExecutor.getLastAppliedMigrationVersion(projectId));
     }
 
     @Override
-    public CompletableFuture<Boolean> isMigrationApplied(String projectId, String version) {
+    public Future<Boolean> isMigrationApplied(String projectId, String version) {
         Validate.notNull(projectId, "Project ID cannot be null");
         Validate.notNull(version, "Migration version cannot be null");
         Validate.isTrue(!projectId.equals(MigrationExecutor.SYSTEM_PROJECT),
                         "Project ID %s is not allowed", MigrationExecutor.SYSTEM_PROJECT);
-        return migrationExecutor.isMigrationAppliedAsync(version, projectId);
+        return crudServiceTemplate.toFuture(migrationExecutor.isMigrationAppliedAsync(version, projectId));
     }
-    
+
     /**
      * Converts API migration definitions to internal Migration objects.
      */
@@ -96,14 +97,14 @@ public class DefaultMigrationService implements MigrationService {
             .map(this::convertToInternalMigration)
             .toList();
     }
-    
+
     /**
      * Converts a single API migration definition to an internal Migration object.
      */
     private Migration convertToInternalMigration(MigrationDefinition definition) {
         return new ProjectMigration(definition, migrationParser);
     }
-    
+
     /**
      * Internal Migration implementation that wraps API migration definitions for project migrations.
      */
@@ -111,22 +112,22 @@ public class DefaultMigrationService implements MigrationService {
         private final MigrationDefinition definition;
         private final MigrationParser parser;
         private MigrationContent cachedContent;
-        
+
         public ProjectMigration(MigrationDefinition definition, MigrationParser parser) {
             this.definition = definition;
             this.parser = parser;
         }
-        
+
         @Override
         public Integer getVersion() {
             return definition.version();
         }
-        
+
         @Override
         public String getName() {
             return definition.name();
         }
-        
+
         @Override
         public MigrationContent getContent() {
             if (cachedContent == null) {

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultNamedQueriesDefinitionService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultNamedQueriesDefinitionService.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services;
 
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.domain.internal.api.services.AbstractProjectScopedService;
@@ -9,8 +10,6 @@ import org.kinotic.persistence.internal.api.repositories.NamedQueriesDefinitionR
 import org.kinotic.persistence.internal.cache.events.CacheEvictionEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/23/24.
@@ -32,7 +31,7 @@ public class DefaultNamedQueriesDefinitionService extends AbstractProjectScopedS
 
 
     @Override
-    public CompletableFuture<NamedQueriesDefinition> findByApplicationAndEntityDefinition(String applicationId, String entityDefinitionName) {
+    public Future<NamedQueriesDefinition> findByApplicationAndEntityDefinition(String applicationId, String entityDefinitionName) {
         return namedQueriesRepository.findByApplicationAndEntityDefinition(applicationId, entityDefinitionName, requireOrganizationId());
     }
 
@@ -42,25 +41,25 @@ public class DefaultNamedQueriesDefinitionService extends AbstractProjectScopedS
     // the index refresh re-caches the old row with no eviction left to clear it.
 
     @Override
-    public CompletableFuture<NamedQueriesDefinition> save(NamedQueriesDefinition definition) {
+    public Future<NamedQueriesDefinition> save(NamedQueriesDefinition definition) {
         // TODO: preprocess queries to correct index name and add Metadata about query type to be used by other parts of the system
         //       The Query type information will speed up other areas the need this as well
         return saveSync(definition);
     }
 
     @Override
-    public CompletableFuture<NamedQueriesDefinition> saveSync(NamedQueriesDefinition definition) {
-        return super.saveSync(definition).thenApply(this::publishModifiedEvent);
+    public Future<NamedQueriesDefinition> saveSync(NamedQueriesDefinition definition) {
+        return super.saveSync(definition).map(this::publishModifiedEvent);
     }
 
     @Override
-    public CompletableFuture<NamedQueriesDefinition> create(NamedQueriesDefinition definition) {
+    public Future<NamedQueriesDefinition> create(NamedQueriesDefinition definition) {
         return createSync(definition);
     }
 
     @Override
-    public CompletableFuture<NamedQueriesDefinition> createSync(NamedQueriesDefinition definition) {
-        return super.createSync(definition).thenApply(this::publishModifiedEvent);
+    public Future<NamedQueriesDefinition> createSync(NamedQueriesDefinition definition) {
+        return super.createSync(definition).map(this::publishModifiedEvent);
     }
 
     /** Evicts cached queries after a successful write; shared by every save/create path. */
@@ -73,31 +72,31 @@ public class DefaultNamedQueriesDefinitionService extends AbstractProjectScopedS
     }
 
     @Override
-    public CompletableFuture<Void> deleteById(String id) {
+    public Future<Void> deleteById(String id) {
         return deleteAndEvict(id);
     }
 
     @Override
-    public CompletableFuture<Void> deleteByIdSync(String id) {
+    public Future<Void> deleteByIdSync(String id) {
         return deleteAndEvict(id);
     }
 
-    private CompletableFuture<Void> deleteAndEvict(String id) {
+    private Future<Void> deleteAndEvict(String id) {
         return findById(id)
-                .thenCompose(namedQuery -> {
+                .compose(namedQuery -> {
                     if (namedQuery == null) {
-                        return CompletableFuture.failedFuture(
+                        return Future.failedFuture(
                                 new IllegalArgumentException("NamedQuery cannot be found for id: " + id));
                     }
                     return super.deleteByIdSync(id)
-                            .thenApply(v -> {
+                            .compose(v -> {
                                 this.eventPublisher.publishEvent(
                                         CacheEvictionEvent.localDeletedNamedQuery(
                                                 namedQuery.getOrganizationId(),
                                                 namedQuery.getApplicationId(),
                                                 namedQuery.getEntityDefinitionName(),
                                                 namedQuery.getId()));
-                                return null;
+                                return Future.succeededFuture();
                             });
                 });
     }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultNamedQueriesService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultNamedQueriesService.java
@@ -1,14 +1,12 @@
 package org.kinotic.persistence.internal.api.services;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import io.vertx.core.Future;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
+import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.kinotic.persistence.api.model.EntityContext;
 import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.persistence.api.model.ParameterHolder;
@@ -23,9 +21,10 @@ import org.kinotic.persistence.internal.cache.events.EvictionSourceType;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
-
-import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/23/24.
@@ -36,11 +35,14 @@ public class DefaultNamedQueriesService implements NamedQueriesService {
 
     private final AsyncLoadingCache<CacheKey, QueryExecutor> cache;
     private final ConcurrentHashMap<String, List<CacheKey>> cacheKeyTracker = new ConcurrentHashMap<>();
+    private final CrudServiceTemplate crudServiceTemplate;
 
     public DefaultNamedQueriesService(DefaultCaffeineCacheFactory cacheFactory,
+                                      CrudServiceTemplate crudServiceTemplate,
                                       NamedQueriesDefinitionRepository namedQueriesRepository,
                                       QueryExecutorFactory queryExecutorFactory) {
 
+        this.crudServiceTemplate = crudServiceTemplate;
         cache = cacheFactory.<CacheKey, QueryExecutor>newBuilder()
                             .name("namedQueriesCache")
                             .expireAfterAccess(Duration.ofHours(20))
@@ -49,6 +51,8 @@ public class DefaultNamedQueriesService implements NamedQueriesService {
                                     .findByApplicationAndEntityDefinition(key.entityDefinition().getApplicationId(),
                                                                           key.entityDefinition().getName(),
                                                                           key.entityDefinition().getOrganizationId())
+                                    .toCompletionStage()
+                                    .toCompletableFuture()
                                     .thenApplyAsync(namedQueriesDefinition -> {
 
                                         Validate.notNull(namedQueriesDefinition, "No Named Query found for EntityDefinition: "
@@ -102,26 +106,26 @@ public class DefaultNamedQueriesService implements NamedQueriesService {
     }
 
     @Override
-    public <T> CompletableFuture<List<T>> executeNamedQuery(EntityDefinition entityDefinition,
-                                                            String queryName,
-                                                            ParameterHolder parameterHolder,
-                                                            Class<T> type,
-                                                            EntityContext context) {
+    public <T> Future<List<T>> executeNamedQuery(EntityDefinition entityDefinition,
+                                                 String queryName,
+                                                 ParameterHolder parameterHolder,
+                                                 Class<T> type,
+                                                 EntityContext context) {
         // Authorization happens in the QueryExecutor so we don't need an additional cache to hold the NamedQueryAuthorizationService
-        return cache.get(new CacheKey(queryName, entityDefinition))
-                    .thenCompose(queryExecutor -> queryExecutor.execute(new QueryContext(context, parameterHolder), type));
+        return crudServiceTemplate.toFuture(cache.get(new CacheKey(queryName, entityDefinition)))
+                                  .compose(queryExecutor -> queryExecutor.execute(new QueryContext(context, parameterHolder), type));
     }
 
     @Override
-    public <T> CompletableFuture<Page<T>> executeNamedQueryPage(EntityDefinition entityDefinition,
-                                                                String queryName,
-                                                                ParameterHolder parameterHolder,
-                                                                Pageable pageable,
-                                                                Class<T> type,
-                                                                EntityContext context) {
+    public <T> Future<Page<T>> executeNamedQueryPage(EntityDefinition entityDefinition,
+                                                     String queryName,
+                                                     ParameterHolder parameterHolder,
+                                                     Pageable pageable,
+                                                     Class<T> type,
+                                                     EntityContext context) {
         // Authorization happens in the QueryExecutor so we don't need an additional cache to hold the NamedQueryAuthorizationService
-        return cache.get(new CacheKey(queryName, entityDefinition))
-                    .thenCompose(queryExecutor -> queryExecutor.executePage(new QueryContext(context, parameterHolder), pageable, type));
+        return crudServiceTemplate.toFuture(cache.get(new CacheKey(queryName, entityDefinition)))
+                                  .compose(queryExecutor -> queryExecutor.executePage(new QueryContext(context, parameterHolder), pageable, type));
     }
 
     private record CacheKey(String queryName, EntityDefinition entityDefinition) {}

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/EntitiesService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/EntitiesService.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.idl.api.schema.FunctionDefinition;
@@ -9,7 +10,6 @@ import org.kinotic.persistence.api.model.TenantSpecificId;
 import org.kinotic.persistence.api.model.ParameterHolder;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provides access to entities for a given {@link EntityDefinition}.
@@ -22,35 +22,35 @@ public interface EntitiesService {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to save the entities for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param entities    all the entities to save
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} that will complete when all entities have been saved
+     * @return {@link Future} that will complete when all entities have been saved
      */
-    <T> CompletableFuture<Void> bulkSave(String entityDefinitionId, T entities, EntityContext context);
+    <T> Future<Void> bulkSave(String entityDefinitionId, T entities, EntityContext context);
 
     /**
      * Updates all given entities.
      * @param entityDefinitionId the id of the {@link EntityDefinition} to update the entities for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param entities    all the entities to save
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} that will complete when all entities have been saved
+     * @return {@link Future} that will complete when all entities have been saved
      */
-    <T> CompletableFuture<Void> bulkUpdate(String entityDefinitionId, T entities, EntityContext context);
+    <T> Future<Void> bulkUpdate(String entityDefinitionId, T entities, EntityContext context);
 
     /**
      * Returns the number of entities available.
      * @param entityDefinitionId the id of the {@link EntityDefinition} to count. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting the number of entities.
+     * @return {@link Future} emitting the number of entities.
      */
-    CompletableFuture<Long> count(String entityDefinitionId, EntityContext context);
+    Future<Long> count(String entityDefinitionId, EntityContext context);
 
     /**
      * Returns the number of entities available for the given query.
      * @param entityDefinitionId the id of the {@link EntityDefinition} to count. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param query       the query used to limit result
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting the number of entities.
+     * @return {@link Future} emitting the number of entities.
      */
-    CompletableFuture<Long> countByQuery(String entityDefinitionId, String query, EntityContext context);
+    Future<Long> countByQuery(String entityDefinitionId, String query, EntityContext context);
 
     /**
      * Deletes the entity with the given id.
@@ -58,9 +58,9 @@ public interface EntitiesService {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to delete the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param id          must not be {@literal null}
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteById(String entityDefinitionId, String id, EntityContext context);
+    Future<Void> deleteById(String entityDefinitionId, String id, EntityContext context);
 
     /**
      * Deletes the entity with the given id.
@@ -69,9 +69,9 @@ public interface EntitiesService {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to delete the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param id          must not be {@literal null}
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteById(String entityDefinitionId, TenantSpecificId id, EntityContext context);
+    Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, EntityContext context);
 
     /**
      * Deletes any entities that match the given query.
@@ -79,9 +79,9 @@ public interface EntitiesService {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to delete the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param query       the query used to filter records to delete, must not be {@literal null}
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteByQuery(String entityDefinitionId, String query, EntityContext context);
+    Future<Void> deleteByQuery(String entityDefinitionId, String query, EntityContext context);
 
     /**
      * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
@@ -92,7 +92,7 @@ public interface EntitiesService {
      * @param context     the context for this operation
      * @return a page of entities
      */
-    <T> CompletableFuture<Page<T>> findAll(String entityDefinitionId, Pageable pageable, Class<T> type, EntityContext context);
+    <T> Future<Page<T>> findAll(String entityDefinitionId, Pageable pageable, Class<T> type, EntityContext context);
 
     /**
      * Retrieves an entity by its id.
@@ -101,9 +101,9 @@ public interface EntitiesService {
      * @param id          must not be {@literal null}
      * @param type        the type of the entity
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} with the entity with the given id or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} with the entity with the given id or {@link Future} emitting null if none found
      */
-    <T> CompletableFuture<T> findById(String entityDefinitionId, String id, Class<T> type, EntityContext context);
+    <T> Future<T> findById(String entityDefinitionId, String id, Class<T> type, EntityContext context);
 
     /**
      * Retrieves an entity by its id.
@@ -113,9 +113,9 @@ public interface EntitiesService {
      * @param id          must not be {@literal null}
      * @param type        the type of the entity
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} with the entity with the given id or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} with the entity with the given id or {@link Future} emitting null if none found
      */
-    <T> CompletableFuture<T> findById(String entityDefinitionId, TenantSpecificId id, Class<T> type, EntityContext context);
+    <T> Future<T> findById(String entityDefinitionId, TenantSpecificId id, Class<T> type, EntityContext context);
 
     /**
      * Retrieves a list of entities by their id.
@@ -124,9 +124,9 @@ public interface EntitiesService {
      * @param ids         must not be {@literal null}
      * @param type        the type of the entity
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} with the list of matched entities with the given ids or {@link CompletableFuture} emitting an empty list if none found
+     * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting an empty list if none found
      */
-    <T> CompletableFuture<List<T>> findByIds(String entityDefinitionId, List<String> ids, Class<T> type, EntityContext context);
+    <T> Future<List<T>> findByIds(String entityDefinitionId, List<String> ids, Class<T> type, EntityContext context);
 
     /**
      * Retrieves a list of entities by their id.
@@ -136,9 +136,9 @@ public interface EntitiesService {
      * @param ids         must not be {@literal null}
      * @param type        the type of the entity
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} with the list of matched entities with the given ids or {@link CompletableFuture} emitting an empty list if none found
+     * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting an empty list if none found
      */
-    <T> CompletableFuture<List<T>> findByIdsWithTenant(String entityDefinitionId, List<TenantSpecificId> ids, Class<T> type, EntityContext context);
+    <T> Future<List<T>> findByIdsWithTenant(String entityDefinitionId, List<TenantSpecificId> ids, Class<T> type, EntityContext context);
 
     /**
      * Executes a named query.
@@ -148,13 +148,13 @@ public interface EntitiesService {
      * @param parameterHolder the parameters to pass to the query
      * @param type            the type of the entity
      * @param context         the context for this operation
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    <T> CompletableFuture<List<T>> namedQuery(String entityDefinitionId,
-                                              String queryName,
-                                              ParameterHolder parameterHolder,
-                                              Class<T> type,
-                                              EntityContext context);
+    <T> Future<List<T>> namedQuery(String entityDefinitionId,
+                                   String queryName,
+                                   ParameterHolder parameterHolder,
+                                   Class<T> type,
+                                   EntityContext context);
 
     /**
      * Executes a named query and returns a {@link Page} of results.
@@ -165,22 +165,22 @@ public interface EntitiesService {
      * @param pageable        the page settings to be used
      * @param type            the type of the entity
      * @param context         the context for this operation
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    <T> CompletableFuture<Page<T>> namedQueryPage(String entityDefinitionId,
-                                                  String queryName,
-                                                  ParameterHolder parameterHolder,
-                                                  Pageable pageable,
-                                                  Class<T> type,
-                                                  EntityContext context);
+    <T> Future<Page<T>> namedQueryPage(String entityDefinitionId,
+                                       String queryName,
+                                       ParameterHolder parameterHolder,
+                                       Pageable pageable,
+                                       Class<T> type,
+                                       EntityContext context);
 
     /**
      * This operation makes all the recent writes immediately available for search.
      * @param entityDefinitionId the id of the {@link EntityDefinition} to sync the index for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param context     the context for this operation
-     * @return a {@link CompletableFuture} that will complete when the operation is complete
+     * @return a {@link Future} that will complete when the operation is complete
      */
-    CompletableFuture<Void> syncIndex(String entityDefinitionId, EntityContext context);
+    Future<Void> syncIndex(String entityDefinitionId, EntityContext context);
 
     /**
      * Saves a given entity. This will override all data if there is an existing entity with the same id.
@@ -189,9 +189,9 @@ public interface EntitiesService {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to save the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param entity      must not be {@literal null}
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting the saved entity
+     * @return {@link Future} emitting the saved entity
      */
-    <T> CompletableFuture<T> save(String entityDefinitionId, T entity, EntityContext context);
+    <T> Future<T> save(String entityDefinitionId, T entity, EntityContext context);
 
     /**
      * Returns a {@link Page} of entities matching the search text and paging restriction provided in the {@code Pageable} object.
@@ -203,9 +203,9 @@ public interface EntitiesService {
      * @param pageable    the page settings to be used
      * @param type        the type of the entity
      * @param context     the context for this operation
-     * @return a {@link CompletableFuture} of a page of entities
+     * @return a {@link Future} of a page of entities
      */
-    <T> CompletableFuture<Page<T>> search(String entityDefinitionId, String searchText, Pageable pageable, Class<T> type, EntityContext context);
+    <T> Future<Page<T>> search(String entityDefinitionId, String searchText, Pageable pageable, Class<T> type, EntityContext context);
 
     /**
      * Updates a given entity. This will only override the fields that are present in the given entity.
@@ -215,8 +215,8 @@ public interface EntitiesService {
      * @param entityDefinitionId the id of the {@link EntityDefinition} to update the entity for. (this is the {@link EntityDefinition#getApplicationId()} + "." + {@link EntityDefinition#getName()})
      * @param entity      must not be {@literal null}
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting the saved entity
+     * @return {@link Future} emitting the saved entity
      */
-    <T> CompletableFuture<T> update(String entityDefinitionId, T entity, EntityContext context);
+    <T> Future<T> update(String entityDefinitionId, T entity, EntityContext context);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/EntityService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/EntityService.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.idl.api.schema.FunctionDefinition;
@@ -10,7 +11,6 @@ import org.kinotic.persistence.api.model.TenantSpecificId;
 import org.kinotic.persistence.api.model.ParameterHolder;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provides functionality to query data for a single "Entity" for a given {@link EntityDefinition}.
@@ -22,44 +22,44 @@ public interface EntityService {
      * Saves all given entities.
      * @param entities all the entities to save
      * @param context the context for this operation
-     * @return {@link CompletableFuture} that will complete when all entities have been saved
+     * @return {@link Future} that will complete when all entities have been saved
      * @param <T> the type of the entities, this can be a {@link List} or {@link RawJson}
      */
-    <T> CompletableFuture<Void> bulkSave(T entities, EntityContext context);
+    <T> Future<Void> bulkSave(T entities, EntityContext context);
 
     /**
      * Updates all given entities.
      * @param entities all the entities to save
      * @param context the context for this operation
-     * @return {@link CompletableFuture} that will complete when all entities have been saved
+     * @return {@link Future} that will complete when all entities have been saved
      * @param <T> the type of the entities, this can be a {@link List} or {@link RawJson}
      */
-    <T> CompletableFuture<Void> bulkUpdate(T entities, EntityContext context);
+    <T> Future<Void> bulkUpdate(T entities, EntityContext context);
 
     /**
      * Returns the number of entities available.
      *
      * @param context the context for this operation
-     * @return {@link CompletableFuture} emitting the number of entities
+     * @return {@link Future} emitting the number of entities
      */
-    CompletableFuture<Long> count(EntityContext context);
+    Future<Long> count(EntityContext context);
 
     /**
      * Returns the number of entities available for the given query.
      * @param query       the query used to limit result
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting the number of entities.
+     * @return {@link Future} emitting the number of entities.
      */
-    CompletableFuture<Long> countByQuery(String query, EntityContext context);
+    Future<Long> countByQuery(String query, EntityContext context);
 
     /**
      * Deletes the entity with the given id.
      *
      * @param id      must not be {@literal null}
      * @param context the context for this operation
-     * @return {@link CompletableFuture} signaling when operation has completed
+     * @return {@link Future} signaling when operation has completed
      */
-    CompletableFuture<Void> deleteById(String id, EntityContext context);
+    Future<Void> deleteById(String id, EntityContext context);
 
     /**
      * Deletes the entity with the given id.
@@ -67,18 +67,18 @@ public interface EntityService {
      *
      * @param id      must not be {@literal null}
      * @param context the context for this operation
-     * @return {@link CompletableFuture} signaling when operation has completed
+     * @return {@link Future} signaling when operation has completed
      */
-    CompletableFuture<Void> deleteById(TenantSpecificId id, EntityContext context);
+    Future<Void> deleteById(TenantSpecificId id, EntityContext context);
 
     /**
      * Deletes any entities that match the given query.
      *
      * @param query       the query used to filter records to delete, must not be {@literal null}
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting when delete is complete
+     * @return {@link Future} emitting when delete is complete
      */
-    CompletableFuture<Void> deleteByQuery(String query, EntityContext context);
+    Future<Void> deleteByQuery(String query, EntityContext context);
 
     /**
      * Returns a {@link Page} of entities meeting the paging restriction provided in the {@link Pageable} object.
@@ -88,7 +88,7 @@ public interface EntityService {
      * @param context  the context for this operation
      * @return a page of entities
      */
-    <T> CompletableFuture<Page<T>> findAll(Pageable pageable, Class<T> type, EntityContext context);
+    <T> Future<Page<T>> findAll(Pageable pageable, Class<T> type, EntityContext context);
 
     /**
      * Retrieves an entity by its id.
@@ -96,9 +96,9 @@ public interface EntityService {
      * @param id      must not be {@literal null}
      * @param type    the type of the entity
      * @param context the context for this operation
-     * @return {@link CompletableFuture} emitting the entity with the given id or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} emitting the entity with the given id or {@link Future} emitting null if none found
      */
-    <T> CompletableFuture<T> findById(String id, Class<T> type, EntityContext context);
+    <T> Future<T> findById(String id, Class<T> type, EntityContext context);
 
     /**
      * Retrieves an entity by its id.
@@ -107,9 +107,9 @@ public interface EntityService {
      * @param id      must not be {@literal null}
      * @param type    the type of the entity
      * @param context the context for this operation
-     * @return {@link CompletableFuture} emitting the entity with the given id or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} emitting the entity with the given id or {@link Future} emitting null if none found
      */
-    <T> CompletableFuture<T> findById(TenantSpecificId id, Class<T> type, EntityContext context);
+    <T> Future<T> findById(TenantSpecificId id, Class<T> type, EntityContext context);
 
     /**
      * Retrieves a list of entities by their id.
@@ -117,9 +117,9 @@ public interface EntityService {
      * @param ids         must not be {@literal null}
      * @param type        the type of the entity
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} with the list of matched entities with the given ids or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting null if none found
      */
-    <T> CompletableFuture<List<T>> findByIds(List<String> ids, Class<T> type, EntityContext context);
+    <T> Future<List<T>> findByIds(List<String> ids, Class<T> type, EntityContext context);
 
     /**
      * Retrieves a list of entities by their id.
@@ -128,9 +128,9 @@ public interface EntityService {
      * @param ids         must not be {@literal null}
      * @param type        the type of the entity
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} with the list of matched entities with the given ids or {@link CompletableFuture} emitting null if none found
+     * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting null if none found
      */
-    <T> CompletableFuture<List<T>> findByIdsWithTenant(List<TenantSpecificId> ids, Class<T> type, EntityContext context);
+    <T> Future<List<T>> findByIdsWithTenant(List<TenantSpecificId> ids, Class<T> type, EntityContext context);
 
     /**
      * Executes a named query.
@@ -139,12 +139,12 @@ public interface EntityService {
      * @param parameterHolder the parameters to pass to the query
      * @param type            the type of the entity
      * @param context         the context for this operation
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    <T> CompletableFuture<List<T>> namedQuery(String queryName,
-                                              ParameterHolder parameterHolder,
-                                              Class<T> type,
-                                              EntityContext context);
+    <T> Future<List<T>> namedQuery(String queryName,
+                                   ParameterHolder parameterHolder,
+                                   Class<T> type,
+                                   EntityContext context);
 
     /**
      * Executes a named query and returns a {@link Page} of results.
@@ -154,13 +154,13 @@ public interface EntityService {
      * @param pageable        the page settings to be used
      * @param type            the type of the entity
      * @param context         the context for this operation
-     * @return {@link CompletableFuture} with the result of the query
+     * @return {@link Future} with the result of the query
      */
-    <T> CompletableFuture<Page<T>> namedQueryPage(String queryName,
-                                                  ParameterHolder parameterHolder,
-                                                  Pageable pageable,
-                                                  Class<T> type,
-                                                  EntityContext context);
+    <T> Future<Page<T>> namedQueryPage(String queryName,
+                                       ParameterHolder parameterHolder,
+                                       Pageable pageable,
+                                       Class<T> type,
+                                       EntityContext context);
 
     /**
      * Saves a given entity. This will override all data if there is an existing entity with the same id.
@@ -168,9 +168,9 @@ public interface EntityService {
      *
      * @param entity  must not be {@literal null}
      * @param context the context for this operation
-     * @return {@link CompletableFuture} emitting the saved entity
+     * @return {@link Future} emitting the saved entity
      */
-    <T> CompletableFuture<T> save(T entity, EntityContext context);
+    <T> Future<T> save(T entity, EntityContext context);
 
     /**
      * Returns a {@link Page} of entities matching the search text and paging restriction provided in the {@link Pageable} object.
@@ -181,14 +181,14 @@ public interface EntityService {
      * @param context    the context for this operation
      * @return a page of entities
      */
-    <T> CompletableFuture<Page<T>> search(String searchText, Pageable pageable, Class<T> type, EntityContext context);
+    <T> Future<Page<T>> search(String searchText, Pageable pageable, Class<T> type, EntityContext context);
 
     /**
      * This operation makes all the recent writes immediately available for search.
      * @param context the context for this operation
-     * @return a {@link CompletableFuture} that will complete when the operation is complete
+     * @return a {@link Future} that will complete when the operation is complete
      */
-    CompletableFuture<Void> syncIndex(EntityContext context);
+    Future<Void> syncIndex(EntityContext context);
 
     /**
      * Updates a given entity. This will only override the fields that are present in the given entity.
@@ -198,8 +198,8 @@ public interface EntityService {
      *
      * @param entity      must not be {@literal null}
      * @param context     the context for this operation
-     * @return {@link CompletableFuture} emitting the saved entity
+     * @return {@link Future} emitting the saved entity
      */
-    <T> CompletableFuture<T> update(T entity, EntityContext context);
+    <T> Future<T> update(T entity, EntityContext context);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/EntityServiceCache.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/EntityServiceCache.java
@@ -2,6 +2,7 @@ package org.kinotic.persistence.internal.api.services;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.kinotic.idl.api.schema.decorators.C3Decorator;
@@ -80,8 +81,8 @@ public class EntityServiceCache {
      * Returns the {@link EntityService} for {@code entityDefinitionId} within {@code organizationId},
      * building and caching it on a miss.
      */
-    public CompletableFuture<EntityService> get(String organizationId, String entityDefinitionId) {
-        return cache.get(new CacheKey(organizationId, entityDefinitionId));
+    public Future<EntityService> get(String organizationId, String entityDefinitionId) {
+        return crudServiceTemplate.toFuture(cache.get(new CacheKey(organizationId, entityDefinitionId)));
     }
 
     /**
@@ -91,22 +92,25 @@ public class EntityServiceCache {
         cache.asMap().remove(new CacheKey(organizationId, entityDefinitionId));
     }
 
+    // Caffeine's AsyncCacheLoader contract requires the (key, executor) signature and a CompletableFuture result
     private CompletableFuture<EntityService> load(CacheKey key, Executor executor) {
         return entityDefinitionRepository.findById(key.entityDefinitionId(), key.organizationId())
-                .thenApply(entityDefinition -> {
+                .map(entityDefinition -> {
                     Validate.notNull(entityDefinition, "No EntityDefinition found for %s", key);
                     return entityDefinition;
                 })
-                .thenComposeAsync(this::createEntityService, executor);
+                .compose(this::createEntityService)
+                .toCompletionStage()
+                .toCompletableFuture();
     }
 
     @SuppressWarnings("unchecked")
-    public CompletableFuture<EntityService> createEntityService(EntityDefinition entityDefinition) {
+    public Future<EntityService> createEntityService(EntityDefinition entityDefinition) {
 
         if(entityDefinition == null){
-            return CompletableFuture.failedFuture(new IllegalArgumentException("EntityDefinition must not be null"));
+            return Future.failedFuture(new IllegalArgumentException("EntityDefinition must not be null"));
         } else if (!entityDefinition.isPublished()) {
-            return CompletableFuture.failedFuture(new IllegalArgumentException("EntityDefinition must be published"));
+            return Future.failedFuture(new IllegalArgumentException("EntityDefinition must be published"));
         }
 
         // Map of jsonPath to DecoratorLogic
@@ -125,7 +129,7 @@ public class EntityServiceCache {
         }
 
         return authServiceFactory.createEntityDefinitionAuthorizationService(entityDefinition)
-                                 .thenApply(authService -> new DefaultEntityService(
+                                 .map(authService -> new DefaultEntityService(
                                          authService,
                                          crudServiceTemplate,
                                          new DelegatingUpsertPreProcessor(persistenceProperties,

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/DataAnalysisTools.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/DataAnalysisTools.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services.insights;
 
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.domain.api.model.security.ApplicationParticipant;
 import org.kinotic.core.api.crud.Page;
@@ -12,7 +13,6 @@ import reactor.core.publisher.FluxSink;
 
 import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -61,8 +61,8 @@ public class DataAnalysisTools {
             EntityContext context = createEntityContext();
             
             Pageable pageable = Pageable.ofSize(limitedSampleSize);
-            CompletableFuture<Page<Map>> future = entitiesService.findAll(entityDefinitionId, pageable, Map.class, context);
-            Page<Map> dataPage = future.join(); // Blocking wait - not ideal but needed for tool interface
+            Future<Page<Map>> future = entitiesService.findAll(entityDefinitionId, pageable, Map.class, context);
+            Page<Map> dataPage = future.toCompletionStage().toCompletableFuture().join(); // Blocking wait - not ideal but needed for tool interface
             
             if (dataPage.getContent().isEmpty()) {
                 return String.format("No data found in EntityDefinition: %s", entityDefinitionId);
@@ -111,8 +111,8 @@ public class DataAnalysisTools {
             EntityContext context = createEntityContext();
             
             // Get total count
-            CompletableFuture<Long> countFuture = entitiesService.count(entityDefinitionId, context);
-            long totalCount = countFuture.join();
+            Future<Long> countFuture = entitiesService.count(entityDefinitionId, context);
+            long totalCount = countFuture.toCompletionStage().toCompletableFuture().join();
             
             if (totalCount == 0) {
                 return String.format("EntityDefinition '%s' contains no data.", entityDefinitionId);
@@ -120,8 +120,8 @@ public class DataAnalysisTools {
             
             // Get sample for field analysis
             Pageable pageable = Pageable.ofSize(Math.min(100, (int) totalCount));
-            CompletableFuture<Page<Map>> dataFuture = entitiesService.findAll(entityDefinitionId, pageable, Map.class, context);
-            Page<Map> sampleData = dataFuture.join();
+            Future<Page<Map>> dataFuture = entitiesService.findAll(entityDefinitionId, pageable, Map.class, context);
+            Page<Map> sampleData = dataFuture.toCompletionStage().toCompletableFuture().join();
             
             StringBuilder result = new StringBuilder();
             result.append(String.format("Data Statistics for EntityDefinition '%s':\n\n", entityDefinitionId));
@@ -159,8 +159,8 @@ public class DataAnalysisTools {
             EntityContext context = createEntityContext();
             Pageable pageable = Pageable.ofSize(limitedSize);
             
-            CompletableFuture<Page<Map>> searchFuture = entitiesService.search(entityDefinitionId, searchQuery, pageable, Map.class, context);
-            Page<Map> searchResults = searchFuture.join();
+            Future<Page<Map>> searchFuture = entitiesService.search(entityDefinitionId, searchQuery, pageable, Map.class, context);
+            Page<Map> searchResults = searchFuture.toCompletionStage().toCompletableFuture().join();
             
             StringBuilder result = new StringBuilder();
             result.append(String.format("Search Results for '%s' in EntityDefinition '%s':\n\n", searchQuery, entityDefinitionId));
@@ -205,8 +205,8 @@ public class DataAnalysisTools {
             // Get sample data to analyze the field
             EntityContext context = createEntityContext();
             Pageable pageable = Pageable.ofSize(100);
-            CompletableFuture<Page<Map>> dataFuture = entitiesService.findAll(entityDefinitionId, pageable, Map.class, context);
-            Page<Map> sampleData = dataFuture.join();
+            Future<Page<Map>> dataFuture = entitiesService.findAll(entityDefinitionId, pageable, Map.class, context);
+            Page<Map> sampleData = dataFuture.toCompletionStage().toCompletableFuture().join();
             
             if (sampleData.getContent().isEmpty()) {
                 return String.format("No data available to analyze field '%s' in EntityDefinition '%s'", fieldName, entityDefinitionId);

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/EntityDefinitionDiscoveryTools.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/EntityDefinitionDiscoveryTools.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services.insights;
 
+import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -14,7 +15,6 @@ import reactor.core.publisher.FluxSink;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Spring AI Tools for discovering and analyzing EntityDefinition schemas.
@@ -55,8 +55,8 @@ public class EntityDefinitionDiscoveryTools {
         try {
             // Get all published EntityDefinitions for the application
             Pageable pageable = Pageable.ofSize(100); // Get up to 100 EntityDefinitions
-            CompletableFuture<Page<EntityDefinition>> entityDefinitionFuture = entityDefinitionService.findAllPublishedForApplication(applicationId, pageable);
-            Page<EntityDefinition> entityDefinitionPage = entityDefinitionFuture.join();
+            Future<Page<EntityDefinition>> entityDefinitionFuture = entityDefinitionService.findAllPublishedForApplication(applicationId, pageable);
+            Page<EntityDefinition> entityDefinitionPage = entityDefinitionFuture.toCompletionStage().toCompletableFuture().join();
             
             if (entityDefinitionPage.getContent().isEmpty()) {
                 return String.format("No published EntityDefinitions found for application: %s", applicationId);
@@ -106,8 +106,8 @@ public class EntityDefinitionDiscoveryTools {
         }
         
         try {
-            CompletableFuture<EntityDefinition> future = entityDefinitionService.findById(entityDefinitionId);
-            EntityDefinition entityDefinition = future.join();
+            Future<EntityDefinition> future = entityDefinitionService.findById(entityDefinitionId);
+            EntityDefinition entityDefinition = future.toCompletionStage().toCompletableFuture().join();
             if (entityDefinition == null) {
                 return String.format("EntityDefinition not found: %s", entityDefinitionId);
             }
@@ -154,8 +154,8 @@ public class EntityDefinitionDiscoveryTools {
         try {
             // Get all published EntityDefinitions and filter by name/description
             Pageable pageable = Pageable.ofSize(100);
-            CompletableFuture<Page<EntityDefinition>> future = entityDefinitionService.findAllPublishedForApplication(applicationId, pageable);
-            Page<EntityDefinition> entityDefinitionPage = future.join();
+            Future<Page<EntityDefinition>> future = entityDefinitionService.findAllPublishedForApplication(applicationId, pageable);
+            Page<EntityDefinition> entityDefinitionPage = future.toCompletionStage().toCompletableFuture().join();
             
             List<EntityDefinition> matchingEntityDefinitions = entityDefinitionPage.getContent().stream()
                                                                             .filter(entityDefinition ->

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/NoopAuthorizationService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/NoopAuthorizationService.java
@@ -1,14 +1,13 @@
 package org.kinotic.persistence.internal.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.model.EntityContext;
 import org.kinotic.persistence.api.services.security.AuthorizationService;
-
-import java.util.concurrent.CompletableFuture;
 
 public class NoopAuthorizationService<T> implements AuthorizationService<T> {
 
     @Override
-    public CompletableFuture<Void> authorize(T operationIdentifier, EntityContext entityContext) {
-        return CompletableFuture.completedFuture(null);
+    public Future<Void> authorize(T operationIdentifier, EntityContext entityContext) {
+        return Future.succeededFuture();
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/NoopAuthorizationServiceFactory.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/NoopAuthorizationServiceFactory.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services.security;
 
+import io.vertx.core.Future;
 import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.persistence.api.model.EntityOperation;
@@ -7,17 +8,15 @@ import org.kinotic.persistence.api.model.NamedQueryOperation;
 import org.kinotic.persistence.api.services.security.AuthorizationService;
 import org.kinotic.persistence.api.services.security.AuthorizationServiceFactory;
 
-import java.util.concurrent.CompletableFuture;
-
 public class NoopAuthorizationServiceFactory implements AuthorizationServiceFactory {
 
     @Override
-    public CompletableFuture<AuthorizationService<EntityOperation>> createEntityDefinitionAuthorizationService(EntityDefinition entityDefinition) {
-        return CompletableFuture.completedFuture(new NoopAuthorizationService<>());
+    public Future<AuthorizationService<EntityOperation>> createEntityDefinitionAuthorizationService(EntityDefinition entityDefinition) {
+        return Future.succeededFuture(new NoopAuthorizationService<>());
     }
 
     @Override
-    public CompletableFuture<AuthorizationService<NamedQueryOperation>> createNamedQueryAuthorizationService(FunctionDefinition namedQuery) {
-        return CompletableFuture.completedFuture(new NoopAuthorizationService<>());
+    public Future<AuthorizationService<NamedQueryOperation>> createNamedQueryAuthorizationService(FunctionDefinition namedQuery) {
+        return Future.succeededFuture(new NoopAuthorizationService<>());
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/graphos/AbstractPolicyEvaluator.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/graphos/AbstractPolicyEvaluator.java
@@ -1,12 +1,12 @@
 package org.kinotic.persistence.internal.api.services.security.graphos;
 
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.model.EntityContext;
 import org.kinotic.persistence.api.services.security.graphos.PolicyAuthorizationRequest;
 import org.kinotic.persistence.api.services.security.graphos.PolicyAuthorizer;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public abstract class AbstractPolicyEvaluator implements PolicyEvaluator {
@@ -20,14 +20,15 @@ public abstract class AbstractPolicyEvaluator implements PolicyEvaluator {
 
     @WithSpan
     @Override
-    public CompletableFuture<AuthorizationResult> evaluatePolicies(EntityContext entityContext) {
+    public Future<AuthorizationResult> evaluatePolicies(EntityContext entityContext) {
         Set<String> allPolicies = new HashSet<>(sharedPolicyManager.getSharedPolicies());
         addOperationPolicies(allPolicies);
 
+        Future<AuthorizationResult> ret;
         // no need to call authorizer if there are no policies to evaluate
         if (allPolicies.isEmpty()) {
 
-            return CompletableFuture.completedFuture(new AuthorizationResult(true, true, Collections.emptyMap()));
+            ret = Future.succeededFuture(new AuthorizationResult(true, true, Collections.emptyMap()));
 
         }else {
             Map<String, PolicyAuthorizationRequest> policyRequests = allPolicies.stream()
@@ -35,19 +36,20 @@ public abstract class AbstractPolicyEvaluator implements PolicyEvaluator {
                                                                                                           DefaultPolicyAuthorizationRequest::new));
             List<PolicyAuthorizationRequest> requests = new ArrayList<>(policyRequests.values());
 
-            return authorizer.authorize(requests, entityContext)
-                             .thenApply(ignored -> {
+            ret = authorizer.authorize(requests, entityContext)
+                            .map(ignored -> {
 
-                                 Map<String, Boolean> fieldResults = evaluateFieldPolicies(policyRequests);
+                                Map<String, Boolean> fieldResults = evaluateFieldPolicies(policyRequests);
 
-                                 boolean operationAllowed = isOperationAllowed(policyRequests);
+                                boolean operationAllowed = isOperationAllowed(policyRequests);
 
-                                 boolean entityAllowed = sharedPolicyManager.getEntityExpression() == null
-                                         || sharedPolicyManager.getEntityExpression().evaluate(policyRequests);
+                                boolean entityAllowed = sharedPolicyManager.getEntityExpression() == null
+                                        || sharedPolicyManager.getEntityExpression().evaluate(policyRequests);
 
-                                 return new AuthorizationResult(operationAllowed, entityAllowed, fieldResults);
-                             });
+                                return new AuthorizationResult(operationAllowed, entityAllowed, fieldResults);
+                            });
         }
+        return ret;
     }
 
     private Map<String, Boolean> evaluateFieldPolicies(Map<String, PolicyAuthorizationRequest> policyRequests) {

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/graphos/PolicyEvaluator.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/security/graphos/PolicyEvaluator.java
@@ -1,9 +1,8 @@
 package org.kinotic.persistence.internal.api.services.security.graphos;
 
 
+import io.vertx.core.Future;
 import org.kinotic.persistence.api.model.EntityContext;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Responsible for evaluating GraphOS policies for a given security context
@@ -14,7 +13,7 @@ public interface PolicyEvaluator {
      * Evaluate the policies with the given security context
      *
      * @param entityContext the security context that is active for this current operation
-     * @return a {@link CompletableFuture} that will complete with the {@link AuthorizationResult} of the evaluation
+     * @return a {@link Future} that will complete with the {@link AuthorizationResult} of the evaluation
      */
-    CompletableFuture<AuthorizationResult> evaluatePolicies(EntityContext entityContext);
+    Future<AuthorizationResult> evaluatePolicies(EntityContext entityContext);
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/DefaultQueryExecutorFactory.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/DefaultQueryExecutorFactory.java
@@ -54,7 +54,8 @@ public class DefaultQueryExecutorFactory implements QueryExecutorFactory {
         if(statements.length == 1){
             QueryExecutor queryExecutor = createQueryExecutorForStatement(entityDefinition, statements[0], namedQuery);
             AuthorizationService<NamedQueryOperation> authorizationService =
-                    authorizationServiceFactory.createNamedQueryAuthorizationService(namedQuery).join();
+                    authorizationServiceFactory.createNamedQueryAuthorizationService(namedQuery)
+                                               .toCompletionStage().toCompletableFuture().join();
             return new ParameterProcessorExecutor(entityDefinition,
                                                   namedQuery,
                                                   new PreAuthorizationExecutor(authorizationService, queryExecutor));

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/elasticsearch/DefaultElasticVertxClient.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/elasticsearch/DefaultElasticVertxClient.java
@@ -7,6 +7,7 @@ import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.SimpleJsonpMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.PoolOptions;
@@ -45,7 +46,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Provides access to ElasticSearch via Vertx.
@@ -112,12 +112,12 @@ public class DefaultElasticVertxClient implements ElasticVertxClient {
     @WithSpan
     @Override
     @SuppressWarnings("unchecked")
-    public <T> CompletableFuture<Page<T>> querySql(String statement,
-                                                   List<?> parameters,
-                                                   JsonObject filter,
-                                                   QueryOptions options,
-                                                   Pageable pageable,
-                                                   Class<T> type) {
+    public <T> Future<Page<T>> querySql(String statement,
+                                        List<?> parameters,
+                                        JsonObject filter,
+                                        QueryOptions options,
+                                        Pageable pageable,
+                                        Class<T> type) {
         JsonObject json = new JsonObject();
         boolean foundCursor = false;
         MutableObject<String> cursorProvided = new MutableObject<>(null);
@@ -131,7 +131,7 @@ public class DefaultElasticVertxClient implements ElasticVertxClient {
                     json.put("fetch_size", pageable.getPageSize());
                 }
             }else{
-                return CompletableFuture.failedFuture(new IllegalArgumentException("Only CursorPageable is supported for queries containing Aggregations."));
+                return Future.failedFuture(new IllegalArgumentException("Only CursorPageable is supported for queries containing Aggregations."));
             }
         }
 
@@ -181,14 +181,13 @@ public class DefaultElasticVertxClient implements ElasticVertxClient {
                                   }else{
                                       throw convertErrorResponse(new ByteArrayInputStream(resp.body().getBytes()));
                                   }
-                              }).toCompletionStage()
-                              .toCompletableFuture();
+                              });
     }
 
     @WithSpan
     @Override
-    public CompletableFuture<TranslateResponse> translateSql(String statement,
-                                                             List<?> parameters){
+    public Future<TranslateResponse> translateSql(String statement,
+                                                  List<?> parameters){
         JsonObject json = new JsonObject().put("query", statement);
         if(parameters != null) {
             JsonArray paramsJson = new JsonArray();
@@ -212,8 +211,7 @@ public class DefaultElasticVertxClient implements ElasticVertxClient {
                                       } else {
                                           throw convertErrorResponse(input);
                                       }
-                                  }).toCompletionStage()
-                                  .toCompletableFuture();
+                                  });
     }
 
     private IllegalArgumentException convertErrorResponse(InputStream input) {

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/elasticsearch/ElasticVertxClient.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/elasticsearch/ElasticVertxClient.java
@@ -1,13 +1,13 @@
 package org.kinotic.persistence.internal.api.services.sql.elasticsearch;
 
 import co.elastic.clients.elasticsearch.sql.TranslateResponse;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.api.model.QueryOptions;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/29/24.
@@ -19,10 +19,10 @@ public interface ElasticVertxClient {
      *
      * @param statement  the SQL statement to translate
      * @param parameters any parameters to be used in the SQL statement
-     * @return a {@link CompletableFuture} that will complete with the {@link TranslateResponse} or an exception if an error occurred
+     * @return a {@link Future} that will complete with the {@link TranslateResponse} or an exception if an error occurred
      */
-    CompletableFuture<TranslateResponse> translateSql(String statement,
-                                                      List<?> parameters);
+    Future<TranslateResponse> translateSql(String statement,
+                                           List<?> parameters);
 
     /**
      * Executes a SQL statement against ElasticSearch
@@ -33,12 +33,12 @@ public interface ElasticVertxClient {
      * @param options    the options to use for the query
      * @param pageable   the pageable to use for the query or null if not needed
      * @param type       the type of the entity
-     * @return a {@link CompletableFuture} that will complete with the response or an exception if an error occurred
+     * @return a {@link Future} that will complete with the response or an exception if an error occurred
      */
-    <T> CompletableFuture<Page<T>> querySql(String statement,
-                                            List<?> parameters,
-                                            JsonObject filter,
-                                            QueryOptions options,
-                                            Pageable pageable,
-                                            Class<T> type);
+    <T> Future<Page<T>> querySql(String statement,
+                                 List<?> parameters,
+                                 JsonObject filter,
+                                 QueryOptions options,
+                                 Pageable pageable,
+                                 Class<T> type);
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/AggregateQueryExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/AggregateQueryExecutor.java
@@ -1,7 +1,6 @@
 package org.kinotic.persistence.internal.api.services.sql.executors;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -11,6 +10,7 @@ import org.kinotic.persistence.api.model.idl.decorators.MultiTenancyType;
 import org.kinotic.persistence.internal.api.services.sql.QueryContext;
 import org.kinotic.persistence.internal.api.services.sql.elasticsearch.ElasticVertxClient;
 
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -35,16 +35,16 @@ public class AggregateQueryExecutor extends AbstractQueryExecutor {
     }
 
     @Override
-    public <T> CompletableFuture<List<T>> execute(QueryContext context, Class<T> type) {
+    public <T> Future<List<T>> execute(QueryContext context, Class<T> type) {
 
         return executePage(context, null, type)
-                                 .thenApply(Page::getContent);
+                                 .map(Page::getContent);
     }
 
     @Override
-    public <T> CompletableFuture<Page<T>> executePage(QueryContext context,
-                                                      Pageable pageable,
-                                                      Class<T> type) {
+    public <T> Future<Page<T>> executePage(QueryContext context,
+                                           Pageable pageable,
+                                           Class<T> type) {
         JsonObject filter = createFilterIfNeeded(context);
 
         return elasticVertxClient.querySql(statement,

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/CompositeQueryExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/CompositeQueryExecutor.java
@@ -1,12 +1,12 @@
 package org.kinotic.persistence.internal.api.services.sql.executors;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.internal.api.services.sql.QueryContext;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/29/24.
@@ -21,16 +21,13 @@ public class CompositeQueryExecutor implements QueryExecutor {
     }
 
     @Override
-    public <T> CompletableFuture<List<T>> execute(QueryContext context, Class<T> type) {
-//         CompletableFuture.allOf(queryExecutors.stream()
-//                                             .map(executor -> executor.execute(parameters, type, context))
-//                                             .toArray(CompletableFuture[]::new));
+    public <T> Future<List<T>> execute(QueryContext context, Class<T> type) {
         return null;
     }
 
     @Override
-    public <T> CompletableFuture<Page<T>> executePage(QueryContext context, Pageable pageable,
-                                                      Class<T> type) {
+    public <T> Future<Page<T>> executePage(QueryContext context, Pageable pageable,
+                                           Class<T> type) {
         return null;
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/ParameterProcessorExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/ParameterProcessorExecutor.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services.sql.executors;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -19,7 +20,6 @@ import org.kinotic.persistence.internal.api.services.sql.QueryMetadata;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A {@link QueryExecutor} that extracts special parameters from the {@link QueryContext} before delegating to another {@link QueryExecutor}
@@ -44,13 +44,13 @@ public class ParameterProcessorExecutor extends AbstractQueryExecutor {
     }
 
     @Override
-    public <T> CompletableFuture<List<T>> execute(QueryContext context, Class<T> type) {
+    public <T> Future<List<T>> execute(QueryContext context, Class<T> type) {
         processQueryContext(context);
         return delegate.execute(context, type);
     }
 
     @Override
-    public <T> CompletableFuture<Page<T>> executePage(QueryContext context, Pageable pageable, Class<T> type) {
+    public <T> Future<Page<T>> executePage(QueryContext context, Pageable pageable, Class<T> type) {
         processQueryContext(context);
         return delegate.executePage(context, pageable, type);
     }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/PreAuthorizationExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/PreAuthorizationExecutor.java
@@ -1,5 +1,6 @@
 package org.kinotic.persistence.internal.api.services.sql.executors;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -8,7 +9,6 @@ import org.kinotic.persistence.api.services.security.AuthorizationService;
 import org.kinotic.persistence.internal.api.services.sql.QueryContext;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created By navidmitchell on 12/30/24
@@ -20,19 +20,19 @@ public class PreAuthorizationExecutor implements QueryExecutor{
     private final QueryExecutor delegate;
 
     @Override
-    public <T> CompletableFuture<List<T>> execute(QueryContext context, Class<T> type) {
+    public <T> Future<List<T>> execute(QueryContext context, Class<T> type) {
         return authorizationService.authorize(NamedQueryOperation.EXECUTE, context.getEntityContext())
-                                   .thenCompose(v -> delegate.execute(
+                                   .compose(v -> delegate.execute(
                                            context, type
                                    ));
     }
 
     @Override
-    public <T> CompletableFuture<Page<T>> executePage(QueryContext context,
-                                                      Pageable pageable,
-                                                      Class<T> type) {
+    public <T> Future<Page<T>> executePage(QueryContext context,
+                                           Pageable pageable,
+                                           Class<T> type) {
         return authorizationService.authorize(NamedQueryOperation.EXECUTE_PAGE, context.getEntityContext())
-                                   .thenCompose(v -> delegate.executePage(
+                                   .compose(v -> delegate.executePage(
                                            context, pageable,
                                            type
                                    ));

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/QueryExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/QueryExecutor.java
@@ -1,11 +1,11 @@
 package org.kinotic.persistence.internal.api.services.sql.executors;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.internal.api.services.sql.QueryContext;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Query executor for executing SQL queries against a data store
@@ -13,11 +13,11 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface QueryExecutor {
 
-    <T> CompletableFuture<List<T>> execute(QueryContext context,
-                                           Class<T> type);
+    <T> Future<List<T>> execute(QueryContext context,
+                                Class<T> type);
 
-    <T> CompletableFuture<Page<T>> executePage(QueryContext context,
-                                               Pageable pageable,
-                                               Class<T> type);
+    <T> Future<Page<T>> executePage(QueryContext context,
+                                    Pageable pageable,
+                                    Class<T> type);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/SelectQueryExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/SelectQueryExecutor.java
@@ -1,11 +1,11 @@
 package org.kinotic.persistence.internal.api.services.sql.executors;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.internal.api.services.sql.QueryContext;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/28/24.
@@ -13,15 +13,15 @@ import java.util.concurrent.CompletableFuture;
 public class SelectQueryExecutor implements QueryExecutor {
 
     @Override
-    public <T> CompletableFuture<List<T>> execute(QueryContext context,
-                                                  Class<T> type) {
+    public <T> Future<List<T>> execute(QueryContext context,
+                                       Class<T> type) {
         return null;
     }
 
     @Override
-    public <T> CompletableFuture<Page<T>> executePage(QueryContext context,
-                                                      Pageable pageable,
-                                                      Class<T> type) {
+    public <T> Future<Page<T>> executePage(QueryContext context,
+                                           Pageable pageable,
+                                           Class<T> type) {
         return null;
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/UpdateQueryExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/UpdateQueryExecutor.java
@@ -1,12 +1,12 @@
 package org.kinotic.persistence.internal.api.services.sql.executors;
 
+import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.internal.api.services.sql.QueryContext;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/28/24.
@@ -17,13 +17,13 @@ public class UpdateQueryExecutor implements QueryExecutor {
     // private final String statement;
 
     @Override
-    public <T> CompletableFuture<List<T>> execute(QueryContext context, Class<T> type) {
+    public <T> Future<List<T>> execute(QueryContext context, Class<T> type) {
         return null;
     }
 
     @Override
-    public <T> CompletableFuture<Page<T>> executePage(QueryContext context, Pageable pageable,
-                                                      Class<T> type) {
+    public <T> Future<Page<T>> executePage(QueryContext context, Pageable pageable,
+                                           Class<T> type) {
         return null;
     }
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/sample/TestDataService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/sample/TestDataService.java
@@ -2,6 +2,8 @@ package org.kinotic.persistence.internal.sample;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jspecify.annotations.Nullable;
 import org.kinotic.core.api.utils.KinoticUtil;
@@ -24,7 +26,6 @@ import tools.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navíd Mitchell 🤪 on 6/1/23.
@@ -54,6 +55,7 @@ public class TestDataService {
 
     private final ApplicationService applicationService;
     private final EntityDefinitionService entityDefinitionService;
+    private final Vertx vertx;
 
     private final AsyncLoadingCache<String, List<Person>> peopleCache;
 
@@ -61,10 +63,12 @@ public class TestDataService {
                            EntityDefinitionService entityDefinitionService,
                            ResourceLoader resourceLoader,
                            ObjectMapper objectMapper,
-                           DefaultCaffeineCacheFactory cacheFactory) {
+                           DefaultCaffeineCacheFactory cacheFactory,
+                           Vertx vertx) {
 
         this.applicationService = applicationService;
         this.entityDefinitionService = entityDefinitionService;
+        this.vertx = vertx;
 
         peopleCache = cacheFactory.<String, List<Person>>newBuilder()
                               .name("peopleCache")
@@ -90,28 +94,30 @@ public class TestDataService {
 
     /**
      * Creates a {@link Car} {@link EntityDefinition} if it does not exist.
-     * @return a {@link CompletableFuture} that will return a {@link Pair} of the {@link EntityDefinition} and a {@link Boolean} indicating if the structure was created.
+     * @return a {@link Future} that will return a {@link Pair} of the {@link EntityDefinition} and a {@link Boolean} indicating if the structure was created.
      */
-    public CompletableFuture<Pair<EntityDefinition, Boolean>> createCarEntityDefinitionIfNotExists(String structureNameSuffix){
+    public Future<Pair<EntityDefinition, Boolean>> createCarEntityDefinitionIfNotExists(String structureNameSuffix){
         String structureId = PersistenceUtil.createEntityDefinitionId(SAMPLE_ORG_ID,
                                                                       SAMPLE_APP_ID,
                                                                       "Car"+(structureNameSuffix != null ? structureNameSuffix : ""));
         return entityDefinitionService.findById(structureId)
-                                      .thenCompose(structure -> {
+                                      .compose(structure -> {
+                                   Future<Pair<EntityDefinition, Boolean>> ret;
                                    if(structure != null){
-                                       return CompletableFuture.completedFuture(Pair.of(structure, false));
+                                       ret = Future.succeededFuture(Pair.of(structure, false));
                                    }else{
-                                       return createCarEntityDefinition(structureNameSuffix).thenApply(saved -> Pair.of(saved, true));
+                                       ret = createCarEntityDefinition(structureNameSuffix).map(saved -> Pair.of(saved, true));
                                    }
+                                   return ret;
                                });
     }
 
     /**
      * Creates a {@link Car} {@link EntityDefinition} and publishes it.
      * @param structureNameSuffix if not null will be appended to the structure name.
-     * @return a {@link CompletableFuture} that will return the {@link EntityDefinition} that was created.
+     * @return a {@link Future} that will return the {@link EntityDefinition} that was created.
      */
-    public CompletableFuture<EntityDefinition> createCarEntityDefinition(String structureNameSuffix) {
+    public Future<EntityDefinition> createCarEntityDefinition(String structureNameSuffix) {
         EntityDefinition structure = new EntityDefinition();
         structure.setName("Car"+(structureNameSuffix != null ? structureNameSuffix : ""));
         structure.setOrganizationId(SAMPLE_ORG_ID);
@@ -124,9 +130,9 @@ public class TestDataService {
         structure.setSchema(carType);
 
         return applicationService.createApplicationIfNotExist(SAMPLE_APP_ID, "Sample application")
-                               .thenCompose(v -> entityDefinitionService.create(structure)
-                                                                        .thenCompose(saved -> entityDefinitionService.publish(saved.getId())
-                                                                                                                     .thenApply(published -> saved)));
+                               .compose(v -> entityDefinitionService.create(structure)
+                                                                    .compose(saved -> entityDefinitionService.publish(saved.getId())
+                                                                                                             .map(saved)));
     }
 
 
@@ -170,34 +176,36 @@ public class TestDataService {
         return ret;
     }
 
-    public CompletableFuture<Pair<EntityDefinition, Boolean>> createPersonEntityDefinitionIfNotExists(){
+    public Future<Pair<EntityDefinition, Boolean>> createPersonEntityDefinitionIfNotExists(){
         return createPersonEntityDefinitionIfNotExists(null);
     }
 
     /**
      * Creates a person structure if it does not exist.
-     * @return a {@link CompletableFuture} that will return a {@link Pair} of the {@link EntityDefinition} and a {@link Boolean} indicating if the structure was created.
+     * @return a {@link Future} that will return a {@link Pair} of the {@link EntityDefinition} and a {@link Boolean} indicating if the structure was created.
      */
-    public CompletableFuture<Pair<EntityDefinition, Boolean>> createPersonEntityDefinitionIfNotExists(String structureNameSuffix){
+    public Future<Pair<EntityDefinition, Boolean>> createPersonEntityDefinitionIfNotExists(String structureNameSuffix){
         String structureId = PersistenceUtil.createEntityDefinitionId(SAMPLE_ORG_ID,
                                                                       SAMPLE_APP_ID,
                                                                       "Person"+(structureNameSuffix != null ? structureNameSuffix : ""));
         return entityDefinitionService.findById(structureId)
-                                      .thenCompose(structure -> {
+                                      .compose(structure -> {
+                                   Future<Pair<EntityDefinition, Boolean>> ret;
                                    if(structure != null){
-                                       return CompletableFuture.completedFuture(Pair.of(structure, false));
+                                       ret = Future.succeededFuture(Pair.of(structure, false));
                                    }else{
-                                       return createPersonEntityDefinition(structureNameSuffix).thenApply(saved -> Pair.of(saved, true));
+                                       ret = createPersonEntityDefinition(structureNameSuffix).map(saved -> Pair.of(saved, true));
                                    }
+                                   return ret;
                                });
     }
 
     /**
      * Creates a {@link Person} {@link EntityDefinition} and publishes it.
      * @param structureNameSuffix if not null will be appended to the structure name.
-     * @return a {@link CompletableFuture} that will return the {@link EntityDefinition} that was created.
+     * @return a {@link Future} that will return the {@link EntityDefinition} that was created.
      */
-    public CompletableFuture<EntityDefinition> createPersonEntityDefinition(String structureNameSuffix) {
+    public Future<EntityDefinition> createPersonEntityDefinition(String structureNameSuffix) {
         EntityDefinition structure = new EntityDefinition();
         structure.setName("Person"+(structureNameSuffix != null ? structureNameSuffix : ""));
         structure.setOrganizationId(SAMPLE_ORG_ID);
@@ -210,65 +218,70 @@ public class TestDataService {
         structure.setSchema(personType);
 
         return applicationService.createApplicationIfNotExist(SAMPLE_APP_ID, "Sample application")
-                               .thenCompose(v -> entityDefinitionService.create(structure)
-                                                                        .thenCompose(saved -> entityDefinitionService.publish(saved.getId())
-                                                                                                                     .thenApply(published -> saved)));
+                               .compose(v -> entityDefinitionService.create(structure)
+                                                                    .compose(saved -> entityDefinitionService.publish(saved.getId())
+                                                                                                             .map(saved)));
     }
 
     /**
-     * @return a {@link CompletableFuture} that will return a random {@link Person} from the cache.
+     * @return a {@link Future} that will return a random {@link Person} from the cache.
      */
-    public CompletableFuture<Person> createTestPerson() {
-        return peopleCache.get(PEOPLE_KEY).thenApply(people -> people.get(KinoticUtil.getRandomNumberInRange(people.size() - 1)));
+    public Future<Person> createTestPerson() {
+        return loadPeople(PEOPLE_KEY).map(people -> people.get(KinoticUtil.getRandomNumberInRange(people.size() - 1)));
     }
 
     /**
-     * @return a {@link CompletableFuture} that will return a random {@link Person} with the id populated, from the cache.
+     * @return a {@link Future} that will return a random {@link Person} with the id populated, from the cache.
      */
-    public CompletableFuture<Person> createTestPersonWithId() {
-        return peopleCache.get(PEOPLE_WITH_ID_KEY).thenApply(people -> people.get(KinoticUtil.getRandomNumberInRange(people.size() - 1)));
+    public Future<Person> createTestPersonWithId() {
+        return loadPeople(PEOPLE_WITH_ID_KEY).map(people -> people.get(KinoticUtil.getRandomNumberInRange(people.size() - 1)));
     }
 
     /**
-     * Creates a {@link CompletableFuture} that will return a {@link List} of static {@link Person} from the cache.
+     * Creates a {@link Future} that will return a {@link List} of static {@link Person} from the cache.
      * Each call will return the exact same {@link List} of {@link Person}.
      * @param numberToCreate the number of {@link Person} to create.
-     * @return a {@link CompletableFuture} that will return a {@link List} of random {@link Person} from the cache.
+     * @return a {@link Future} that will return a {@link List} of random {@link Person} from the cache.
      */
-    public CompletableFuture<List<Person>> createTestPeople(int numberToCreate) {
-        return getPeopleCompletableFuture(numberToCreate, false, PEOPLE_KEY);
+    public Future<List<Person>> createTestPeople(int numberToCreate) {
+        return getPeopleFuture(numberToCreate, false, PEOPLE_KEY);
     }
 
     /**
-     * Creates a {@link CompletableFuture} that will return a {@link List} of static {@link Person} with the id populated, from the cache.
+     * Creates a {@link Future} that will return a {@link List} of static {@link Person} with the id populated, from the cache.
      * Each call will return the exact same {@link List} of {@link Person}.
      * @param numberToCreate the number of {@link Person} with the id populated, to create.
-     * @return a {@link CompletableFuture} that will return a {@link List} of random {@link Person} with the id populated, from the cache.
+     * @return a {@link Future} that will return a {@link List} of random {@link Person} with the id populated, from the cache.
      */
-    public CompletableFuture<List<Person>> createTestPeopleWithId(int numberToCreate) {
-        return getPeopleCompletableFuture(numberToCreate, false, PEOPLE_WITH_ID_KEY);
+    public Future<List<Person>> createTestPeopleWithId(int numberToCreate) {
+        return getPeopleFuture(numberToCreate, false, PEOPLE_WITH_ID_KEY);
     }
 
     /**
      * @param numberToCreate the number of random {@link Person} to create.
-     * @return a {@link CompletableFuture} that will return a {@link List} of random {@link Person} from the cache.
+     * @return a {@link Future} that will return a {@link List} of random {@link Person} from the cache.
      */
-    public CompletableFuture<List<Person>> createRandomTestPeople(int numberToCreate) {
-        return getPeopleCompletableFuture(numberToCreate, true, PEOPLE_KEY);
+    public Future<List<Person>> createRandomTestPeople(int numberToCreate) {
+        return getPeopleFuture(numberToCreate, true, PEOPLE_KEY);
     }
 
     /**
      * @param numberToCreate the number of random {@link Person} with the id populated, to create.
-     * @return a {@link CompletableFuture} that will return a {@link List} of random {@link Person} with the id populated, from the cache.
+     * @return a {@link Future} that will return a {@link List} of random {@link Person} with the id populated, from the cache.
      */
-    public CompletableFuture<List<Person>> createRandomTestPeopleWithId(int numberToCreate) {
-        return getPeopleCompletableFuture(numberToCreate, true, PEOPLE_WITH_ID_KEY);
+    public Future<List<Person>> createRandomTestPeopleWithId(int numberToCreate) {
+        return getPeopleFuture(numberToCreate, true, PEOPLE_WITH_ID_KEY);
     }
 
-    private CompletableFuture<List<Person>> getPeopleCompletableFuture(int numberToCreate,
-                                                                       boolean random,
-                                                                       String peopleKey) {
-        return peopleCache.get(peopleKey).thenApply(people -> {
+    // Caffeine loads on its own executor, so bind the completion back to the calling Vert.x context
+    private Future<List<Person>> loadPeople(String peopleKey) {
+        return Future.fromCompletionStage(peopleCache.get(peopleKey), vertx.getOrCreateContext());
+    }
+
+    private Future<List<Person>> getPeopleFuture(int numberToCreate,
+                                                 boolean random,
+                                                 String peopleKey) {
+        return loadPeople(peopleKey).map(people -> {
             int size = people.size();
             if(!random && size < numberToCreate){
                 throw new IllegalArgumentException("Cannot create "+numberToCreate+" people, a max of "+size+" are available." +
@@ -291,7 +304,7 @@ public class TestDataService {
         public PeopleCacheLoader(ResourceLoader resourceLoader,
                                  ObjectMapper objectMapper) {
 
-            this.resourceLoader = resourceLoader instanceof PathMatchingResourcePatternResolver 
+            this.resourceLoader = resourceLoader instanceof PathMatchingResourcePatternResolver
             ? (PathMatchingResourcePatternResolver) resourceLoader : new PathMatchingResourcePatternResolver(resourceLoader);
             this.objectMapper = objectMapper;
         }

--- a/kinotic-test/src/test/java/org/kinotic/test/support/kinotic/KinoticTestBase.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/support/kinotic/KinoticTestBase.java
@@ -1,6 +1,8 @@
 package org.kinotic.test.support.kinotic;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.kinotic.core.api.security.ParticipantConstants;
 import org.kinotic.core.api.security.SecurityContext;
@@ -16,7 +18,6 @@ import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
@@ -92,24 +93,18 @@ public abstract class KinoticTestBase {
      * {@link #TEST_ORG_ID} from the current participant. This lets tests exercise scoped
      * services without authenticating through the gateway.
      */
-    protected <T> CompletableFuture<T> runAsOrganization(Supplier<CompletableFuture<T>> supplier) {
-        CompletableFuture<T> result = new CompletableFuture<>();
+    protected <T> Future<T> runAsOrganization(Supplier<Future<T>> supplier) {
+        Promise<T> promise = Promise.promise();
         Context context = vertx.getOrCreateContext();
         context.runOnContext(v -> {
             securityContext.setParticipant(context, TEST_ORGANIZATION_PARTICIPANT);
             try {
-                supplier.get().whenComplete((value, error) -> {
-                    if (error != null) {
-                        result.completeExceptionally(error);
-                    } else {
-                        result.complete(value);
-                    }
-                });
+                supplier.get().onComplete(promise);
             } catch (Throwable t) {
-                // a service that throws synchronously would otherwise leave result uncompleted, hanging the test
-                result.completeExceptionally(t);
+                // a service that throws synchronously would otherwise leave the promise uncompleted, hanging the test
+                promise.fail(t);
             }
         });
-        return result;
+        return promise.future();
     }
 }

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/ApplicationTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/ApplicationTests.java
@@ -22,16 +22,16 @@ public class ApplicationTests extends KinoticTestBase {
 		Application test = new Application("Test App", "Testing This Application");
 		test.setOrganizationId(TEST_ORG_ID);
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.save(test))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> applicationService.save(test)).toCompletionStage()))
 					.expectNextMatches(application -> application.getId().equals("test-app") && application.getUpdated() != null)
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.deleteById(test.getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> applicationService.deleteById(test.getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.findById(test.getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> applicationService.findById(test.getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 	}
@@ -41,13 +41,13 @@ public class ApplicationTests extends KinoticTestBase {
 		Application test = new Application("Slugs. And Snails!", "Testing id derivation");
 		test.setOrganizationId(TEST_ORG_ID);
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.create(test))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> applicationService.create(test)).toCompletionStage()))
 					.expectNextMatches(application -> application.getId().equals("slugs-and-snails")
 							&& application.getName().equals("Slugs. And Snails!"))
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.deleteById("slugs-and-snails"))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> applicationService.deleteById("slugs-and-snails")).toCompletionStage()))
 					.expectComplete()
 					.verify();
 	}

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/BulkUpdateTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/BulkUpdateTests.java
@@ -1,5 +1,6 @@
 package org.kinotic.test.tests.core.entity;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,6 @@ import reactor.test.StepVerifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 
 @SpringBootTest
@@ -76,23 +76,23 @@ public class BulkUpdateTests extends KinoticTestBase {
         Assertions.assertNotNull(holder2);
 
         // Sync Index since bulk updates are not queryable until they are indexed
-        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
-        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).await();
+        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).await();
 
         // TODO: verify all data items as well, not just sizes
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
                                                                                    Pageable.ofSize(numberOfPeopleToCreate * 2),// make sure page size is larger than number of entities
                                                                                    RawJson.class,
-                                                                                   context1))))
+                                                                                   context1)).toCompletionStage()))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == numberOfPeopleToCreate
                             && rawJsons.getContent().size() == numberOfPeopleToCreate)
                     .as("Verifying Tenant 1 has "+numberOfPeopleToCreate+" entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
                                                                                    Pageable.ofSize(numberOfPeopleToCreate * 2), // make sure page size is larger than number of entities
                                                                                    RawJson.class,
-                                                                                   context2))))
+                                                                                   context2)).toCompletionStage()))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == numberOfPeopleToCreate
                             && rawJsons.getContent().size() == numberOfPeopleToCreate)
                     .as("Verifying Tenant 2 has "+numberOfPeopleToCreate+" entities")
@@ -102,15 +102,15 @@ public class BulkUpdateTests extends KinoticTestBase {
     @Test
     public void bulkSaveObjectWithMultipleIds() throws Exception{
         EntityContext entityContext = new DefaultEntityContext(applicationParticipant());
-        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = runAsOrganization(() -> testDataService.createCarEntityDefinitionIfNotExists("_bulkSaveMultipleIds"));
+        Future<Pair<EntityDefinition, Boolean>> createStructure = runAsOrganization(() -> testDataService.createCarEntityDefinitionIfNotExists("_bulkSaveMultipleIds"));
 
-        StepVerifier.create(Mono.fromFuture(createStructure))
+        StepVerifier.create(Mono.fromCompletionStage(createStructure.toCompletionStage()))
                     .expectNextMatches(pair -> pair.getLeft() != null && pair.getRight())
                     .verifyComplete();
 
-        EntityDefinition entityDefinition = createStructure.join().getLeft();
+        EntityDefinition entityDefinition = createStructure.await().getLeft();
 
-        List<Person> personList = testDataService.createRandomTestPeopleWithId(50).join();
+        List<Person> personList = testDataService.createRandomTestPeopleWithId(50).await();
 
         Assertions.assertEquals(50, personList.size(), "Failed to create test person");
 
@@ -126,12 +126,12 @@ public class BulkUpdateTests extends KinoticTestBase {
             cars.add(car);
         }
 
-        testHelper.bulkSaveCarsAsRawJson(cars, entityDefinition, entityContext).join();
+        testHelper.bulkSaveCarsAsRawJson(cars, entityDefinition, entityContext).await();
 
         // Sync Index since bulk updates are not queryable until they are indexed
-        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).await();
 
-        Page<RawJson> page = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
+        Page<RawJson> page = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).await();
 
         Assertions.assertEquals(50, page.getTotalElements(), "Wrong number of entities");
     }
@@ -139,15 +139,15 @@ public class BulkUpdateTests extends KinoticTestBase {
     @Test
     public void bulkUpdateObjectWithMultipleIds() throws Exception{
         EntityContext entityContext = new DefaultEntityContext(applicationParticipant());
-        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = runAsOrganization(() -> testDataService.createCarEntityDefinitionIfNotExists("_bulkUpdateMultipleIds"));
+        Future<Pair<EntityDefinition, Boolean>> createStructure = runAsOrganization(() -> testDataService.createCarEntityDefinitionIfNotExists("_bulkUpdateMultipleIds"));
 
-        StepVerifier.create(Mono.fromFuture(createStructure))
+        StepVerifier.create(Mono.fromCompletionStage(createStructure.toCompletionStage()))
                     .expectNextMatches(pair -> pair.getLeft() != null && pair.getRight())
                     .verifyComplete();
 
-        EntityDefinition entityDefinition = createStructure.join().getLeft();
+        EntityDefinition entityDefinition = createStructure.await().getLeft();
 
-        List<Person> personList = testDataService.createRandomTestPeopleWithId(50).join();
+        List<Person> personList = testDataService.createRandomTestPeopleWithId(50).await();
 
         Assertions.assertEquals(50, personList.size(), "Failed to create test person");
 
@@ -163,12 +163,12 @@ public class BulkUpdateTests extends KinoticTestBase {
             cars.add(car);
         }
 
-        testHelper.bulkUpdateCarsAsRawJson(cars, entityDefinition, entityContext).join();
+        testHelper.bulkUpdateCarsAsRawJson(cars, entityDefinition, entityContext).await();
 
         // Sync Index since bulk updates are not queryable until they are indexed
-        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).await();
 
-        Page<RawJson> page = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
+        Page<RawJson> page = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).await();
 
         Assertions.assertEquals(50, page.getTotalElements(), "Wrong number of entities");
     }

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityCrudTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityCrudTests.java
@@ -2,6 +2,7 @@
 
 package org.kinotic.test.tests.core.entity;
 
+import io.vertx.core.Future;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 @SpringBootTest
@@ -57,9 +57,9 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.deleteById(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.deleteById(holder.getEntityDefinition().getId(),
                                                                                       holder.getFirstPerson().getId(),
-                                                                                      new DefaultEntityContext(applicationParticipant())))))
+                                                                                      new DefaultEntityContext(applicationParticipant()))).toCompletionStage()))
                     .verifyComplete();
     }
 
@@ -71,21 +71,21 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        runAsOrganization(() -> entitiesService.syncIndex(holder.getEntityDefinition().getId(), context)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder.getEntityDefinition().getId(), context)).await();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.count(holder.getEntityDefinition().getId(), context))))
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.count(holder.getEntityDefinition().getId(), context)).toCompletionStage()))
                 .expectNext(20L)
                 .as("Verifying Tenant 1 has 20 entities")
                 .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.deleteByQuery(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.deleteByQuery(holder.getEntityDefinition().getId(),
                                                                                          "lastName: A*",
-                                                                                         context))))
+                                                                                         context)).toCompletionStage()))
                 .verifyComplete();
 
-        runAsOrganization(() -> entitiesService.syncIndex(holder.getEntityDefinition().getId(), context)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder.getEntityDefinition().getId(), context)).await();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.count(holder.getEntityDefinition().getId(), context))))
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.count(holder.getEntityDefinition().getId(), context)).toCompletionStage()))
                 .expectNext(18L)
                 .as("Verifying Tenant 1 has 18 entities after delete by query")
                 .verifyComplete();
@@ -99,10 +99,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findById(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findById(holder.getEntityDefinition().getId(),
                                                                                     holder.getFirstPerson().getId(),
                                                                                     RawJson.class,
-                                                                                    new DefaultEntityContext(applicationParticipant())))))
+                                                                                    new DefaultEntityContext(applicationParticipant()))).toCompletionStage()))
                     .expectNextMatches(found -> {
                         boolean ret;
                         try {
@@ -139,10 +139,10 @@ public class EntityCrudTests extends KinoticTestBase {
             }
         }
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findByIds(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findByIds(holder.getEntityDefinition().getId(),
                                                                                      ids,
                                                                                      RawJson.class,
-                                                                                     context))))
+                                                                                     context)).toCompletionStage()))
                 .expectNextMatches(responseList -> {
                     boolean ret = false;
                     try {
@@ -181,10 +181,10 @@ public class EntityCrudTests extends KinoticTestBase {
             }
         }
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findByIds(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findByIds(holder.getEntityDefinition().getId(),
                                                                                      ids,
                                                                                      RawJson.class,
-                                                                                     context))))
+                                                                                     context)).toCompletionStage()))
                 .expectNextMatches(List::isEmpty)
                 .as("Verifying Tenant ids query to be empty as none of ids matches")
                 .verifyComplete();
@@ -204,15 +204,15 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
-        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).await();
+        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).await();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.count(holder1.getEntityDefinition().getId(), context1))))
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.count(holder1.getEntityDefinition().getId(), context1)).toCompletionStage()))
                     .expectNext(10L)
                     .as("Verifying Tenant 1 has 10 entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.count(holder2.getEntityDefinition().getId(), context2))))
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.count(holder2.getEntityDefinition().getId(), context2)).toCompletionStage()))
                     .expectNext(20L)
                     .as("Verifying Tenant 2 has 20 entities")
                     .verifyComplete();
@@ -232,20 +232,20 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
-        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).await();
+        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).await();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.countByQuery(holder1.getEntityDefinition().getId(), "lastName: Z*", context1))))
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.countByQuery(holder1.getEntityDefinition().getId(), "lastName: Z*", context1)).toCompletionStage()))
                 .expectNext(2L)
                 .as("Verifying Tenant 1 has 2 entities by search")
                 .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.countByQuery(holder2.getEntityDefinition().getId(), "lastName: A*", context2))))
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.countByQuery(holder2.getEntityDefinition().getId(), "lastName: A*", context2)).toCompletionStage()))
                 .expectNext(2L)
                 .as("Verifying Tenant 2 has 2 entities by search")
                 .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.countByQuery(holder2.getEntityDefinition().getId(), "lastName: a*", context2))))
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.countByQuery(holder2.getEntityDefinition().getId(), "lastName: a*", context2)).toCompletionStage()))
                 .expectNext(0L)
                 .as("Verifying Tenant 0 has 2 entities by search")
                 .verifyComplete();
@@ -267,23 +267,23 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
-        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).await();
+        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).await();
 
         // TODO: verify all data items as well, not just sizes
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
                                                                                    Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                                    RawJson.class,
-                                                                                   context1))))
+                                                                                   context1)).toCompletionStage()))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == 10
                             && rawJsons.getContent().size() == 10)
                     .as("Verifying Tenant 1 has 10 entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
                                                                                    Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                                    RawJson.class,
-                                                                                   context2))))
+                                                                                   context2)).toCompletionStage()))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == 20
                             && rawJsons.getContent().size() == 20)
                     .as("Verifying Tenant 2 has 20 entities")
@@ -305,8 +305,8 @@ public class EntityCrudTests extends KinoticTestBase {
         Assertions.assertNotNull(holder2);
 
         // Make sure all data is indexed
-        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
-        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).await();
+        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).await();
 
         Thread.sleep(10000); // TODO: why does this still fail without a sleep? Sync index should be ensuring data is indexed.
 
@@ -314,12 +314,12 @@ public class EntityCrudTests extends KinoticTestBase {
         Sort sort = Sort.by("firstName");
         AtomicReference<String> cursorRef = new AtomicReference<>();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
                                                                                    Pageable.create("",
                                                                                     20,
                                                                                     Sort.by("firstName")),
                                                                                    RawJson.class,
-                                                                                   context1))))
+                                                                                   context1)).toCompletionStage()))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         if(page instanceof CursorPage){
@@ -335,10 +335,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
                                                                                    Pageable.create(cursorRef.get(), 20, sort),
                                                                                    RawJson.class,
-                                                                                   context1))))
+                                                                                   context1)).toCompletionStage()))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -355,10 +355,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder1.getEntityDefinition().getId(),
                                                                                    Pageable.create(cursorRef.get(), 20, sort),
                                                                                    RawJson.class,
-                                                                                   context1))))
+                                                                                   context1)).toCompletionStage()))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -377,10 +377,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNull(cursorRef.get(), "Cursor is not null");
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
                                                                                    Pageable.create("", 10, sort),
                                                                                    RawJson.class,
-                                                                                   context2))))
+                                                                                   context2)).toCompletionStage()))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         if(page instanceof CursorPage){
@@ -396,10 +396,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
                                                                                    Pageable.create(cursorRef.get(), 10, sort),
                                                                                    RawJson.class,
-                                                                                   context2))))
+                                                                                   context2)).toCompletionStage()))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -416,10 +416,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
                                                                                    Pageable.create(cursorRef.get(), 10, sort),
                                                                                    RawJson.class,
-                                                                                   context2))))
+                                                                                   context2)).toCompletionStage()))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -437,10 +437,10 @@ public class EntityCrudTests extends KinoticTestBase {
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findAll(holder2.getEntityDefinition().getId(),
                                                                                    Pageable.create(cursorRef.get(), 10, sort),
                                                                                    RawJson.class,
-                                                                                   context2))))
+                                                                                   context2)).toCompletionStage()))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -469,15 +469,15 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
-        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(holder1.getEntityDefinition().getId(), context1)).await();
+        runAsOrganization(() -> entitiesService.syncIndex(holder2.getEntityDefinition().getId(), context2)).await();
 
         // TODO: verify all data items as well, not just sizes
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.search(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.search(holder1.getEntityDefinition().getId(),
                                                                                   "lastName: Z*",
                                                                                   Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                                   RawJson.class,
-                                                                                  context1))))
+                                                                                  context1)).toCompletionStage()))
                     .expectNextMatches(rawJsons -> {
                         boolean b = rawJsons.getTotalElements() == 2
                                 && rawJsons.getContent().size() == 2;
@@ -489,11 +489,11 @@ public class EntityCrudTests extends KinoticTestBase {
                     .as("Verifying search for Tenant 1 has 2 entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.search(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.search(holder2.getEntityDefinition().getId(),
                                                                                   "lastName: Z*",
                                                                                   Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                                   RawJson.class,
-                                                                                  context2))))
+                                                                                  context2)).toCompletionStage()))
                     .expectNextMatches(rawJsons -> {
                         boolean b = rawJsons.getTotalElements() == 2
                                 && rawJsons.getContent().size() == 2;
@@ -521,13 +521,13 @@ public class EntityCrudTests extends KinoticTestBase {
 
         contextMap.forEach((context, holder) -> {
 
-            runAsOrganization(() -> entitiesService.syncIndex(holder.getEntityDefinition().getId(), context)).join();
+            runAsOrganization(() -> entitiesService.syncIndex(holder.getEntityDefinition().getId(), context)).await();
 
-            StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.search(holder.getEntityDefinition().getId(),
+            StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.search(holder.getEntityDefinition().getId(),
                                                                                       "lastName: *",
                                                                                       Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                                       RawJson.class,
-                                                                                      context))))
+                                                                                      context)).toCompletionStage()))
                     .expectNextMatches(rawJsons -> {
                         long expectedCount = holder.getPersons().size();
                         long queriedCount = rawJsons.getTotalElements();
@@ -548,19 +548,19 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.findById(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.findById(holder.getEntityDefinition().getId(),
                                                                                     "missing",
                                                                                     RawJson.class,
-                                                                                    new DefaultEntityContext(applicationParticipant())))))
+                                                                                    new DefaultEntityContext(applicationParticipant()))).toCompletionStage()))
                     .verifyComplete();
     }
 
     @Test
     public void testPartialUpdate() throws Exception {
         EntityContext entityContext = new DefaultEntityContext(applicationParticipant());
-        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = runAsOrganization(() -> testDataService.createCarEntityDefinitionIfNotExists("_partialUpdate"));
+        Future<Pair<EntityDefinition, Boolean>> createStructure = runAsOrganization(() -> testDataService.createCarEntityDefinitionIfNotExists("_partialUpdate"));
 
-        StepVerifier.create(Mono.fromFuture(createStructure))
+        StepVerifier.create(Mono.fromCompletionStage(createStructure.toCompletionStage()))
                     .expectNextMatches(pair -> {
                         boolean ret = pair.getLeft() != null && pair.getRight();
                         if(!ret){
@@ -570,7 +570,7 @@ public class EntityCrudTests extends KinoticTestBase {
                     })
                     .verifyComplete();
 
-        EntityDefinition entityDefinition = createStructure.join().getLeft();
+        EntityDefinition entityDefinition = createStructure.await().getLeft();
 
         Car car = new Car();
         car.setId(UUID.randomUUID().toString());
@@ -578,17 +578,17 @@ public class EntityCrudTests extends KinoticTestBase {
         car.setModel("Civic");
         car.setYear(2019);
 
-        Car result = testHelper.saveCarAsRawJson(car, entityDefinition, entityContext).join();
+        Car result = testHelper.saveCarAsRawJson(car, entityDefinition, entityContext).await();
 
         Assertions.assertEquals(car.getId(), result.getId(), "Car id does not match");
 
-        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).await();
 
-        Page<RawJson> page = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
+        Page<RawJson> page = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).await();
 
         Assertions.assertEquals(1, page.getTotalElements(), "Wrong number of entities");
 
-        List<Person> personList = testDataService.createRandomTestPeopleWithId(1).join();
+        List<Person> personList = testDataService.createRandomTestPeopleWithId(1).await();
 
         Assertions.assertEquals(1, personList.size(), "Failed to create test person");
 
@@ -600,13 +600,13 @@ public class EntityCrudTests extends KinoticTestBase {
            .setYear(null)
            .setOwner(person);
 
-        Car result2 = testHelper.updateCarAsRawJson(car, entityDefinition, entityContext).join();
+        Car result2 = testHelper.updateCarAsRawJson(car, entityDefinition, entityContext).await();
 
         Assertions.assertEquals(car.getId(), result2.getId(), "Car id does not match after partial update");
 
-        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).join();
+        runAsOrganization(() -> entitiesService.syncIndex(entityDefinition.getId(), entityContext)).await();
 
-        Page<RawJson> page2 = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
+        Page<RawJson> page2 = runAsOrganization(() -> entitiesService.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).await();
 
         Assertions.assertEquals(1, page2.getTotalElements(), "Wrong number of entities after partial update");
 

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityDefinitionCrudTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityDefinitionCrudTests.java
@@ -2,6 +2,7 @@
 
 package org.kinotic.test.tests.core.entity;
 
+import io.vertx.core.Future;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kinotic.idl.api.converter.C3ConversionException;
@@ -16,8 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
-import java.util.concurrent.CompletableFuture;
 
 // FIXME: Migrate to E2E tests
 @SpringBootTest
@@ -43,9 +42,9 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
+		Future<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
 
-		StepVerifier.create(Mono.fromFuture(future))
+		StepVerifier.create(Mono.fromCompletionStage(future.toCompletionStage()))
 					.expectNextMatches(savedStructure -> {
 						Assertions.assertNotNull(savedStructure.getId());
 						Assertions.assertNotNull(savedStructure.getCreated());
@@ -58,15 +57,15 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.publish(future.join().getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.publish(future.await().getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.unPublish(future.join().getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.unPublish(future.await().getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.deleteById(future.join().getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.deleteById(future.await().getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 	}
@@ -81,9 +80,9 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
+		Future<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
 
-		StepVerifier.create(Mono.fromFuture(future))
+		StepVerifier.create(Mono.fromCompletionStage(future.toCompletionStage()))
 					.expectNextMatches(savedStructure -> {
 						Assertions.assertNotNull(savedStructure.getId());
 						Assertions.assertNotNull(savedStructure.getCreated());
@@ -96,11 +95,11 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.publish(future.join().getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.publish(future.await().getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.deleteById(future.join().getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.deleteById(future.await().getId())).toCompletionStage()))
 					.expectError(IllegalStateException.class)
 					.verify();
 
@@ -117,7 +116,7 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, true));
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.create(entityDefinition))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.create(entityDefinition)).toCompletionStage()))
 					.expectError(C3ConversionException.class)
 					.verify();
 	}
@@ -132,9 +131,9 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
+		Future<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
 
-		StepVerifier.create(Mono.fromFuture(future))
+		StepVerifier.create(Mono.fromCompletionStage(future.toCompletionStage()))
 					.expectNextMatches(savedStructure -> {
 						Assertions.assertNotNull(savedStructure.getId());
 						Assertions.assertNotNull(savedStructure.getCreated());
@@ -147,11 +146,11 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.create(entityDefinition))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.create(entityDefinition)).toCompletionStage()))
 					.expectError(IllegalArgumentException.class)
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.deleteById(future.join().getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.deleteById(future.await().getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 	}
@@ -166,9 +165,9 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
+		Future<EntityDefinition> future = runAsOrganization(() -> entityDefinitionService.create(entityDefinition));
 
-		StepVerifier.create(Mono.fromFuture(future))
+		StepVerifier.create(Mono.fromCompletionStage(future.toCompletionStage()))
 					.expectNextMatches(savedStructure -> {
 						Assertions.assertNotNull(savedStructure.getId());
 						Assertions.assertNotNull(savedStructure.getCreated());
@@ -181,11 +180,11 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entitiesService.count(future.join().getId(), new DefaultEntityContext(applicationParticipant())))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entitiesService.count(future.await().getId(), new DefaultEntityContext(applicationParticipant()))).toCompletionStage()))
 					.expectError(IllegalArgumentException.class)
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> entityDefinitionService.deleteById(future.join().getId()))))
+		StepVerifier.create(Mono.fromCompletionStage(runAsOrganization(() -> entityDefinitionService.deleteById(future.await().getId())).toCompletionStage()))
 					.expectComplete()
 					.verify();
 	}

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/security/graphos/PolicyAuthorizationServiceTest.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/security/graphos/PolicyAuthorizationServiceTest.java
@@ -1,5 +1,6 @@
 package org.kinotic.test.tests.core.security.graphos;
 
+import io.vertx.core.Future;
 import org.junit.jupiter.api.Test;
 import org.kinotic.idl.api.schema.ObjectC3Type;
 import org.kinotic.core.api.exceptions.AuthorizationException;
@@ -12,8 +13,6 @@ import org.kinotic.persistence.api.services.security.graphos.EntityDefinitionPol
 import org.kinotic.persistence.api.services.security.graphos.PolicyAuthorizer;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -32,9 +31,9 @@ public class PolicyAuthorizationServiceTest {
 
         EntityDefinitionPolicyAuthorizationService service = new EntityDefinitionPolicyAuthorizationService(structure, authorizer);
 
-        CompletableFuture<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
+        Future<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
 
-        assertDoesNotThrow(result::join); // Should pass since there are no policies
+        assertDoesNotThrow(() -> { result.await(); }); // Should pass since there are no policies
     }
 
     @Test
@@ -49,9 +48,9 @@ public class PolicyAuthorizationServiceTest {
 
         EntityDefinitionPolicyAuthorizationService service = new EntityDefinitionPolicyAuthorizationService(structure, authorizer);
 
-        CompletableFuture<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
+        Future<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
 
-        assertDoesNotThrow(result::join); // Should pass since the READ operation policy is allowed
+        assertDoesNotThrow(() -> { result.await(); }); // Should pass since the READ operation policy is allowed
     }
 
     @Test
@@ -66,11 +65,10 @@ public class PolicyAuthorizationServiceTest {
 
         EntityDefinitionPolicyAuthorizationService service = new EntityDefinitionPolicyAuthorizationService(structure, authorizer);
 
-        CompletableFuture<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
+        Future<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
 
-        Throwable exception = assertThrows(CompletionException.class, result::join);
-        assertInstanceOf(AuthorizationException.class, exception.getCause());
-        assertTrue(exception.getCause().getMessage().endsWith("Entity access not allowed.")); // Fails due to policy2
+        AuthorizationException exception = assertThrows(AuthorizationException.class, result::await);
+        assertTrue(exception.getMessage().endsWith("Entity access not allowed.")); // Fails due to policy2
     }
 
     @Test
@@ -78,9 +76,9 @@ public class PolicyAuthorizationServiceTest {
         EntityDefinition entityDefinition = createStructureWithNoFieldPolicies();
         EntityDefinitionPolicyAuthorizationService service = new EntityDefinitionPolicyAuthorizationService(entityDefinition, authorizer);
 
-        CompletableFuture<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
+        Future<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
 
-        assertDoesNotThrow(result::join); // Should pass since the READ operation policy is allowed
+        assertDoesNotThrow(() -> { result.await(); }); // Should pass since the READ operation policy is allowed
     }
 
     @Test
@@ -88,11 +86,10 @@ public class PolicyAuthorizationServiceTest {
         EntityDefinition entityDefinition = createStructureWithNoFieldPolicies();
         EntityDefinitionPolicyAuthorizationService service = new EntityDefinitionPolicyAuthorizationService(entityDefinition, authorizer);
 
-        CompletableFuture<Void> result = service.authorize(EntityOperation.SAVE, null);
+        Future<Void> result = service.authorize(EntityOperation.SAVE, null);
 
-        Throwable exception = assertThrows(CompletionException.class, result::join);
-        assertInstanceOf(AuthorizationException.class, exception.getCause());
-        assertTrue(exception.getCause().getMessage().contains("Operation SAVE not allowed.")); // Fails due to policy2
+        AuthorizationException exception = assertThrows(AuthorizationException.class, result::await);
+        assertTrue(exception.getMessage().contains("Operation SAVE not allowed.")); // Fails due to policy2
     }
 
     @Test
@@ -100,11 +97,10 @@ public class PolicyAuthorizationServiceTest {
         EntityDefinition entityDefinition = createStructureWithFieldPolicies();
         EntityDefinitionPolicyAuthorizationService service = new EntityDefinitionPolicyAuthorizationService(entityDefinition, authorizer);
 
-        CompletableFuture<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
+        Future<Void> result = service.authorize(EntityOperation.FIND_ALL, null);
 
-        Throwable exception = assertThrows(CompletionException.class, result::join);
-        assertInstanceOf(AuthorizationException.class, exception.getCause());
-        assertEquals("testorganization.testapplication.testname Fields [lastName] access not allowed.", exception.getCause().getMessage());
+        AuthorizationException exception = assertThrows(AuthorizationException.class, result::await);
+        assertEquals("testorganization.testapplication.testname Fields [lastName] access not allowed.", exception.getMessage());
     }
 
     @Test
@@ -112,11 +108,10 @@ public class PolicyAuthorizationServiceTest {
         EntityDefinition entityDefinition = createStructureWithFieldPolicies();
         EntityDefinitionPolicyAuthorizationService service = new EntityDefinitionPolicyAuthorizationService(entityDefinition, authorizer);
 
-        CompletableFuture<Void> result = service.authorize(EntityOperation.SAVE, null);
+        Future<Void> result = service.authorize(EntityOperation.SAVE, null);
 
-        Throwable exception = assertThrows(CompletionException.class, result::join);
-        assertInstanceOf(AuthorizationException.class, exception.getCause());
-        assertTrue(exception.getCause().getMessage().contains("Operation SAVE not allowed."));
+        AuthorizationException exception = assertThrows(AuthorizationException.class, result::await);
+        assertTrue(exception.getMessage().contains("Operation SAVE not allowed."));
     }
 
     private EntityDefinition createStructureWithNoFieldPolicies() {
@@ -205,7 +200,7 @@ public class PolicyAuthorizationServiceTest {
 
     private static class MockPolicyAuthorizer implements PolicyAuthorizer {
         @Override
-        public CompletableFuture<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext) {
+        public Future<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext) {
             for (PolicyAuthorizationRequest request : requests) {
                 switch (request.policy()) {
                     case "policy1", "policy4", "policy5", "policy6" -> request.authorize(); // Authorized policies
@@ -213,7 +208,7 @@ public class PolicyAuthorizationServiceTest {
                     default -> request.deny(); // Default deny
                 }
             }
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
     }
 }

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/security/graphos/PolicyEvaluatorTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/security/graphos/PolicyEvaluatorTests.java
@@ -1,5 +1,6 @@
 package org.kinotic.test.tests.core.security.graphos;
 
+import io.vertx.core.Future;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kinotic.persistence.api.model.EntityContext;
@@ -9,7 +10,6 @@ import org.kinotic.persistence.api.services.security.graphos.PolicyAuthorizer;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -43,14 +43,14 @@ public class PolicyEvaluatorTests {
     }
 
     @Test
-    public void testPolicyEvaluatorWithFailedOperations() throws Exception {
+    public void testPolicyEvaluatorWithFailedOperations() {
         List<List<String>> operationPolicies = List.of(
                 List.of("policy1", "policy2") // AND group
         );
 
         PolicyEvaluator evaluator = new PolicyEvaluatorWithOperation(authorizer, sharedPolicyManager, operationPolicies);
 
-        AuthorizationResult result = evaluator.evaluatePolicies(null).get();
+        AuthorizationResult result = evaluator.evaluatePolicies(null).await();
 
         assertFalse(result.operationAllowed()); // Operation policies are not satisfied
         assertTrue(result.entityAllowed());     // Domain policy is satisfied
@@ -61,7 +61,7 @@ public class PolicyEvaluatorTests {
     }
 
     @Test
-    public void testPolicyEvaluatorWithMissingDomainPolicy() throws Exception {
+    public void testPolicyEvaluatorWithMissingDomainPolicy() {
         List<List<String>> operationPolicies = List.of(
                 List.of("policy1", "policy3") // AND group
         );
@@ -70,7 +70,7 @@ public class PolicyEvaluatorTests {
         SharedPolicyManager modifiedPolicyManager = new SharedPolicyManager(null, sharedPolicyManager.getFieldPolicies());
         PolicyEvaluator evaluator = new PolicyEvaluatorWithOperation(authorizer, modifiedPolicyManager, operationPolicies);
 
-        AuthorizationResult result = evaluator.evaluatePolicies(null).get();
+        AuthorizationResult result = evaluator.evaluatePolicies(null).await();
 
         assertTrue(result.operationAllowed()); // Operation policies are satisfied
         assertTrue(result.entityAllowed());   // Domain policy is missing
@@ -81,7 +81,7 @@ public class PolicyEvaluatorTests {
     }
 
     @Test
-    public void testPolicyEvaluatorWithSuccessfulLastName() throws Exception {
+    public void testPolicyEvaluatorWithSuccessfulLastName() {
         List<List<String>> operationPolicies = List.of(
                 List.of("policy1", "policy3") // AND group
         );
@@ -89,7 +89,7 @@ public class PolicyEvaluatorTests {
         // Update MockPolicyAuthorizer to authorize policy7 for this test
         PolicyAuthorizer updatedAuthorizer = new PolicyAuthorizer() {
             @Override
-            public CompletableFuture<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext) {
+            public Future<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext) {
                 for (PolicyAuthorizationRequest request : requests) {
                     if ("policy1".equals(request.policy()) ||
                             "policy3".equals(request.policy()) ||
@@ -101,13 +101,13 @@ public class PolicyEvaluatorTests {
                         request.deny();
                     }
                 }
-                return CompletableFuture.completedFuture(null);
+                return Future.succeededFuture();
             }
         };
 
         PolicyEvaluator evaluator = new PolicyEvaluatorWithOperation(updatedAuthorizer, sharedPolicyManager, operationPolicies);
 
-        AuthorizationResult result = evaluator.evaluatePolicies(null).get();
+        AuthorizationResult result = evaluator.evaluatePolicies(null).await();
 
         assertTrue(result.operationAllowed()); // Operation policies are satisfied
         assertTrue(result.entityAllowed());    // Domain policy is satisfied
@@ -118,14 +118,14 @@ public class PolicyEvaluatorTests {
     }
 
     @Test
-    public void testPolicyEvaluatorWithSuccessfulOperations() throws Exception {
+    public void testPolicyEvaluatorWithSuccessfulOperations() {
         List<List<String>> operationPolicies = List.of(
                 List.of("policy1", "policy3") // AND group
         );
 
         PolicyEvaluator evaluator = new PolicyEvaluatorWithOperation(authorizer, sharedPolicyManager, operationPolicies);
 
-        AuthorizationResult result = evaluator.evaluatePolicies(null).get();
+        AuthorizationResult result = evaluator.evaluatePolicies(null).await();
 
         assertTrue(result.operationAllowed()); // Operation policies are satisfied
         assertTrue(result.entityAllowed());    // Domain policy is satisfied
@@ -136,10 +136,10 @@ public class PolicyEvaluatorTests {
     }
 
     @Test
-    public void testPolicyEvaluatorWithoutOperations() throws Exception {
+    public void testPolicyEvaluatorWithoutOperations() {
         PolicyEvaluator evaluator = new PolicyEvaluatorWithoutOperation(authorizer, sharedPolicyManager);
 
-        AuthorizationResult result = evaluator.evaluatePolicies(null).get();
+        AuthorizationResult result = evaluator.evaluatePolicies(null).await();
 
         assertTrue(result.operationAllowed()); // No operation policies mean it's always allowed
         assertTrue(result.entityAllowed());    // Domain policy is satisfied
@@ -163,7 +163,7 @@ public class PolicyEvaluatorTests {
     // Mock Implementation for PolicyAuthorizer
     private static class MockPolicyAuthorizer implements PolicyAuthorizer {
         @Override
-        public CompletableFuture<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext) {
+        public Future<Void> authorize(List<PolicyAuthorizationRequest> requests, EntityContext entityContext) {
             for (PolicyAuthorizationRequest request : requests) {
                 // Authorize specific policies for testing
                 if ("policy1".equals(request.policy()) ||
@@ -175,7 +175,7 @@ public class PolicyEvaluatorTests {
                     request.deny();
                 }
             }
-            return CompletableFuture.completedFuture(null);
+            return Future.succeededFuture();
         }
     }
 }

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/support/TestHelper.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/support/TestHelper.java
@@ -1,6 +1,8 @@
 package org.kinotic.test.tests.core.support;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.persistence.api.model.EntityContext;
@@ -22,7 +24,6 @@ import tools.jackson.databind.util.TokenBuffer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 @Component
@@ -48,25 +49,19 @@ public class TestHelper {
      * {@link KinoticTestBase#TEST_ORGANIZATION_PARTICIPANT} bound, so that org-scoped
      * services resolve {@link KinoticTestBase#TEST_ORG_ID} from the current participant.
      */
-    public <T> CompletableFuture<T> runAsOrganization(Supplier<CompletableFuture<T>> supplier) {
-        CompletableFuture<T> result = new CompletableFuture<>();
+    public <T> Future<T> runAsOrganization(Supplier<Future<T>> supplier) {
+        Promise<T> promise = Promise.promise();
         Context context = vertx.getOrCreateContext();
         context.runOnContext(v -> {
             securityContext.setParticipant(context, KinoticTestBase.TEST_ORGANIZATION_PARTICIPANT);
             try {
-                supplier.get().whenComplete((value, error) -> {
-                    if (error != null) {
-                        result.completeExceptionally(error);
-                    } else {
-                        result.complete(value);
-                    }
-                });
+                supplier.get().onComplete(promise);
             } catch (Throwable t) {
-                // a service that throws synchronously would otherwise leave result uncompleted, hanging the test
-                result.completeExceptionally(t);
+                // a service that throws synchronously would otherwise leave the promise uncompleted, hanging the test
+                promise.fail(t);
             }
         });
-        return result;
+        return promise.future();
     }
 
 
@@ -101,35 +96,35 @@ public class TestHelper {
         return ret;
     }
 
-    public CompletableFuture<Void> bulkUpdateCarsAsRawJson(List<Car> cars, EntityDefinition entityDefinition, EntityContext entityContext){
+    public Future<Void> bulkUpdateCarsAsRawJson(List<Car> cars, EntityDefinition entityDefinition, EntityContext entityContext){
         TokenBuffer tokenBuffer = new TokenBuffer(objectMapper._serializationContext(), false);
         try {
             tokenBuffer.writePOJO(cars);
         } catch (JacksonException e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
         return runAsOrganization(() -> entitiesService.bulkUpdate(entityDefinition.getId(), tokenBuffer, entityContext));
     }
 
-    public CompletableFuture<Void> bulkSaveCarsAsRawJson(List<Car> cars, EntityDefinition entityDefinition, EntityContext entityContext){
+    public Future<Void> bulkSaveCarsAsRawJson(List<Car> cars, EntityDefinition entityDefinition, EntityContext entityContext){
         TokenBuffer tokenBuffer = new TokenBuffer(objectMapper._serializationContext(), false);
         try {
             tokenBuffer.writePOJO(cars);
         } catch (JacksonException e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
         return runAsOrganization(() -> entitiesService.bulkSave(entityDefinition.getId(), tokenBuffer, entityContext));
     }
 
-    public CompletableFuture<Car> saveCarAsRawJson(Car car, EntityDefinition entityDefinition, EntityContext entityContext){
+    public Future<Car> saveCarAsRawJson(Car car, EntityDefinition entityDefinition, EntityContext entityContext){
         TokenBuffer tokenBuffer = new TokenBuffer(objectMapper._serializationContext(), false);
         try {
             tokenBuffer.writePOJO(car);
         } catch (JacksonException e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
         return runAsOrganization(() -> entitiesService.save(entityDefinition.getId(), tokenBuffer, entityContext))
-                                 .thenApply(saved -> {
+                                 .map(saved -> {
                                   try (JsonParser parser = saved.asParser()) {
                                       return objectMapper.readValue(parser, Car.class);
                                   } catch (JacksonException e) {
@@ -139,16 +134,16 @@ public class TestHelper {
     }
 
 
-    public CompletableFuture<Car> updateCarAsRawJson(Car car, EntityDefinition entityDefinition, EntityContext entityContext){
+    public Future<Car> updateCarAsRawJson(Car car, EntityDefinition entityDefinition, EntityContext entityContext){
         TokenBuffer tokenBuffer = new TokenBuffer(objectMapper._serializationContext(), false);
         try {
             tokenBuffer.writePOJO(car);
         } catch (JacksonException e) {
-            return CompletableFuture.failedFuture(e);
+            return Future.failedFuture(e);
         }
 
         return runAsOrganization(() -> entitiesService.update(entityDefinition.getId(), tokenBuffer, entityContext))
-                                 .thenApply(saved -> {
+                                 .map(saved -> {
                                   try (JsonParser parser = saved.asParser()) {
                                       return objectMapper.readValue(parser, Car.class);
                                   } catch (JacksonException e) {
@@ -169,72 +164,70 @@ public class TestHelper {
                                                                            boolean randomPeople,
                                                                            EntityContext entityContext,
                                                                            String structureNameSuffix){
-        return Mono.fromFuture(() -> runAsOrganization(() -> testDataService
+        return Mono.fromCompletionStage(() -> runAsOrganization(() -> testDataService
                 .createPersonEntityDefinitionIfNotExists(structureNameSuffix)
-                .thenCompose(pair -> createTestPeopleWithCorrectMethod(numberOfPeopleToCreate, randomPeople)
-                                             .thenCompose(people -> {
+                .compose(pair -> createTestPeopleWithCorrectMethod(numberOfPeopleToCreate, randomPeople)
+                                             .compose(people -> {
                                                  EntityDefinition entityDefinition = pair.getLeft();
-                                                 List<CompletableFuture<Person>> completableFutures = new ArrayList<>();
+                                                 List<Future<Person>> futures = new ArrayList<>();
                                                  for(Person person : people){
                                                      try (TokenBuffer tokenBuffer = new TokenBuffer(objectMapper._serializationContext(), false)) {
                                                          tokenBuffer.writePOJO(person);
-                                                         completableFutures.add(entitiesService.save(entityDefinition.getId(),
-                                                                                                     tokenBuffer,
-                                                                                                     entityContext)
-                                                                                               .thenCompose(saved -> {
-                                                                                                   try (JsonParser parser = saved.asParser()) {
-                                                                                                       Person deserializedPerson = objectMapper.readValue(parser,
-                                                                                                                                                          Person.class);
-                                                                                                       return CompletableFuture.completedFuture(deserializedPerson);
-                                                                                                   } catch (JacksonException e) {
-                                                                                                       return CompletableFuture.failedFuture(e);
-                                                                                                   }
-                                                                                               }));
+                                                         futures.add(entitiesService.save(entityDefinition.getId(),
+                                                                                          tokenBuffer,
+                                                                                          entityContext)
+                                                                                    .compose(saved -> {
+                                                                                        try (JsonParser parser = saved.asParser()) {
+                                                                                            Person deserializedPerson = objectMapper.readValue(parser,
+                                                                                                                                               Person.class);
+                                                                                            return Future.succeededFuture(deserializedPerson);
+                                                                                        } catch (JacksonException e) {
+                                                                                            return Future.failedFuture(e);
+                                                                                        }
+                                                                                    }));
                                                      } catch (JacksonException e) {
-                                                         return CompletableFuture.failedFuture(e);
+                                                         return Future.failedFuture(e);
                                                      }
                                                  }
-                                                 return CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0]))
-                                                                         .thenApply(v -> {
-                                                                             StructureAndPersonHolder holder = new StructureAndPersonHolder();
-                                                                             holder.setEntityDefinition(entityDefinition);
-                                                                             for(CompletableFuture<Person> future : completableFutures){
-                                                                                 holder.addPerson(future.join());
-                                                                             }
-                                                                             return holder;
-                                                                         });
-                                             }))));
+                                                 return Future.all(futures)
+                                                              .map(cf -> {
+                                                                  StructureAndPersonHolder holder = new StructureAndPersonHolder();
+                                                                  holder.setEntityDefinition(entityDefinition);
+                                                                  for(Person person : cf.<Person>list()){
+                                                                      holder.addPerson(person);
+                                                                  }
+                                                                  return holder;
+                                                              });
+                                             }))).toCompletionStage());
     }
 
     public Mono<StructureAndPersonHolder> createPersonStructureAndEntitiesBulk(int numberOfPeopleToCreate,
                                                                                boolean randomPeople,
                                                                                EntityContext entityContext,
                                                                                String structureNameSuffix){
-        return Mono.fromFuture(() -> runAsOrganization(() -> testDataService
+        return Mono.fromCompletionStage(() -> runAsOrganization(() -> testDataService
                 .createPersonEntityDefinitionIfNotExists(structureNameSuffix)
-                .thenCompose(pair -> createTestPeopleWithCorrectMethod(numberOfPeopleToCreate, randomPeople)
-                                             .thenCompose(people -> {
+                .compose(pair -> createTestPeopleWithCorrectMethod(numberOfPeopleToCreate, randomPeople)
+                                             .compose(people -> {
                                                  EntityDefinition entityDefinition = pair.getLeft();
                                                  TokenBuffer tokenBuffer = new TokenBuffer(objectMapper._serializationContext(), false);
                                                  try {
                                                      tokenBuffer.writePOJO(people);
                                                  } catch (JacksonException e) {
-                                                     return CompletableFuture.failedFuture(e);
+                                                     return Future.failedFuture(e);
                                                  }
 
                                                  return entitiesService.bulkSave(entityDefinition.getId(),
                                                                                  tokenBuffer,
                                                                                  entityContext)
-                                                                       .thenCompose(unused -> CompletableFuture
-                                                                 .completedFuture(new StructureAndPersonHolder(
-                                                                         entityDefinition,
-                                                                         people)));
-                                             }))));
+                                                                       .map(new StructureAndPersonHolder(entityDefinition,
+                                                                                                         people));
+                                             }))).toCompletionStage());
     }
 
 
-    private CompletableFuture<List<Person>> createTestPeopleWithCorrectMethod(int numberOfPeopleToCreate,
-                                                                              boolean randomPeople){
+    private Future<List<Person>> createTestPeopleWithCorrectMethod(int numberOfPeopleToCreate,
+                                                                   boolean randomPeople){
         if(randomPeople){
             return testDataService.createRandomTestPeople(numberOfPeopleToCreate);
         }else {

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -59,10 +59,10 @@ The input schema's property names are the service interface's Java parameter nam
 public interface CrudService<T, ID> {
 
     @McpToolInfo(readOnlyHint = true)
-    CompletableFuture<T> findById(ID id);
+    Future<T> findById(ID id);
 
     @McpToolInfo(destructiveHint = true, idempotentHint = true)
-    CompletableFuture<Void> deleteById(ID id);
+    Future<Void> deleteById(ID id);
 }
 ```
 
@@ -109,12 +109,12 @@ Every hint is always written to the wire, which matters most for `openWorldHint`
 
 ```java
 @McpTool(openWorldHint = true)
-CompletableFuture<Project> retryRepoInitialization(String projectId);
+Future<Project> retryRepoInitialization(String projectId);
 ```
 
 Nothing in a function's name says whether it calls out, so `openWorldHint` is never inferred — only a declaration sets it.
 
-A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool — registration fails with an error naming the function. Single-value async returns (`CompletableFuture`, `Mono`) are fine.
+A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool — registration fails with an error naming the function. Single-value async returns (`Future`, `CompletableFuture`, `Mono`) are fine.
 
 ## Tool naming
 


### PR DESCRIPTION
## Summary

Migrate the codebase from Java's `CompletableFuture` to Vert.x's `Future` API across all service layers, repositories, and test utilities. This ensures consistent async handling within the Vert.x event loop context and prevents context loss when composing async operations.

## Key Changes

- **Service interfaces and implementations**: Updated return types in `EntityService`, `EntitiesService`, `CrudService`, `IdentifiableCrudService`, and all domain/persistence service implementations to return `Future<T>` instead of `CompletableFuture<T>`
- **Repository layer**: Converted `AbstractRepository`, `AbstractOrganizationScopedRepository`, `AbstractApplicationScopedRepository`, `AbstractProjectScopedRepository`, and all concrete repository implementations to use `Future`
- **CRUD service template**: Updated `CrudServiceTemplate.appendToDataStream()` and related methods to return `Future` instead of `CompletableFuture`
- **Test utilities**: Modified `TestHelper.runAsOrganization()` to work with `Future` and use `Promise` for context-aware completion
- **Import cleanup**: Removed `java.util.concurrent.CompletableFuture` imports and added `io.vertx.core.Future` imports across all modified files
- **Composition operators**: Changed `.thenCompose()` to `.compose()` and `.thenApply()` to `.map()` to match Vert.x Future API
- **Test assertions**: Updated test code to use `Mono.fromCompletionStage()` where needed for Reactor integration

## Implementation Details

The migration preserves all existing behavior while ensuring operations remain bound to the Vert.x event loop context. This prevents `SecurityContext` and other context-local values from being lost when async operations complete on foreign threads (e.g., from Azure SDK, Caffeine loaders, or JDK executors).

All service method signatures now consistently use `Future<T>` as the return type, making the async contract explicit and leveraging Vert.x's context-aware composition semantics.

https://claude.ai/code/session_01HD8QK1RPbkcrThxbTJpjbg