### PR TITLE
Fix the usage chart's scroll direction, and add a second deck animation

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -1,0 +1,322 @@
+<script setup lang="ts">
+/**
+ * The branch-environment deck on the CI/CD feature card. Four cards run the same
+ * cycle one slot apart, so the deck always holds a front, a mid and a back card
+ * while a fourth is off-deck, and each pipeline stage takes the front slot in turn.
+ *
+ * `v1` folds the front card down and under the deck. `v2` runs that in reverse:
+ * the next stage rises up in front while the cards already there recede.
+ */
+defineProps<{ version: 'v1' | 'v2' }>()
+
+/** The stages a pushed branch moves through, one per card in the deck. */
+const PIPELINE_STEPS = [
+  { branch: 'feature/checkout', stage: 'PUSH · a41f9c', icon: 'Folder', live: false },
+  { branch: 'feature/checkout', stage: 'BUILD · 3 SERVICES', icon: 'Cog', live: false },
+  { branch: 'feature/checkout', stage: 'DEPLOY · POD PENDING', icon: 'Refresh', live: false },
+  { branch: 'feature/checkout', stage: 'LIVE · DEV · ENV', icon: 'ThLarge', live: true },
+] as const
+</script>
+
+<template>
+  <div class="envstack" :class="`envstack--${version}`" aria-hidden="true">
+    <div v-for="step in PIPELINE_STEPS" :key="step.stage" class="envstack__card">
+      <span class="envstack__body">
+        <span class="envstack__icon"><KinoticIcon :name="step.icon" :size="16" /></span>
+        <span class="envstack__meta">
+          <span class="envstack__branch">{{ step.branch }}</span>
+          <span class="envstack__tags">{{ step.stage }}</span>
+        </span>
+        <span class="k-livedot envstack__dot" :class="{ 'envstack__dot--live': step.live }" />
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.envstack {
+  position: relative;
+  width: 260px;
+  height: 132px;
+  perspective: 820px;
+}
+
+.envstack__card {
+  position: absolute;
+  left: 0;
+  top: 30px;
+  width: 260px;
+  height: 72px;
+  padding: 0 20px;
+  border: 1px solid rgba(40, 254, 180, 0.8);
+  border-radius: 13px;
+  background: #0E1511;
+  /* Hinging on the top edge is what makes the card leaving or arriving read as a
+     fold: the body tips away from the viewer as it passes under the deck. */
+  transform-origin: 50% 0%;
+  backface-visibility: hidden;
+  will-change: transform, opacity;
+  animation-duration: 13.6s;
+  animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+  animation-iteration-count: infinite;
+  animation-delay: var(--envstack-phase);
+}
+
+/* A card in one of the slots behind sits high enough that its contents clear the
+   front card's top edge and show through, so a card only shows what it is
+   carrying over the stretch where it owns the front slot. */
+.envstack__body {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  height: 100%;
+  opacity: 0;
+  animation-duration: 13.6s;
+  animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+  animation-iteration-count: infinite;
+  animation-delay: var(--envstack-phase);
+}
+
+/* ── Slot poses ──
+   Where each card sits before its animation takes over, and what reduced motion
+   freezes it at. The two versions travel the deck in opposite directions, so
+   they disagree about which card starts at mid and which starts off-deck. */
+.envstack__card:nth-child(1) {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+  z-index: 3;
+  box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
+}
+
+.envstack__card:nth-child(1) .envstack__body {
+  opacity: 1;
+}
+
+.envstack__card:nth-child(3) {
+  transform: translateY(-27px) scale(0.86);
+  opacity: 0.45;
+  z-index: 1;
+  border-color: rgba(40, 254, 180, 0.25);
+}
+
+.envstack--v1 .envstack__card:nth-child(2),
+.envstack--v2 .envstack__card:nth-child(4) {
+  transform: translateY(-14px) scale(0.93);
+  opacity: 0.7;
+  z-index: 2;
+  border-color: rgba(40, 254, 180, 0.4);
+}
+
+.envstack--v1 .envstack__card:nth-child(4),
+.envstack--v2 .envstack__card:nth-child(2) {
+  opacity: 0;
+  z-index: 0;
+}
+
+/* ── v1: the front card folds down and under the deck ── */
+.envstack--v1 .envstack__card {
+  animation-name: envstack-fold;
+}
+
+.envstack--v1 .envstack__body {
+  animation-name: envstack-fold-reveal;
+}
+
+.envstack--v1 .envstack__card:nth-child(1) { --envstack-phase: -6.8s; }
+.envstack--v1 .envstack__card:nth-child(2) { --envstack-phase: -3.4s; }
+.envstack--v1 .envstack__card:nth-child(3) { --envstack-phase: 0s; }
+.envstack--v1 .envstack__card:nth-child(4) { --envstack-phase: -10.2s; }
+
+@keyframes envstack-fold {
+  0%, 15% {
+    transform: translateY(-27px) scale(0.86);
+    opacity: 0.45;
+    border-color: rgba(40, 254, 180, 0.25);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 1;
+  }
+
+  25%, 40% {
+    transform: translateY(-14px) scale(0.93);
+    opacity: 0.7;
+    border-color: rgba(40, 254, 180, 0.4);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 2;
+  }
+
+  50%, 65% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+    border-color: rgba(40, 254, 180, 0.8);
+    box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
+    z-index: 3;
+  }
+
+  /* Drops behind the rest of the deck for the whole fold, otherwise the card it
+     is sliding under would be the one that gets covered. The fold leads with its
+     travel so the card is clear of the front slot before the one replacing it
+     brings its own label up. */
+  65.01% {
+    z-index: 0;
+    animation-timing-function: cubic-bezier(0.3, 0.85, 0.4, 1);
+  }
+
+  69% {
+    transform: translateY(32px) scale(0.96) rotateX(44deg);
+    opacity: 0.55;
+  }
+
+  75% {
+    transform: translateY(52px) scale(0.92) rotateX(72deg);
+    opacity: 0;
+    z-index: 0;
+  }
+
+  /* Back of the deck, still invisible: the return trip has to happen in one
+     frame or the card would be seen travelling back up. */
+  75.01%, 90% {
+    transform: translateY(-27px) scale(0.86);
+    opacity: 0;
+    border-color: rgba(40, 254, 180, 0.25);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 1;
+  }
+
+  100% {
+    transform: translateY(-27px) scale(0.86);
+    opacity: 0.45;
+    border-color: rgba(40, 254, 180, 0.25);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 1;
+  }
+}
+
+@keyframes envstack-fold-reveal {
+  0%, 45% { opacity: 0; }
+  49%, 75% { opacity: 1; }
+  75.01%, 100% { opacity: 0; }
+}
+
+/* ── v2: the next card rises in front and the deck recedes behind it ── */
+.envstack--v2 .envstack__card {
+  animation-name: envstack-rise;
+}
+
+.envstack--v2 .envstack__body {
+  animation-name: envstack-rise-reveal;
+}
+
+.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: 0s; }
+.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: -10.2s; }
+.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: -6.8s; }
+.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: -3.4s; }
+
+@keyframes envstack-rise {
+  0%, 15% {
+    transform: translateY(0) scale(1) rotateX(0deg);
+    opacity: 1;
+    border-color: rgba(40, 254, 180, 0.8);
+    box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
+    z-index: 3;
+  }
+
+  /* Gives up the top of the deck the moment it starts receding, so the card
+     rising out from under it passes in front rather than behind. */
+  15.01% {
+    z-index: 2;
+  }
+
+  25%, 40% {
+    transform: translateY(-14px) scale(0.93) rotateX(0deg);
+    opacity: 0.7;
+    border-color: rgba(40, 254, 180, 0.4);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 2;
+  }
+
+  50%, 65% {
+    transform: translateY(-27px) scale(0.86) rotateX(0deg);
+    opacity: 0.45;
+    border-color: rgba(40, 254, 180, 0.25);
+    z-index: 1;
+  }
+
+  72% {
+    transform: translateY(-38px) scale(0.8) rotateX(0deg);
+    opacity: 0;
+    z-index: 1;
+  }
+
+  /* Under the deck, still invisible: the drop has to happen in one frame or the
+     card would be seen crossing the deck on its way down. */
+  72.01%, 90% {
+    transform: translateY(52px) scale(0.92) rotateX(72deg);
+    opacity: 0;
+    border-color: rgba(40, 254, 180, 0.8);
+    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
+    z-index: 3;
+  }
+
+  95% {
+    transform: translateY(26px) scale(0.96) rotateX(38deg);
+    opacity: 0.75;
+  }
+
+  100% {
+    transform: translateY(0) scale(1) rotateX(0deg);
+    opacity: 1;
+    border-color: rgba(40, 254, 180, 0.8);
+    box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
+    z-index: 3;
+  }
+}
+
+@keyframes envstack-rise-reveal {
+  0%, 15% { opacity: 1; }
+  18%, 90% { opacity: 0; }
+  97%, 100% { opacity: 1; }
+}
+
+.envstack__icon {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid rgba(40, 254, 180, 0.5);
+  color: var(--color-k-mint);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.envstack__meta {
+  flex: 1;
+}
+
+.envstack__branch {
+  display: block;
+  font-family: var(--font-k-mono);
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--color-k-text);
+}
+
+.envstack__tags {
+  display: block;
+  font-family: var(--font-k-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  color: var(--color-k-dim);
+  margin-top: 3px;
+}
+
+.envstack__dot {
+  width: 8px;
+  height: 8px;
+  background: var(--color-k-red);
+}
+
+.envstack__dot--live {
+  background: var(--color-k-mint);
+}
+</style>

--- a/website/app/components/home/FeaturesComponent.vue
+++ b/website/app/components/home/FeaturesComponent.vue
@@ -8,7 +8,7 @@ interface ChartFrame {
 
 /** Horizontal gap between two samples, in viewBox units. */
 const SPACING = 30
-/** Where the newest sample — and the mint probe riding it — is pinned. */
+/** Where the mint probe is pinned; the newest sample slides in to meet it. */
 const HEAD_X = 278
 /** Where the red probe is pinned; it only ever travels vertically. */
 const RED_X = 120
@@ -21,8 +21,8 @@ const VALLEY_SPAN = 32
 
 // Seeded rather than generated so the server-rendered frame matches the first
 // client frame; the walk takes over once the animation starts.
-const values = [68, 92, 96, 96, 58, 78, 32, 66, 48, 74, 60, 68, 42]
-let peak = true
+const values = [68, 92, 96, 96, 58, 78, 32, 66, 48, 74, 60, 42, 86]
+let peak = false
 let offset = 0
 
 /**
@@ -37,10 +37,19 @@ function nextValue(): number {
     : VALLEY_TOP + Math.random() * VALLEY_SPAN
 }
 
+/**
+ * Where sample `index` currently sits horizontally. The newest sample is placed
+ * one step past HEAD_X and travels left into it, so the head always has a sample
+ * either side of it and the probe riding there never jumps when the lattice shifts.
+ */
+function sampleX(index: number): number {
+  return HEAD_X + SPACING - offset - (values.length - 1 - index) * SPACING
+}
+
 /** Height of the line at `x`, interpolated between the two samples either side of it. */
 function yAt(x: number): number {
   const last = values.length - 1
-  const position = Math.min(last, Math.max(0, (x - HEAD_X - offset) / SPACING + last))
+  const position = Math.min(last, Math.max(0, (x - sampleX(last)) / SPACING + last))
   const index = Math.floor(position)
   const start = values[index]!
   const end = values[Math.min(last, index + 1)]!
@@ -48,24 +57,16 @@ function yAt(x: number): number {
 }
 
 function buildFrame(): ChartFrame {
-  // The samples sit on a lattice that slides left past both edges, so the path
-  // is capped with an interpolated point at each edge rather than a sample.
+  // Both ends are capped with an interpolated point rather than a sample, since
+  // the lattice slides past them rather than landing on them.
   const segments = [`M 0 ${yAt(0).toFixed(2)}`]
   for (let i = 0; i < values.length; i++) {
-    const x = HEAD_X + offset - (values.length - 1 - i) * SPACING
+    const x = sampleX(i)
     if (x > 0 && x < HEAD_X) segments.push(`L ${x.toFixed(2)} ${values[i]!.toFixed(2)}`)
   }
   segments.push(`L ${HEAD_X} ${yAt(HEAD_X).toFixed(2)}`)
   return { d: segments.join(' '), redY: yAt(RED_X), headY: yAt(HEAD_X) }
 }
-
-/** The stages a pushed branch moves through, one per card in the deck. */
-const PIPELINE_STEPS = [
-  { branch: 'feature/checkout', stage: 'PUSH · a41f9c', icon: 'Folder', live: false },
-  { branch: 'feature/checkout', stage: 'BUILD · 3 SERVICES', icon: 'Cog', live: false },
-  { branch: 'feature/checkout', stage: 'DEPLOY · POD PENDING', icon: 'Refresh', live: false },
-  { branch: 'feature/checkout', stage: 'LIVE · DEV · ENV', icon: 'ThLarge', live: true },
-] as const
 
 const chart = ref<ChartFrame>(buildFrame())
 let frame = 0
@@ -146,18 +147,7 @@ onBeforeUnmount(() => cancelAnimationFrame(frame))
 
         <article class="features__card" data-reveal>
           <div class="features__visual features__visual--mint">
-            <div class="envstack" aria-hidden="true">
-              <div v-for="step in PIPELINE_STEPS" :key="step.stage" class="envstack__card">
-                <span class="envstack__body">
-                  <span class="envstack__icon"><KinoticIcon :name="step.icon" :size="16" /></span>
-                  <span class="envstack__meta">
-                    <span class="envstack__branch">{{ step.branch }}</span>
-                    <span class="envstack__tags">{{ step.stage }}</span>
-                  </span>
-                  <span class="k-livedot envstack__dot" :class="{ 'envstack__dot--live': step.live }" />
-                </span>
-              </div>
-            </div>
+            <HomeEnvStack version="v2" />
           </div>
           <div class="features__caption">
             <div class="features__lead">CI/CD day one</div>
@@ -322,202 +312,6 @@ onBeforeUnmount(() => cancelAnimationFrame(frame))
   color: var(--color-k-muted);
   margin: 0;
   max-width: 380px;
-}
-
-/* ── Per-branch environment card ── */
-.envstack {
-  position: relative;
-  width: 260px;
-  height: 132px;
-  perspective: 820px;
-}
-
-.envstack__card {
-  position: absolute;
-  left: 0;
-  top: 30px;
-  width: 260px;
-  height: 72px;
-  padding: 0 20px;
-  border: 1px solid rgba(40, 254, 180, 0.8);
-  border-radius: 13px;
-  background: #0E1511;
-  /* Hinging on the top edge is what makes the exit read as a fold: the body
-     tips away from the viewer and slides under the card taking its place. */
-  transform-origin: 50% 0%;
-  backface-visibility: hidden;
-  will-change: transform, opacity;
-  animation-name: envstack-cycle;
-  animation-duration: 13.6s;
-  animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
-  animation-iteration-count: infinite;
-  animation-delay: var(--envstack-phase);
-}
-
-/* Every card runs the same four-slot cycle one slot apart, so the deck always
-   has a back, a mid, a front and one folding away. The pose declared here is
-   the slot each card starts in, and the one reduced motion freezes it at. */
-.envstack__card:nth-child(1) {
-  --envstack-phase: -6.8s;
-  transform: translateY(0) scale(1);
-  opacity: 1;
-  z-index: 3;
-  box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
-}
-
-.envstack__card:nth-child(2) {
-  --envstack-phase: -3.4s;
-  transform: translateY(-14px) scale(0.93);
-  opacity: 0.7;
-  z-index: 2;
-  border-color: rgba(40, 254, 180, 0.4);
-}
-
-.envstack__card:nth-child(3) {
-  --envstack-phase: 0s;
-  transform: translateY(-27px) scale(0.86);
-  opacity: 0.45;
-  z-index: 1;
-  border-color: rgba(40, 254, 180, 0.25);
-}
-
-.envstack__card:nth-child(4) {
-  --envstack-phase: -10.2s;
-  opacity: 0;
-  z-index: 0;
-}
-
-/* A card in one of the slots behind sits high enough that its contents clear
-   the front card's top edge and show through, so a card only shows what it is
-   carrying from the moment it lands in the front slot until it has folded away. */
-.envstack__body {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  height: 100%;
-  opacity: 0;
-  animation-name: envstack-reveal;
-  animation-duration: 13.6s;
-  animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
-  animation-iteration-count: infinite;
-  animation-delay: var(--envstack-phase);
-}
-
-.envstack__card:nth-child(1) .envstack__body {
-  opacity: 1;
-}
-
-@keyframes envstack-reveal {
-  0%, 45% { opacity: 0; }
-  49%, 75% { opacity: 1; }
-  75.01%, 100% { opacity: 0; }
-}
-
-@keyframes envstack-cycle {
-  0%, 15% {
-    transform: translateY(-27px) scale(0.86);
-    opacity: 0.45;
-    border-color: rgba(40, 254, 180, 0.25);
-    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
-    z-index: 1;
-  }
-
-  25%, 40% {
-    transform: translateY(-14px) scale(0.93);
-    opacity: 0.7;
-    border-color: rgba(40, 254, 180, 0.4);
-    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
-    z-index: 2;
-  }
-
-  50%, 65% {
-    transform: translateY(0) scale(1);
-    opacity: 1;
-    border-color: rgba(40, 254, 180, 0.8);
-    box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
-    z-index: 3;
-  }
-
-  /* Drops behind the rest of the deck for the whole fold, otherwise the card it
-     is sliding under would be the one that gets covered. The fold leads with its
-     travel so the card is clear of the front slot before the one replacing it
-     brings its own label up. */
-  65.01% {
-    z-index: 0;
-    animation-timing-function: cubic-bezier(0.3, 0.85, 0.4, 1);
-  }
-
-  69% {
-    transform: translateY(32px) scale(0.96) rotateX(44deg);
-    opacity: 0.55;
-  }
-
-  75% {
-    transform: translateY(52px) scale(0.92) rotateX(72deg);
-    opacity: 0;
-    z-index: 0;
-  }
-
-  /* Back of the deck, still invisible: the return trip has to happen in one
-     frame or the card would be seen travelling back up. */
-  75.01%, 90% {
-    transform: translateY(-27px) scale(0.86);
-    opacity: 0;
-    border-color: rgba(40, 254, 180, 0.25);
-    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
-    z-index: 1;
-  }
-
-  100% {
-    transform: translateY(-27px) scale(0.86);
-    opacity: 0.45;
-    border-color: rgba(40, 254, 180, 0.25);
-    box-shadow: 0 0 0 rgba(40, 254, 180, 0);
-    z-index: 1;
-  }
-}
-
-.envstack__icon {
-  flex: none;
-  width: 34px;
-  height: 34px;
-  border-radius: 8px;
-  border: 1px solid rgba(40, 254, 180, 0.5);
-  color: var(--color-k-mint);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.envstack__meta {
-  flex: 1;
-}
-
-.envstack__branch {
-  display: block;
-  font-family: var(--font-k-mono);
-  font-size: 13.5px;
-  font-weight: 600;
-  color: var(--color-k-text);
-}
-
-.envstack__tags {
-  display: block;
-  font-family: var(--font-k-mono);
-  font-size: 9.5px;
-  letter-spacing: 0.1em;
-  color: var(--color-k-dim);
-  margin-top: 3px;
-}
-
-.envstack__dot {
-  width: 8px;
-  height: 8px;
-  background: var(--color-k-red);
-}
-
-.envstack__dot--live {
-  background: var(--color-k-mint);
 }
 
 /* ── Globe ── */


### PR DESCRIPTION
Follow-up to #463. Two changes to the feature cards on the home page.

## The chart was scrolling the wrong way, and the mint probe jumped

The sample lattice travelled **right**, and the head cap read the sample one step *behind* the newest one. Every time the lattice shifted — once every 1.9s — the probe riding the head snapped to a freshly generated value:

```ts
// before: the newest sample sits AT the cap, then slides past it, so the cap
// falls back to the previous sample and jumps when the array shifts
const x = HEAD_X + offset - (values.length - 1 - i) * SPACING

// after: the newest sample is born one step past the cap and travels left into it
function sampleX(index: number): number {
  return HEAD_X + SPACING - offset - (values.length - 1 - index) * SPACING
}
```

One step of look-ahead means the cap always has a sample either side of it to interpolate, so nothing jumps. Measured over 600 frames spanning several shifts:

```
max probe move per frame:  red 0.41   mint 0.41   viewBox units
```

Interior vertices now travel left (`38.00 → 24.45` over a second, leftmost dropping off) instead of chasing the head.

## The environment deck moves to its own component, carrying two versions

`FeaturesComponent.vue` was holding the deck's markup, data and ~130 lines of keyframes alongside the chart. That moves to `EnvStack.vue`, which carries both passes of the motion behind a prop:

```html
<HomeEnvStack version="v2" />   <!-- FeaturesComponent.vue:150 -->
```

`v2` is `v1` reversed — the next stage rises up in front while the cards already there recede:

```css
/* v1: front card leaves downward */          /* v2: next card arrives from below */
50%, 65% { translateY(0) }                    72.01%, 90% { translateY(52px) rotateX(72deg) }
69%  { translateY(32px) rotateX(44deg) }      95%  { translateY(26px) rotateX(38deg) }
75%  { translateY(52px) rotateX(72deg) }      100% { translateY(0)  rotateX(0deg) }
                                              /* deck steps back: 0 → -14 → -27 → -38px */
```

The detail that needed care in `v2`: the front card gives up the top of the stack the instant it starts receding, or the card rising out from under it comes up *behind* it.

```css
0%, 15% { z-index: 3; }
15.01%  { z-index: 2; }   /* hands off before the riser overlaps */
```

## Checks

- Scrubbed the paused timeline frame by frame in Chromium: dwell frames show one labelled card over two slivers; mid-handover shows the new card unfolding upward in front of the receding deck.
- Reduced motion freezes both — chart holds its seeded frame (verified the `d` attribute stops changing), deck holds `PUSH` in front.
- Home and `/V2` both render with no console or page errors on top of #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_