### PR TITLE
Point the client default host at the deployed domain; fix two doc bugs

### DIFF
--- a/kinotic-js/workspace/packages/core/src/api/ConnectOptions.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ConnectOptions.ts
@@ -62,7 +62,7 @@ export enum SessionKeepAliveMode {
  * Options for {@link IKinotic#connect}. Every field is optional: absent {@link server}
  * fields resolve from the environment (the {@code KINOTIC_SERVER_HOST} /
  * {@code KINOTIC_SERVER_PORT} / {@code KINOTIC_SERVER_USE_SSL} variables, the browser's own
- * location, then {@code https://api.kinotic.com}), and absent {@link credentials} resolve
+ * location, then {@code https://api.kinotic.ai}), and absent {@link credentials} resolve
  * through the default {@link ChainedCredentialsResolver} (environment variables, then the
  * browser session).
  *

--- a/kinotic-js/workspace/packages/core/src/internal/api/Util.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/Util.ts
@@ -9,7 +9,7 @@ import {SessionCredentialsResolver} from '@/api/security/SessionCredentialsResol
 const DEFAULT_PORT = 58503
 
 /** Where a fully unconfigured client connects: the Kinotic cloud. */
-const DEFAULT_HOST = 'api.kinotic.com'
+const DEFAULT_HOST = 'api.kinotic.ai'
 
 /**
  * Static utility functions used across the Kinoitc core runtime.
@@ -53,7 +53,7 @@ export class Util {
      * Fills every absent {@link ConnectOptions} field from the environment. Server fields
      * resolve explicit value → {@code KINOTIC_SERVER_HOST/PORT/USE_SSL} → the browser's own
      * location (only when the host itself came from the location, so an explicit cross-origin
-     * host never inherits the page's port) → {@code https://api.kinotic.com}. Absent
+     * host never inherits the page's port) → {@code https://api.kinotic.ai}. Absent
      * credentials get the default chain: environment variables, then the browser session.
      */
     public static resolveConnectOptions(options?: ConnectOptions): ConnectOptions {

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ApplicationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ApplicationService.java
@@ -32,8 +32,9 @@ public interface ApplicationService extends IdentifiableCrudService<Application,
      * Returns the enabled OIDC configurations registered on the given application.
      *
      * @param applicationId the id of the application
-     * @return the enabled configurations, or an empty list if the application is not
-     *         found or has no configurations attached
+     * @return the enabled configurations, or an empty list if the application has no
+     *         configurations attached; fails when the id names no application in the
+     *         caller's organization
      */
     Future<List<OidcConfiguration>> getOidcConfigurations(String applicationId);
 

--- a/website/content/01.apps/02.quick-start.md
+++ b/website/content/01.apps/02.quick-start.md
@@ -101,7 +101,7 @@ Kinotic.use(PersistencePlugin)
 Kinotic.zonePrefix = appZone(config.organizationId, config.applicationId)
 
 // server and credentials resolve from the environment: KINOTIC_SERVER_HOST/PORT/USE_SSL,
-// KINOTIC_CLIENT_ID/KINOTIC_CLIENT_SECRET — https://api.kinotic.com when nothing is set
+// KINOTIC_CLIENT_ID/KINOTIC_CLIENT_SECRET — https://api.kinotic.ai when nothing is set
 await Kinotic.connect()
 
 const personRepository = new PersonRepository()

--- a/website/content/01.apps/04.services/02.publishing-services.md
+++ b/website/content/01.apps/04.services/02.publishing-services.md
@@ -38,6 +38,10 @@ import config from './.config/kinotic.config'
 Kinotic.zonePrefix = appZone(config.organizationId, config.applicationId)
 ```
 
+Instantiate `@Publish` classes only after `Kinotic.connect()` resolves: registration
+subscribes the service over the live connection, and throws when none exists yet. The
+entry-point order is therefore `zonePrefix` → `connect()` → instantiate services.
+
 ```typescript
 @Publish()                       // → srv://app.acme-org.orders-app~OrderService
 class OrderService { ... }

--- a/website/content/01.apps/04.services/03.service-proxies.md
+++ b/website/content/01.apps/04.services/03.service-proxies.md
@@ -32,8 +32,8 @@ export class NotificationService implements INotificationService {
     constructor(kinotic: IKinotic) {
         // A proxy targets the service's full address, including its zone (see CRI Format).
         // A platform service is reached in os-api or app-api; an application's own service
-        // is reached in its app zone, e.g. app.acme-org.orders-app.com.example.NotificationService
-        this.serviceProxy = kinotic.serviceProxy('app.acme-org.orders-app.com.example.NotificationService')
+        // is reached in its app zone, e.g. app.acme-org.orders-app~com.example.NotificationService
+        this.serviceProxy = kinotic.serviceProxy('app.acme-org.orders-app~com.example.NotificationService')
     }
 
     sendAlert(message: string): Promise<void> {

--- a/website/content/01.apps/06.security/01.authentication.md
+++ b/website/content/01.apps/06.security/01.authentication.md
@@ -44,7 +44,7 @@ await Kinotic.connect({
 
 The constructor is `BasicCredentialsResolver(clientId, clientSecret, organizationId?, applicationId?)`. The `clientId` is your user's email and `clientSecret` is the password — or a machine identity's id and provisioned secret. The platform looks up the user by email within your application's scope, verifies the password against a securely stored bcrypt hash, and establishes a session.
 
-With no `credentials` at all, `Kinotic.connect()` resolves through the default chain: the `KINOTIC_CLIENT_ID` / `KINOTIC_CLIENT_SECRET` (plus optional `KINOTIC_ORGANIZATION_ID` / `KINOTIC_APPLICATION_ID`) environment variables, then the browser session. Server settings resolve the same way — the `server` option, the `KINOTIC_SERVER_HOST/PORT/USE_SSL` variables, the page's own location in a browser, then `https://api.kinotic.com`. To pin the server explicitly, pass it alongside the credentials:
+With no `credentials` at all, `Kinotic.connect()` resolves through the default chain: the `KINOTIC_CLIENT_ID` / `KINOTIC_CLIENT_SECRET` (plus optional `KINOTIC_ORGANIZATION_ID` / `KINOTIC_APPLICATION_ID`) environment variables, then the browser session. Server settings resolve the same way — the `server` option, the `KINOTIC_SERVER_HOST/PORT/USE_SSL` variables, the page's own location in a browser, then `https://api.kinotic.ai`. To pin the server explicitly, pass it alongside the credentials:
 
 ```typescript
 await Kinotic.connect({


### PR DESCRIPTION
Three findings from the plugin↔develop reconciliation audit (kinotic-ai/claude-plugin#6):

## Default host

```ts
// kinotic-js/workspace/packages/core/src/internal/api/Util.ts
const DEFAULT_HOST = 'api.kinotic.ai'   // was api.kinotic.com
```

Every deployment artifact serves `kinotic.ai` (terraform `domain_name`, portal `VITE_KINOTIC_HOST`, PRODUCTION.md), so a fully unconfigured client was pointed at a domain nothing deploys. The doc-comment mentions in `Util.ts`/`ConnectOptions.ts` and the two website mentions (quick-start, authentication) are reconciled with it.

## service-proxies.md used a dotted (zone-less) address

```ts
// before: collapses the zone into the resource name — routes nowhere
kinotic.serviceProxy('app.acme-org.orders-app.com.example.NotificationService')
```
```ts
// after: ~ delimits zone from qualified name, matching ServiceIdentifier.qualifiedName()
kinotic.serviceProxy('app.acme-org.orders-app~com.example.NotificationService')
```

## getOidcConfigurations Javadoc contradicted the implementation

The Javadoc promised "an empty list if the application is not found"; `DefaultApplicationService` fails with `Application not found: <id>` (`Validate.notNull`) and returns `[]` only for an application with no configurations. The contract now says what the code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pfUEHkWYPqt9g6WWrTQHG

---
_Generated by [Claude Code](https://claude.ai/code/session_014pfUEHkWYPqt9g6WWrTQHG)_