### PR TITLE
Name spans for the service, not its full address

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -369,9 +369,6 @@ public class ServiceInvocationSupervisor {
         // The path is the method id, carrying the leading / the method map is keyed by
         String methodName = incomingEvent.cri().path().substring(1);
         String serviceName = serviceDescriptor.serviceIdentifier().qualifiedName();
-        // Named for the simple service name: the zone and package are identical across a node's
-        // services, so a fully qualified name pushes the only distinguishing part out of view in a
-        // trace list. The full name stays on rpc.service.
         return tracer.spanBuilder(serviceDescriptor.serviceIdentifier().name() + "/" + methodName)
                      .setParent(parent)
                      .setSpanKind(SpanKind.SERVER)

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -369,8 +369,10 @@ public class ServiceInvocationSupervisor {
         // The path is the method id, carrying the leading / the method map is keyed by
         String methodName = incomingEvent.cri().path().substring(1);
         String serviceName = serviceDescriptor.serviceIdentifier().qualifiedName();
-
-        return tracer.spanBuilder(serviceName + "/" + methodName)
+        // Named for the simple service name: the zone and package are identical across a node's
+        // services, so a fully qualified name pushes the only distinguishing part out of view in a
+        // trace list. The full name stays on rpc.service.
+        return tracer.spanBuilder(serviceDescriptor.serviceIdentifier().name() + "/" + methodName)
                      .setParent(parent)
                      .setSpanKind(SpanKind.SERVER)
                      .setAttribute(TelemetryUtil.RPC_SYSTEM, TelemetryUtil.SYSTEM_VALUE)

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
@@ -180,7 +180,6 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
      */
     private Span startInvocationSpan(Method method, String scope){
         String serviceName = serviceIdentifier.qualifiedName();
-        // Simple name here, fully qualified on rpc.service — see ServiceInvocationSupervisor
         Span ret = tracer.spanBuilder(serviceIdentifier.name() + "/" + method.getName())
                          .setSpanKind(SpanKind.CLIENT)
                          .setAttribute(TelemetryUtil.RPC_SYSTEM, TelemetryUtil.SYSTEM_VALUE)

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
@@ -180,7 +180,8 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
      */
     private Span startInvocationSpan(Method method, String scope){
         String serviceName = serviceIdentifier.qualifiedName();
-        Span ret = tracer.spanBuilder(serviceName + "/" + method.getName())
+        // Simple name here, fully qualified on rpc.service — see ServiceInvocationSupervisor
+        Span ret = tracer.spanBuilder(serviceIdentifier.name() + "/" + method.getName())
                          .setSpanKind(SpanKind.CLIENT)
                          .setAttribute(TelemetryUtil.RPC_SYSTEM, TelemetryUtil.SYSTEM_VALUE)
                          .setAttribute(TelemetryUtil.RPC_SERVICE, serviceName)

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/ServiceInvocationTracingTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/ServiceInvocationTracingTests.java
@@ -64,7 +64,6 @@ public class ServiceInvocationTracingTests {
         Assertions.assertEquals(SpanKind.SERVER, span.getKind());
         Assertions.assertEquals("kinotic", span.getAttributes().get(RPC_SYSTEM));
         Assertions.assertEquals("getMonoWithValue", span.getAttributes().get(RPC_METHOD));
-        // Short enough to read in a trace list, while rpc.service keeps the addressable name
         Assertions.assertEquals("RpcTestService/getMonoWithValue", span.getName());
         Assertions.assertTrue(span.getAttributes().get(RPC_SERVICE).endsWith("RpcTestService"),
                               "rpc.service must carry the fully qualified name");

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/ServiceInvocationTracingTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/ServiceInvocationTracingTests.java
@@ -64,7 +64,10 @@ public class ServiceInvocationTracingTests {
         Assertions.assertEquals(SpanKind.SERVER, span.getKind());
         Assertions.assertEquals("kinotic", span.getAttributes().get(RPC_SYSTEM));
         Assertions.assertEquals("getMonoWithValue", span.getAttributes().get(RPC_METHOD));
-        Assertions.assertEquals(span.getAttributes().get(RPC_SERVICE) + "/getMonoWithValue", span.getName());
+        // Short enough to read in a trace list, while rpc.service keeps the addressable name
+        Assertions.assertEquals("RpcTestService/getMonoWithValue", span.getName());
+        Assertions.assertTrue(span.getAttributes().get(RPC_SERVICE).endsWith("RpcTestService"),
+                              "rpc.service must carry the fully qualified name");
     }
 
     @Test

--- a/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
@@ -249,8 +249,6 @@ export class ServiceInvocationSupervisor {
         }
 
         const serviceName = this.serviceIdentifier.qualifiedName()
-        // Named for the simple service name: the zone and namespace repeat across every service, so
-        // a fully qualified name pushes the method out of view in a trace list. rpc.service keeps it.
         return this.tracer.startSpan(`${this.serviceIdentifier.name}/${methodName}`,
                                      {
                                          kind: SpanKind.SERVER,

--- a/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
@@ -249,7 +249,9 @@ export class ServiceInvocationSupervisor {
         }
 
         const serviceName = this.serviceIdentifier.qualifiedName()
-        return this.tracer.startSpan(`${serviceName}/${methodName}`,
+        // Named for the simple service name: the zone and namespace repeat across every service, so
+        // a fully qualified name pushes the method out of view in a trace list. rpc.service keeps it.
+        return this.tracer.startSpan(`${this.serviceIdentifier.name}/${methodName}`,
                                      {
                                          kind: SpanKind.SERVER,
                                          attributes: {


### PR DESCRIPTION
Every row of a trace list reads the same, because the only part that identifies the call is the part that gets truncated away:

```
system~org.kinotic.orchestrator.api.servic…      what the Trace Name column shows
system~org.kinotic.orchestrator.api.services.IVmNodeService/findAll
└──────────────── identical across a node's services ────────────┘└─ the part you need
```

## Change

The span name is the simple service name and the method, in all three places that name one — the supervisor (SERVER), the RPC proxy (CLIENT), and the TypeScript supervisor — so both halves of a call still match:

```java
// ServiceInvocationSupervisor
return tracer.spanBuilder(serviceDescriptor.serviceIdentifier().name() + "/" + methodName)
```
```
IVmNodeService/findAll
```

The addressable name is unchanged and still queryable, on the attribute where length costs nothing:

```java
.setAttribute(TelemetryUtil.RPC_SERVICE, serviceName)   // system~org.kinotic…IVmNodeService
```

Tempo's span-metrics `span_name` label shortens with it, so the dashboard's span panels get a readable legend rather than a column of identical prefixes.

## Trade-off

OTel's RPC convention suggests the fully qualified `{rpc.service}/{rpc.method}` as the span name, which is what gRPC emits. This deviates deliberately: a name nothing can read is worse than a convention kept. Two services sharing a simple name across packages look alike in a list and are told apart by `rpc.service`.

## Verification

The test encodes the contract directly rather than deriving the name from the attribute:

```java
Assertions.assertEquals("RpcTestService/getMonoWithValue", span.getName());
Assertions.assertTrue(span.getAttributes().get(RPC_SERVICE).endsWith("RpcTestService"),
                      "rpc.service must carry the fully qualified name");
```

76 tests, 0 failed, run against the current `develop` — which includes #437's `CompletableFuture` to Vert.x `Future` refactor, touching the same files. TypeScript typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7wR4j1JKAE1ZAvqcGZxSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7wR4j1JKAE1ZAvqcGZxSM)_