### PR TITLE
Drop the refresh wait from the VmNode heartbeat write

### DIFF
--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeOrchestrationService.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/internal/api/services/DefaultVmNodeOrchestrationService.java
@@ -95,16 +95,23 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
 
         return vmNodeService.findById(nodeId)
                 .compose(node -> {
+                    Future<VmNode> ret;
                     if (node == null) {
-                        return Future.failedFuture(
+                        ret = Future.failedFuture(
                                 new IllegalArgumentException("Node not registered: " + nodeId));
-                    }
-                    node.setLastSeen(new Date());
-                    if (node.getStatus() == VmNodeStatus.OFFLINE) {
+                    } else if (node.getStatus() == VmNodeStatus.OFFLINE) {
                         log.info("VmNode {} came back online", nodeId);
                         node.setStatus(VmNodeStatus.ONLINE);
+                        // findAvailableNode selects on status with a search, so the recovered node
+                        // has to be refreshed into the index before it can be scheduled onto
+                        ret = vmNodeService.saveSync(node);
+                    } else {
+                        // lastSeen is stamped by DefaultVmNodeService.beforeSave. Only checkNodeHealth
+                        // reads it, via a search against a heartbeatTimeoutSeconds cutoff, so a
+                        // refresh wait costs the caller the index refresh interval and buys nothing.
+                        ret = vmNodeService.save(node);
                     }
-                    return vmNodeService.saveSync(node);
+                    return ret;
                 });
     }
 


### PR DESCRIPTION
Heartbeat requests were taking ~1s. Tempo traces show the cost is entirely in the index write, and it isn't work — it's a timer.

```
kinotic-server  system~...VmNodeOrchestrationService    834.01ms / 937.52ms / 1.01s
├─ get (1.76ms)      → elasticsearch GET (1.45ms)
└─ index (831.85ms)  → elasticsearch PUT (831.55ms)   ← clusters at exactly 1s
```

## Cause

`heartbeat` wrote through `saveSync`:

```java
// kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java:654
public <T> Future<IndexResponse> saveSync(String indexName, String id, T document,
                                          Consumer<IndexRequest.Builder<T>> builderConsumer) {
    return save(indexName, id, document, builder -> {
        if (builderConsumer != null) { builderConsumer.accept(builder); }
        builder.refresh(Refresh.WaitFor);   // PUT parks until the next scheduled refresh
    });
}
```

The document indexes in ~1ms, then the request blocks until Elasticsearch's `refresh_interval` (default 1s) fires. That is why the span duration lands wherever in the refresh cycle the request happened to arrive — 831ms, 933ms, 1.01s.

## Why the heartbeat path does not need it

Neither read on this path requires a refreshed index.

```java
// CrudServiceTemplate.java:463 — findById builds a GetRequest, not a SearchRequest
GetRequest.Builder builder = new GetRequest.Builder();   // realtime: reads the translog
```

And the only consumer of `lastSeen` is `checkNodeHealth`, which searches against a 90s cutoff on a 30s timer:

```java
// kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/config/VmNodeProperties.java:21
private long heartbeatTimeoutSeconds = 90;
private long healthCheckIntervalSeconds = 30;
```

Sub-second index staleness is invisible to a 90s cutoff.

## Change

```java
// DefaultVmNodeOrchestrationService.java:93
} else if (node.getStatus() == VmNodeStatus.OFFLINE) {
    log.info("VmNode {} came back online", nodeId);
    node.setStatus(VmNodeStatus.ONLINE);
    ret = vmNodeService.saveSync(node);   // findOnlineNodes() selects on status via search
} else {
    ret = vmNodeService.save(node);       // refresh=false — returns once durable
}
```

`OFFLINE -> ONLINE` keeps `saveSync`, because `findAvailableNode` reaches the node through a real search on `status` and a recovered node should be schedulable immediately. The steady-state tick — every 30s per node, `VmManagerConfig.ts:16` — becomes a GET plus an unblocked PUT.

**~835ms -> ~5ms** per heartbeat.

Also removed a redundant line from `heartbeat`:

```java
node.setLastSeen(new Date());   // deleted
```

```java
// DefaultVmNodeService.java:38 — beforeSave already stamps it, on every write path
protected Future<Void> beforeSave(VmNode entity) {
    Validate.notNull(entity, "VmNode cannot be null");
    Validate.notNull(entity.getId(), "VmNode id cannot be null");
    entity.setLastSeen(new Date());
    return Future.succeededFuture();
}
```

`AbstractCrudService` routes `save`, `saveSync`, `create`, and `createSync` through `beforeSave`, so the explicit set was immediately overwritten a few microseconds later.

## Notes

This lowers false-offline risk rather than raising it. The old code spent ~1s of the node's 90s budget inside the call the vm-manager was awaiting; that budget now goes to the network round trip instead of an ES refresh timer.

`reportWorkloadStatus` fires immediately after each heartbeat with a full snapshot (`vm-manager/src/index.ts:44`), but `applyStatusReport` returns early on unchanged status before writing, so the snapshot costs GETs and no `saveSync`. Left unchanged.

No docs affected — `docs/ServerPlaneArchitecture.md:309` covers the interval/timeout contract, not refresh semantics.

## Testing

`./gradlew :kinotic-orchestrator:compileJava` — BUILD SUCCESSFUL. Behavioral verification is the Tempo trace after deploy: the `index` span should drop out of the flame graph.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMahoP4CTj3iZ5rtyNeSCs

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMahoP4CTj3iZ5rtyNeSCs)_