### PR TITLE
Report the connections and event bus traffic Vert.x can see

### DIFF
--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -116,6 +116,7 @@ dependencyManagement {
         dependency "io.vertx:vertx-grpcio-server:${vertxVersion}"
         dependency "io.vertx:vertx-health-check:${vertxVersion}"
         dependency "io.vertx:vertx-ignite:${vertxVersion}"
+        dependency "io.vertx:vertx-micrometer-metrics:${vertxVersion}"
         dependency "io.vertx:vertx-reactive-streams:${vertxVersion}"
         dependency "io.vertx:vertx-web:${vertxVersion}"
         dependency "io.vertx:vertx-web-client:${vertxVersion}"

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -172,6 +172,9 @@ nothing. The rules that matter:
   `http.server.request.duration` → `http_server_request_duration_seconds_bucket`) because
   `mimir.yml` sets `otel_metric_suffixes_enabled: true`. Mimir defaults that off, which stores
   bare `jvm_memory_used` and leaves every stock dashboard empty.
+- **Vert.x metrics** (`vertx_http_server_active_connections`, `vertx_http_server_active_ws_connections`,
+  `vertx_eventbus_*`, `vertx_pool_*`) arrive through Micrometer's global registry, which the agent
+  bridges onto the OTLP exporter — so they are only exported when the agent is attached.
 - **Tempo's metrics-generator** writes its own series to Mimir — `traces_spanmetrics_calls_total`
   and `traces_spanmetrics_latency_bucket`, labelled `service`, `span_name`, `span_kind`,
   `status_code`. These only exist because `tempo.yml` enables the processors under `overrides`;

--- a/kinotic-core/build.gradle
+++ b/kinotic-core/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'io.vertx:vertx-auth-common'
     implementation 'io.vertx:vertx-auth-oauth2'
     implementation 'io.vertx:vertx-ignite'
+    implementation 'io.vertx:vertx-micrometer-metrics'
     implementation 'io.vertx:vertx-web'
     implementation 'io.vertx:vertx-web-client'
 

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/config/KinoticVertxConfig.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/config/KinoticVertxConfig.java
@@ -1,5 +1,6 @@
 package org.kinotic.core.internal.config;
 
+import io.micrometer.core.instrument.Metrics;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
@@ -8,6 +9,8 @@ import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.shareddata.SharedData;
 import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.micrometer.MicrometerMetricsFactory;
+import io.vertx.micrometer.MicrometerMetricsOptions;
 import org.apache.ignite.Ignite;
 import org.kinotic.core.api.config.KinoticProperties;
 import org.kinotic.core.api.event.Event;
@@ -68,7 +71,13 @@ public class KinoticVertxConfig {
         // JacksonModule bean the modules contribute (including vertxJackson3Module for the vertx types)
         VertxJackson3Codec.setMapper(jsonMapper);
 
-        VertxBuilder builder = Vertx.builder();
+        // The agent bridges Micrometer's global registry onto the OTLP exporter, so Vert.x's meters
+        // need no exporter of their own. With no agent attached the registry has no backends.
+        VertxOptions options = new VertxOptions()
+                .setMetricsOptions(new MicrometerMetricsOptions().setEnabled(true));
+
+        VertxBuilder builder = Vertx.builder()
+                                    .withMetrics(new MicrometerMetricsFactory(Metrics.globalRegistry));
         Vertx vertx;
 
         if (clusterManager != null) {
@@ -84,17 +93,14 @@ public class KinoticVertxConfig {
                 eventBusOptions.setClusterPublicHost(properties.getEventBusClusterPublicHost());
             }
 
-            VertxOptions options = new VertxOptions()
-                    .setEventBusOptions(eventBusOptions);
-
-            vertx = builder.with(options)
+            vertx = builder.with(options.setEventBusOptions(eventBusOptions))
                            .withClusterManager(clusterManager)
                            .buildClustered()
                            .toCompletionStage()
                            .toCompletableFuture()
                            .get(2, MINUTES);
         }else{
-            vertx = builder.build();
+            vertx = builder.with(options).build();
         }
 
         // Register the Event codec and auto-select it for any Event body, so callers never set a codec


### PR DESCRIPTION
The JVM runtime metrics say nothing about how many clients are connected or how much the event bus is carrying — only Vert.x holds that state, and its metrics were never enabled.

## Change

`KinoticVertxConfig` turns them on against Micrometer's global registry:

```java
VertxOptions options = new VertxOptions()
        .setEventBusOptions(eventBusOptions)
        .setMetricsOptions(metricsOptions());

vertx = builder.with(options)
               .withMetrics(new MicrometerMetricsFactory(Metrics.globalRegistry))
```

No exporter of their own is needed. The OpenTelemetry agent instruments Micrometer's static registry — `MetricsInstrumentation$StaticInitializerAdvice` adds an `OpenTelemetryMeterRegistry` to it — so these meters travel the OTLP path the platform already uses. With no agent attached the registry has no backends and they are inert.

Both construction paths set the options; only the clustered branch built `VertxOptions` before.

## What it produces

Dumped from a running context rather than taken from the docs:

```
vertx.http.server.active.connections          also active_ws_connections, for STOMP clients
vertx.eventbus.handlers / pending / processed / discarded
vertx.pool.in.use / queue.pending / queue.time / ratio / usage
```

Cardinality is bounded by Vert.x's default label set, `[HTTP_METHOD, HTTP_CODE, POOL_TYPE, POOL_NAME, EB_SIDE]`, which excludes the remote address — a connection gauge stays one series rather than one per client. JVM metrics are left off, since the agent already reports them.

## Verification

`VertxMetricsTests` starts a real server, opens a connection, and asserts the gauge is published:

```java
try (Socket ignored = new Socket("localhost", server.actualPort())) {
    Awaitility.await().atMost(Duration.ofSeconds(10)).until(() -> activeConnections() != null);
```

It uses a plain socket rather than a Vert.x client deliberately: Vert.x 5 shares client instances across the context, and an earlier version of this test failed with `Client is closed` when another test disposed of one first.

77 tests, 0 failed. `dependencyInsight` reports `io.vertx:vertx-micrometer-metrics:5.1.6 (selected by rule)`, confirming the version comes from the managed block rather than the module.

## Event bus spans

Not included, deliberately. The agent instruments `vertx/{web,client,kafka,sql,reactive}` but not the event bus, so spans there would mean enabling Vert.x's own tracing SPI (`vertx-opentelemetry`). That SPI covers all request kinds at once, so it would also emit HTTP server spans duplicating the agent's vertx-web instrumentation — the agent's suppression only applies to spans it creates itself. For RPC the payoff is small, since the CLIENT and SERVER spans already bracket the bus hop; the remainder would be a span per reply and control message. `vertx_eventbus_pending` and `processed` give throughput and backpressure without that noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7wR4j1JKAE1ZAvqcGZxSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7wR4j1JKAE1ZAvqcGZxSM)_