### PR TITLE
Animate live usage chart and pipeline card deck

### DIFF
--- a/website/app/components/home/FeaturesComponent.vue
+++ b/website/app/components/home/FeaturesComponent.vue
@@ -1,3 +1,98 @@
+<script setup lang="ts">
+/** A rendered frame of the live-usage chart: the polyline plus where each probe sits on it. */
+interface ChartFrame {
+  d: string
+  redY: number
+  headY: number
+}
+
+/** Horizontal gap between two samples, in viewBox units. */
+const SPACING = 30
+/** Where the newest sample — and the mint probe riding it — is pinned. */
+const HEAD_X = 278
+/** Where the red probe is pinned; it only ever travels vertically. */
+const RED_X = 120
+/** viewBox units the line travels per second. */
+const SCROLL_SPEED = 16
+const PEAK_TOP = 26
+const PEAK_SPAN = 30
+const VALLEY_TOP = 66
+const VALLEY_SPAN = 32
+
+// Seeded rather than generated so the server-rendered frame matches the first
+// client frame; the walk takes over once the animation starts.
+const values = [68, 92, 96, 96, 58, 78, 32, 66, 48, 74, 60, 68, 42]
+let peak = true
+let offset = 0
+
+/**
+ * The next sample scrolling in at the right edge, alternating between a high
+ * and a low band so the incoming line keeps the amplitude of the seed. The
+ * occasional repeat stops it reading as a perfect sawtooth.
+ */
+function nextValue(): number {
+  if (Math.random() < 0.82) peak = !peak
+  return peak
+    ? PEAK_TOP + Math.random() * PEAK_SPAN
+    : VALLEY_TOP + Math.random() * VALLEY_SPAN
+}
+
+/** Height of the line at `x`, interpolated between the two samples either side of it. */
+function yAt(x: number): number {
+  const last = values.length - 1
+  const position = Math.min(last, Math.max(0, (x - HEAD_X - offset) / SPACING + last))
+  const index = Math.floor(position)
+  const start = values[index]!
+  const end = values[Math.min(last, index + 1)]!
+  return start + (end - start) * (position - index)
+}
+
+function buildFrame(): ChartFrame {
+  // The samples sit on a lattice that slides left past both edges, so the path
+  // is capped with an interpolated point at each edge rather than a sample.
+  const segments = [`M 0 ${yAt(0).toFixed(2)}`]
+  for (let i = 0; i < values.length; i++) {
+    const x = HEAD_X + offset - (values.length - 1 - i) * SPACING
+    if (x > 0 && x < HEAD_X) segments.push(`L ${x.toFixed(2)} ${values[i]!.toFixed(2)}`)
+  }
+  segments.push(`L ${HEAD_X} ${yAt(HEAD_X).toFixed(2)}`)
+  return { d: segments.join(' '), redY: yAt(RED_X), headY: yAt(HEAD_X) }
+}
+
+/** The stages a pushed branch moves through, one per card in the deck. */
+const PIPELINE_STEPS = [
+  { branch: 'feature/checkout', stage: 'PUSH · a41f9c', icon: 'Folder', live: false },
+  { branch: 'feature/checkout', stage: 'BUILD · 3 SERVICES', icon: 'Cog', live: false },
+  { branch: 'feature/checkout', stage: 'DEPLOY · POD PENDING', icon: 'Refresh', live: false },
+  { branch: 'feature/checkout', stage: 'LIVE · DEV · ENV', icon: 'ThLarge', live: true },
+] as const
+
+const chart = ref<ChartFrame>(buildFrame())
+let frame = 0
+
+onMounted(() => {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+  let last = performance.now()
+  const tick = (now: number) => {
+    // Clamping the delta keeps the line from lurching after a background tab resumes.
+    const delta = Math.min(42, now - last)
+    last = now
+    offset += delta * 0.001 * SCROLL_SPEED
+    while (offset >= SPACING) {
+      offset -= SPACING
+      values.shift()
+      values.push(nextValue())
+    }
+    chart.value = buildFrame()
+    frame = requestAnimationFrame(tick)
+  }
+  frame = requestAnimationFrame(tick)
+})
+
+onBeforeUnmount(() => cancelAnimationFrame(frame))
+</script>
+
 <template>
   <section class="k-section features">
     <div class="k-wrap">
@@ -15,15 +110,29 @@
               <span class="k-livedot features__badgedot" />Live usage
             </div>
             <svg class="features__chart" viewBox="0 0 300 120" fill="none" aria-hidden="true">
