### PR TITLE
Keep .config/c3 committable: the server consumes it from the repository

### DIFF
--- a/kinotic-js/kinotic-cli/src/internal/Utils.ts
+++ b/kinotic-js/kinotic-cli/src/internal/Utils.ts
@@ -222,15 +222,8 @@ export function tryGetNodeModuleName(nodeModulePath: string): string | null {
  * @return the absolute path to the subdirectory
  */
 async function ensureC3Directory(subdirectory: string): Promise<string> {
-    const c3Dir = path.resolve(resolveKinoticConfigDir(), 'c3')
-    const ret = path.resolve(c3Dir, subdirectory)
+    const ret = path.resolve(resolveKinoticConfigDir(), 'c3', subdirectory)
     await fsPromises.mkdir(ret, {recursive: true})
-    // c3 holds only what this generator rewrites from the entity sources on every run, so the
-    // directory ignores itself instead of every project needing to add the rule
-    const ignorePath = path.resolve(c3Dir, '.gitignore')
-    if (!fs.existsSync(ignorePath)) {
-        await fsPromises.writeFile(ignorePath, '*\n')
-    }
     return ret
 }
 

--- a/kinotic-js/kinotic-cli/test/internal/EntityCodeGenerationService.test.ts
+++ b/kinotic-js/kinotic-cli/test/internal/EntityCodeGenerationService.test.ts
@@ -108,6 +108,10 @@ describe('EntityCodeGenerationService', () => {
     it('writes the entity C3Type json and the Repository classes without verbose', async () => {
         await generate()
 
+        // The schemas are consumed server-side from the committed repository, so
+        // generate must never leave a gitignore that hides them.
+        expect(readIfExists('.config/c3/.gitignore'), 'c3 self-ignore').to.be.null
+
         const entityJson = readIfExists('.config/c3/entities/my.app.Todo.json')
         expect(entityJson, 'entity C3Type json').to.not.be.null
 


### PR DESCRIPTION
## What

The generator wrote a self-ignoring `.gitignore` into `.config/c3`, but the entity/query schemas there are what Kinotic OS reads from the connected GitHub repository — ignoring them breaks synchronization.

```ts
// kinotic-js/kinotic-cli/src/internal/Utils.ts — before
const ignorePath = path.resolve(c3Dir, '.gitignore')
if (!fs.existsSync(ignorePath)) {
    await fsPromises.writeFile(ignorePath, '*\n')
}
```
```ts
// after: ensureC3Directory only creates the directory
const ret = path.resolve(resolveKinoticConfigDir(), 'c3', subdirectory)
await fsPromises.mkdir(ret, {recursive: true})
return ret
```

No healing/removal of previously-written ignores — nothing has shipped, so no project has one. `EntityCodeGenerationService.test.ts` asserts generate leaves no `.config/c3/.gitignore` behind; all 3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pfUEHkWYPqt9g6WWrTQHG