### PR TITLE
Fix typo: kinoitc → kinotic throughout codebase

### DIFF
--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -107,7 +107,7 @@ public class StompAuthorizerFactoryTest {
     public void applicationParticipantSubscribesOnlyToReplyDestinations() {
         StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
 
-        assertTrue(authorizer.subscribeAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinotic.js.EventBus/replyHandler")));
 
         // not even its own zone: an application's services are hosted by its runtime, which
         // authenticates as an organization participant
@@ -212,21 +212,21 @@ public class StompAuthorizerFactoryTest {
     public void replyDestinationIsScopedToTheConnectionsReplyToId() {
         StompAuthorizer authorizer = organizationAuthorizer("acme-org");
 
-        assertTrue(authorizer.subscribeAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("reply://other-id:sub-1@kinoitc.js.EventBus/replyHandler")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("reply://kinoitc.js.EventBus/replyHandler")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinotic.js.EventBus/replyHandler")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("reply://other-id:sub-1@kinotic.js.EventBus/replyHandler")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("reply://kinotic.js.EventBus/replyHandler")));
     }
 
     @Test
     public void temporaryGrantsAllowOneExactMatchSend() {
         StompAuthorizer authorizer = organizationAuthorizer("acme-org");
-        String replyDestination = "reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler";
+        String replyDestination = "reply://" + REPLY_TO_ID + ":sub-1@kinotic.js.EventBus/replyHandler";
 
         assertFalse(authorizer.sendAllowed(CRI.create(replyDestination)));
 
         // grants match by exact string, so a case variant of the granted destination stays denied
         authorizer.addTemporarySendAllowed(replyDestination);
-        assertFalse(authorizer.sendAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@Kinoitc.js.EventBus/replyHandler")));
+        assertFalse(authorizer.sendAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@Kinotic.js.EventBus/replyHandler")));
         assertTrue(authorizer.sendAllowed(CRI.create(replyDestination)));
 
         // a grant authorizes exactly one send

--- a/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
@@ -60,7 +60,7 @@ export class ServiceRegistry implements IServiceRegistry {
     private _eventBus: IEventBus
     private supervisors: Map<string, ServiceInvocationSupervisor> = new Map()
     private contextInterceptor: ContextInterceptor<any> | null = null
-    private debugLogger = debug('kinoitc:serviceRegistry')
+    private debugLogger = debug('kinotic:serviceRegistry')
 
     constructor(eventBus: IEventBus) {
         this._eventBus = eventBus

--- a/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
@@ -1,9 +1,9 @@
 import {DefaultCRI} from './DefaultCRI'
 
 /**
- * `CRI` is a Kinoitc Resource Identifier used by Kinoitc to route requests appropriately.
+ * `CRI` is a Kinotic Resource Identifier used by Kinotic to route requests appropriately.
  *
- * The `CRI` is a URI where the parts are named differently for clarity as to their purpose within Kinoitc.
+ * The `CRI` is a URI where the parts are named differently for clarity as to their purpose within Kinotic.
  *
  * Will be in a format as follows where anything surrounded with `[]` is optional:
  *

--- a/kinotic-js/workspace/packages/core/src/api/event/IEventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/IEventBus.ts
@@ -4,7 +4,7 @@ import {ConnectedInfo} from '@/api/security/ConnectedInfo'
 import {type ConnectOptions, ServerInfo} from '@/api/ConnectOptions'
 
 /**
- * Part of the low level portion of kinoitc representing data to be processed
+ * Part of the low level portion of kinotic representing data to be processed
  *
  * This is similar to a Stomp Frame but with more required information and no control plane semantics.
  *
@@ -71,7 +71,7 @@ export interface IEvent {
 }
 
 /**
- * Part of the low level portion of kinoitc representing a connection to a kinoitc server
+ * Part of the low level portion of kinotic representing a connection to a kinotic server
  * This is similar to a Stomp Client but with more required information and no control plane semantics.
  *
  * Created by Navid Mitchell on 2019-01-04.
@@ -110,7 +110,7 @@ export interface IEventBus {
 
     /**
      * Determines if the connection is connected.
-     * This means that there is an open connection to the Kinoitc server
+     * This means that there is an open connection to the Kinotic server
      * @return true if the connection is active false if not
      */
     isConnected(): boolean

--- a/kinotic-js/workspace/packages/core/src/internal/api/Logger.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/Logger.ts
@@ -1,7 +1,7 @@
 import debug from 'debug'
 
 /**
- * Logging utilities for the Kinoitc library.
+ * Logging utilities for the Kinotic library.
  *
  * @author Navid Mitchell 🤝Grok
  * @since 3/25/2025

--- a/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
@@ -12,7 +12,7 @@ import opentelemetry, { context, propagation, trace, SpanKind, SpanStatusCode, t
 import info from '../../../package.json' with { type: 'json' }
 
 /**
- * Handles invoking services registered with Kinoitc in TypeScript.
+ * Handles invoking services registered with Kinotic in TypeScript.
  *
  * @author Navid Mitchell 🤝Grok
  * @since 3/25/2025
@@ -52,7 +52,7 @@ export class ServiceInvocationSupervisor {
         this._eventBus = eventBusService
         this.interceptorProvider = interceptorProvider
 
-        this.log = options.logger || createDebugLogger("kinoitc:ServiceInvocationSupervisor")
+        this.log = options.logger || createDebugLogger("kinotic:ServiceInvocationSupervisor")
         this.argumentResolver = options.argumentResolver || new JsonArgumentResolver()
         this.returnValueConverter = options.returnValueConverter || new BasicReturnValueConverter()
 

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
@@ -44,7 +44,7 @@ export class StompConnectionManager {
     private readonly JITTER_MAX: number = 5000
     private readonly MAX_RECONNECT_DELAY: number = 120000 // 2 mins
     private connectionAttempts: number = 0
-    private debugLogger = debug('kinoitc:stomp')
+    private debugLogger = debug('kinotic:stomp')
     private readonly fatalErrorsSubject: Subject<Error> = new Subject<Error>()
     private readonly _fatalErrors: Observable<Error> = this.fatalErrorsSubject.asObservable()
     private initialConnectionSuccessful: boolean = false
@@ -282,7 +282,7 @@ export class StompConnectionManager {
 
                 const newReplyToCri: string = EventConstants.REPLY_DESTINATION_PREFIX
                     + connectedInfo.replyToId + ':' + this.uuidv4
-                    + '@kinoitc.js.EventBus/replyHandler'
+                    + '@kinotic.js.EventBus/replyHandler'
 
                 if (!this.initialConnectionSuccessful) {
                     this._replyToCri = newReplyToCri

--- a/kinotic-js/workspace/packages/core/src/internal/api/Util.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/Util.ts
@@ -12,7 +12,7 @@ const DEFAULT_PORT = 58503
 const DEFAULT_HOST = 'api.kinotic.ai'
 
 /**
- * Static utility functions used across the Kinoitc core runtime.
+ * Static utility functions used across the Kinotic core runtime.
  *
  * @author Navid Mitchell 🤝Grok
  * @since 3/25/2025

--- a/kinotic-js/workspace/packages/os-api/src/api/services/ILogManager.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/ILogManager.ts
@@ -35,13 +35,13 @@ export class LoggersDescriptor {
 export interface ILogManager {
 
     /**
-     * @param nodeId the kinoitc node to get the LoggersDescriptor from
+     * @param nodeId the kinotic node to get the LoggersDescriptor from
      * @return a {@link LoggersDescriptor} containing all the loggers and their levels
      */
     loggers(nodeId: string): Promise<LoggersDescriptor>
 
     /**
-     * @param nodeId the kinoitc node to get the LoggerLevelsDescriptor from
+     * @param nodeId the kinotic node to get the LoggerLevelsDescriptor from
      * @param name the name of the logger to get
      * @return a {@link LoggerLevelsDescriptor} containing the logger and its levels
      */
@@ -49,7 +49,7 @@ export interface ILogManager {
 
     /**
      * Configures the log level for the logger with the given name
-     * @param nodeId the kinoitc node to set the log level on
+     * @param nodeId the kinotic node to set the log level on
      * @param name the name of the logger to set
      * @param level the {@link LogLevel} to set for the logger with the given name
      */


### PR DESCRIPTION
Corrects a systematic typo where "kinoitc" was used instead of the correct project name "kinotic" across Java and TypeScript source files.

## Changes

- **Java test files** (`StompAuthorizerFactoryTest.java`): Fixed typo in test string literals and CRI destinations from `kinoitc.js.EventBus` to `kinotic.js.EventBus`
- **TypeScript API documentation** (`IEventBus.ts`, `ILogManager.ts`, `CRI.ts`): Corrected JSDoc comments and inline documentation from "Kinoitc" to "Kinotic"
- **TypeScript internal implementations**: Fixed debug logger namespace prefixes and CRI destination strings:
  - `ServiceInvocationSupervisor.ts`: Debug logger from `kinoitc:ServiceInvocationSupervisor` to `kinotic:ServiceInvocationSupervisor`
  - `StompConnectionManager.ts`: Debug logger from `kinoitc:stomp` to `kinotic:stomp` and reply destination from `@kinoitc.js.EventBus` to `@kinotic.js.EventBus`
  - `ServiceRegistry.ts`: Debug logger from `kinoitc:serviceRegistry` to `kinotic:serviceRegistry`
  - `Logger.ts`: JSDoc comment from "Kinoitc library" to "Kinotic library"
  - `Util.ts`: JSDoc comment from "Kinoitc core runtime" to "Kinotic core runtime"

All changes are purely corrective — no functional behavior is altered, only the spelling of the project name in strings, comments, and documentation.

https://claude.ai/code/session_01UE1gyTodteAyqv95fAYuqs