-              <path
-                d="M 10 96 L 50 96 L 78 58 L 100 78 L 120 32 L 146 66 L 172 48 L 200 74 L 226 60 L 250 68 L 278 42"
-                stroke="#28FEB4"
-                stroke-width="2.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <circle cx="120" cy="32" r="4.5" fill="#EC1F52" />
-              <circle cx="278" cy="42" r="4.5" fill="#28FEB4" />
+              <defs>
+                <linearGradient id="usage-edge" x1="0" y1="0" x2="1" y2="0">
+                  <stop offset="0" stop-color="#fff" stop-opacity="0" />
+                  <stop offset="1" stop-color="#fff" stop-opacity="1" />
+                </linearGradient>
+                <!-- Dissolves the trailing edge so the line reads as streaming
+                     off the left of the card rather than being cut off there. -->
+                <mask id="usage-trail">
+                  <rect x="0" y="0" width="72" height="120" fill="url(#usage-edge)" />
+                  <rect x="72" y="0" width="228" height="120" fill="#fff" />
+                </mask>
+              </defs>
+              <g mask="url(#usage-trail)">
+                <path
+                  :d="chart.d"
+                  stroke="#28FEB4"
+                  stroke-width="2.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </g>
+              <circle :cx="RED_X" :cy="chart.redY" r="4.5" fill="#EC1F52" />
+              <circle :cx="HEAD_X" :cy="chart.headY" r="4.5" fill="#28FEB4" />
             </svg>
           </div>
           <div class="features__caption">
@@ -37,16 +146,16 @@
 
         <article class="features__card" data-reveal>
           <div class="features__visual features__visual--mint">
-            <div class="envstack">
-              <div class="envstack__shadow envstack__shadow--back" />
-              <div class="envstack__shadow envstack__shadow--mid" />
-              <div class="envstack__front">
-                <span class="envstack__icon"><KinoticIcon name="Folder" :size="16" /></span>
-                <span class="envstack__meta">
-                  <span class="envstack__branch">feature/checkout</span>
-                  <span class="envstack__tags">POD · DEV · ENV</span>
+            <div class="envstack" aria-hidden="true">
+              <div v-for="step in PIPELINE_STEPS" :key="step.stage" class="envstack__card">
+                <span class="envstack__body">
+                  <span class="envstack__icon"><KinoticIcon :name="step.icon" :size="16" /></span>
+                  <span class="envstack__meta">
+                    <span class="envstack__branch">{{ step.branch }}</span>
+                    <span class="envstack__tags">{{ step.stage }}</span>
+                  </span>
+                  <span class="k-livedot envstack__dot" :class="{ 'envstack__dot--live': step.live }" />
                 </span>
-                <span class="k-livedot envstack__dot" />
               </div>
             </div>
           </div>
@@ -219,46 +328,153 @@
 .envstack {
   position: relative;
   width: 260px;
-  height: 110px;
+  height: 132px;
+  perspective: 820px;
 }
 
