### PR TITLE
Slow both feature-card animations to the pace of the cards below

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -39,6 +39,9 @@ const PIPELINE_STEPS = [
   width: 260px;
   height: 132px;
   perspective: 820px;
+  /* One trip through all four stages. Each card's phase is a quarter of this,
+     so the pace of the whole deck is tuned from here. */
+  --envstack-cycle: 26s;
 }
 
 .envstack__card {
@@ -56,7 +59,7 @@ const PIPELINE_STEPS = [
   transform-origin: 50% 0%;
   backface-visibility: hidden;
   will-change: transform, opacity;
-  animation-duration: 13.6s;
+  animation-duration: var(--envstack-cycle);
   animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
   animation-iteration-count: infinite;
   animation-delay: var(--envstack-phase);
@@ -71,7 +74,7 @@ const PIPELINE_STEPS = [
   gap: 14px;
   height: 100%;
   opacity: 0;
-  animation-duration: 13.6s;
+  animation-duration: var(--envstack-cycle);
   animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
   animation-iteration-count: infinite;
   animation-delay: var(--envstack-phase);
@@ -122,10 +125,10 @@ const PIPELINE_STEPS = [
   animation-name: envstack-fold-reveal;
 }
 
-.envstack--v1 .envstack__card:nth-child(1) { --envstack-phase: -6.8s; }
-.envstack--v1 .envstack__card:nth-child(2) { --envstack-phase: -3.4s; }
+.envstack--v1 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.5); }
+.envstack--v1 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.25); }
 .envstack--v1 .envstack__card:nth-child(3) { --envstack-phase: 0s; }
-.envstack--v1 .envstack__card:nth-child(4) { --envstack-phase: -10.2s; }
+.envstack--v1 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.75); }
 
 @keyframes envstack-fold {
   0%, 15% {
@@ -207,9 +210,9 @@ const PIPELINE_STEPS = [
 }
 
 .envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: 0s; }
-.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: -10.2s; }
-.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: -6.8s; }
-.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: -3.4s; }
+.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.75); }
+.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.5); }
+.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.25); }
 
 @keyframes envstack-rise {
   0%, 15% {

--- a/website/app/components/home/FeaturesComponent.vue
+++ b/website/app/components/home/FeaturesComponent.vue
@@ -13,7 +13,7 @@ const HEAD_X = 278
 /** Where the red probe is pinned; it only ever travels vertically. */
 const RED_X = 120
 /** viewBox units the line travels per second. */
-const SCROLL_SPEED = 16
+const SCROLL_SPEED = 7
 const PEAK_TOP = 26
 const PEAK_SPAN = 30
 const VALLEY_TOP = 66


### PR DESCRIPTION
Follow-up to #464. The usage chart and the environment deck were running noticeably faster than the globe and layer cards beside them, so they now sit at the same ambient pace.

```ts
// FeaturesComponent.vue:16 — viewBox units per second
const SCROLL_SPEED = 7   // was 16
```
```css
/* EnvStack.vue:44 */
--envstack-cycle: 26s;   /* was 13.6s */
```

| | before | now | neighbour it matches |
|---|---|---|---|
| chart traverse | 18.7s | **43s** | `globe-spin` 34s |
| chart, per new sample | 1.9s | **4.3s** | — |
| deck, per stage | 3.4s | **6.5s** | `layer-float` 5.5s |
| deck handover | 1.4s | **2.6s** | `globe-ping` 2.6s |

## The deck's cycle length now has one home

Tuning the deck meant editing eight places: two `animation-duration` declarations and six hardcoded phase offsets that were really just quarters of the same number. Changing the pace again would have meant recomputing all of them.

```css
/* before — six magic delays to recompute on every change */
animation-duration: 13.6s;
.envstack--v1 .envstack__card:nth-child(2) { --envstack-phase: -3.4s; }

/* after — one knob, and the phase states the slot offset it actually is */
--envstack-cycle: 26s;
animation-duration: var(--envstack-cycle);
.envstack--v1 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.25); }
```

## Checks

A `var()` that fails to resolve makes `animation-delay` fall back to `0s`, which would silently stack all four cards at the same phase rather than error — so the computed values were read back from the browser:

```
26s delay 0s  ·  26s delay -19.5s  ·  26s delay -13s  ·  26s delay -6.5s
```

- Chart drift measured at `6.99 units/sec` leftward on two consecutive runs, matching `SCROLL_SPEED`. Samples are matched across frames by value, since any single vertex's x jumps a whole `SPACING` when the leftmost one scrolls off.
- Deck handover and dwell frames scrubbed from the paused timeline at the new duration; proportions are unchanged, just slower.
- Reduced motion still freezes both. No console or page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_