-.envstack__shadow {
-  position: absolute;
-  border-radius: 10px;
-  background: var(--color-k-bg-panel);
-}
-
-.envstack__shadow--back {
-  left: 18px;
-  top: 0;
-  width: 224px;
-  height: 20px;
-  border: 1px solid rgba(40, 254, 180, 0.25);
-}
-
-.envstack__shadow--mid {
-  left: 9px;
-  top: 11px;
-  width: 242px;
-  height: 22px;
-  border: 1px solid rgba(40, 254, 180, 0.4);
-  border-radius: 11px;
-}
-
-.envstack__front {
+.envstack__card {
   position: absolute;
   left: 0;
-  top: 24px;
+  top: 30px;
   width: 260px;
   height: 72px;
-  display: flex;
-  align-items: center;
-  gap: 14px;
   padding: 0 20px;
   border: 1px solid rgba(40, 254, 180, 0.8);
   border-radius: 13px;
   background: #0E1511;
+  /* Hinging on the top edge is what makes the exit read as a fold: the body
+     tips away from the viewer and slides under the card taking its place. */
+  transform-origin: 50% 0%;
+  backface-visibility: hidden;
+  will-change: transform, opacity;
+  animation-name: envstack-cycle;
+  animation-duration: 13.6s;
+  animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+  animation-iteration-count: infinite;
+  animation-delay: var(--envstack-phase);
+}
+
+/* Every card runs the same four-slot cycle one slot apart, so the deck always
+   has a back, a mid, a front and one folding away. The pose declared here is
+   the slot each card starts in, and the one reduced motion freezes it at. */
+.envstack__card:nth-child(1) {
+  --envstack-phase: -6.8s;
+  transform: translateY(0) scale(1);
+  opacity: 1;
+  z-index: 3;
   box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
+}
+
+.envstack__card:nth-child(2) {
+  --envstack-phase: -3.4s;
+  transform: translateY(-14px) scale(0.93);
+  opacity: 0.7;
+  z-index: 2;
+  border-color: rgba(40, 254, 180, 0.4);
+}
+
+.envstack__card:nth-child(3) {
+  --envstack-phase: 0s;
+  transform: translateY(-27px) scale(0.86);
+  opacity: 0.45;
+  z-index: 1;
+  border-color: rgba(40, 254, 180, 0.25);
+}
+
+.envstack__card:nth-child(4) {
+  --envstack-phase: -10.2s;
+  opacity: 0;
+  z-index: 0;
+}
+
+/* A card in one of the slots behind sits high enough that its contents clear
+   the front card's top edge and show through, so a card only shows what it is
+   carrying from the moment it lands in the front slot until it has folded away. */
+.envstack__body {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  height: 100%;
+  opacity: 0;
+  animation-name: envstack-reveal;
+  animation-duration: 13.6s;
+  animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+  animation-iteration-count: infinite;
+  animation-delay: var(--envstack-phase);
+}
+
+.envstack__card:nth-child(1) .envstack__body {
+  opacity: 1;
+}
+
+@keyframes envstack-reveal {
+  0%, 45% { opacity: 0; }
+  49%, 75% { opacity: 1; }
+  75.01%, 100% { opacity: 0; }
+}
+
+@keyframes envstack-cycle {
+  0%, 15% {
+    transform: translateY(-27px) scale(0.86);
+    opacity: 0.45;
+    border-color: rgba(40, 254, 180, 0.25);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 1;
+  }
+
+  25%, 40% {
+    transform: translateY(-14px) scale(0.93);
+    opacity: 0.7;
+    border-color: rgba(40, 254, 180, 0.4);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 2;
+  }
+
+  50%, 65% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+    border-color: rgba(40, 254, 180, 0.8);
+    box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
+    z-index: 3;
+  }
+
+  /* Drops behind the rest of the deck for the whole fold, otherwise the card it
+     is sliding under would be the one that gets covered. The fold leads with its
+     travel so the card is clear of the front slot before the one replacing it
+     brings its own label up. */
+  65.01% {
+    z-index: 0;
+    animation-timing-function: cubic-bezier(0.3, 0.85, 0.4, 1);
+  }
+
+  69% {
+    transform: translateY(32px) scale(0.96) rotateX(44deg);
+    opacity: 0.55;
+  }
+
+  75% {
+    transform: translateY(52px) scale(0.92) rotateX(72deg);
+    opacity: 0;
+    z-index: 0;
+  }
+
+  /* Back of the deck, still invisible: the return trip has to happen in one
+     frame or the card would be seen travelling back up. */
+  75.01%, 90% {
+    transform: translateY(-27px) scale(0.86);
+    opacity: 0;
+    border-color: rgba(40, 254, 180, 0.25);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 1;
+  }
+
+  100% {
+    transform: translateY(-27px) scale(0.86);
+    opacity: 0.45;
+    border-color: rgba(40, 254, 180, 0.25);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 1;
+  }
 }
 
 .envstack__icon {
@@ -298,6 +514,10 @@
   width: 8px;
   height: 8px;
   background: var(--color-k-red);
+}
+
+.envstack__dot--live {
+  background: var(--color-k-mint);
 }
 
 /* ── Globe ── */


### PR DESCRIPTION
Replaces static SVG visualizations in the features section with animated components that continuously update to reflect live data flow.

## Changes

**Live usage chart** — Converts the hardcoded polyline into a procedurally generated, continuously scrolling line that:
- Generates random sample values alternating between high and low bands to maintain visual amplitude
- Interpolates the line height between samples for smooth rendering
- Animates horizontally at a constant scroll speed, with new samples entering from the right
- Applies a gradient mask to the trailing edge so the line appears to stream off the left rather than being cut off
- Respects `prefers-reduced-motion` by skipping animation setup
- Tracks two probe positions (red at a fixed x-coordinate, mint at the newest sample) that move vertically with the line

**Pipeline card deck** — Replaces the single static card with a four-card rotating stack that:
- Cycles through four pipeline stages (PUSH, BUILD, DEPLOY, LIVE) with appropriate icons and labels
- Uses CSS keyframe animations to move cards through four slots: back (scaled 0.86, opacity 0.45), mid (0.93, 0.7), front (1.0, 1.0), and folding away
- Each card folds away with a 3D rotation effect (`rotateX`) before returning to the back of the deck
- All four cards run the same 13.6-second cycle offset by 3.4 seconds, creating a continuous loop
- Content visibility is tied to the front slot via a separate `envstack-reveal` animation
- Respects `prefers-reduced-motion` by freezing cards in their initial positions

## Implementation details

- Chart animation uses `requestAnimationFrame` with delta-time clamping to handle background tab resumption smoothly
- Sample values are seeded rather than generated on first render to ensure server-rendered and client-rendered frames match
- Card animations use CSS custom properties (`--envstack-phase`) to stagger the cycle start times
- The fold animation uses `animation-timing-function` changes mid-cycle to control the exit and return speeds independently
- Z-index management in the keyframes ensures the folding card drops behind the deck before the replacement card rises

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm