### PR TITLE
Hold each animation at its first frame until it scrolls into view

### DIFF
--- a/website/app/app.css
+++ b/website/app/app.css
@@ -322,6 +322,20 @@ html.k-canvas-dark body {
 
 /* Scroll reveal. Elements start displaced and are un-hidden by the
    IntersectionObserver in pages/index.vue adding `.in`. */
+/* Every animation is held at its first frame until the block containing it scrolls
+   into view, so a reader arriving at a section watches one start instead of catching
+   it half-finished. The rule has to be static CSS rather than something the observer
+   applies, or the animation would already have run for however long hydration took.
+   useMarketingMotion() releases a block by adding the class, which frees everything
+   inside it — including nodes rendered later, such as the code panes' rows.
+   The `!important` is load-bearing: a component's scoped `.foo[data-v-x] { animation }`
+   ties this rule on specificity and wins on source order, since the components are
+   injected after this sheet. A released element stops matching, so the running side
+   needs no override. */
+.k-marketing :not(.k-motion-run, .k-motion-run *) {
+  animation-play-state: paused !important;
+}
+
 [data-reveal] {
   opacity: 0;
   transform: translateY(26px);

--- a/website/app/composables/useMarketingMotion.ts
+++ b/website/app/composables/useMarketingMotion.ts
@@ -1,42 +1,114 @@
+/** Marks a block whose animations have been released; see app.css for the hold. */
+const MOTION_RUN = 'k-motion-run'
+
+/** The SMIL timelines held on one block, keyed by the block that releases them. */
+type HeldSmil = Map<Element, SVGSVGElement[]>
+
+/**
+ * The block an animated node is released with: its nearest containing block,
+ * never the node itself. Releasing an ancestor rather than the node frees
+ * siblings rendered later — the code panes replace their rows on every slide.
+ */
+function blockOf(node: Element, root: Element): Element {
+  return node.parentElement?.closest('div, article, section') ?? root
+}
+
+/**
+ * Collects everything animating under `root` and stops it, returning the blocks
+ * to watch and the SVG timelines each one owns.
+ */
+function holdAnimations(root: Element): { blocks: Set<Element>, smil: HeldSmil } {
+  const smil: HeldSmil = new Map()
+  const blocks = new Set<Element>()
+
+  // SMIL is outside the CSS animation model, so the paused rule in app.css never
+  // reaches <animate>/<animateMotion>. Each SVG's own timeline has to be stopped.
+  for (const svg of root.querySelectorAll('svg')) {
+    if (!svg.querySelector('animate, animateMotion, animateTransform')) continue
+    svg.pauseAnimations()
+    // Rewound as well as stopped: the timeline ran from first paint until this
+    // call, so a held SVG would otherwise resume from however long hydration took.
+    svg.setCurrentTime(0)
+    const block = blockOf(svg, root)
+    smil.set(block, [...(smil.get(block) ?? []), svg])
+    blocks.add(block)
+  }
+
+  for (const node of root.querySelectorAll('*')) {
+    if (getComputedStyle(node).animationName !== 'none') blocks.add(blockOf(node, root))
+  }
+
+  return { blocks, smil }
+}
+
+/** Starts a block's animations, which holdAnimations() left at their first frame. */
+function release(block: Element, smil: HeldSmil) {
+  block.classList.add(MOTION_RUN)
+  for (const svg of smil.get(block) ?? []) svg.unpauseAnimations()
+}
+
 /**
  * Wires the shared motion behaviour of the marketing pages: elements carrying
- * `data-reveal` fade in as they scroll into view, and every SVG on the page is
- * frozen when the viewer has asked for reduced motion.
+ * `data-reveal` fade in as they scroll into view, and every animation is held at
+ * its first frame until the block containing it appears — or held for good, when
+ * the viewer has asked for reduced motion.
  *
- * Call once from a page's `setup`; the observer is released when that page
+ * Call once from a page's `setup`; the observers are released when that page
  * unmounts.
  */
 export function useMarketingMotion() {
-  let observer: IntersectionObserver | undefined
+  let reveal: IntersectionObserver | undefined
+  let motion: IntersectionObserver | undefined
 
   onMounted(() => {
-    // SMIL is outside the CSS animation model, so the `animation: none` rule in
-    // app.css never reaches the <animate>/<animateMotion> elements in the section
-    // illustrations, and `display: none` on them is ignored. Pausing each SVG's
-    // own timeline is what actually freezes them at their first frame.
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      document.querySelectorAll('svg').forEach(svg => svg.pauseAnimations())
-    }
-
+    const observable = 'IntersectionObserver' in window
     const targets = document.querySelectorAll('[data-reveal]')
 
     // Without an observer the reveal targets would stay at opacity 0 forever, so
     // show everything rather than render a blank page.
-    if (!('IntersectionObserver' in window)) {
+    if (!observable) {
       targets.forEach(el => el.classList.add('in'))
+    }
+    else {
+      reveal = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue
+          entry.target.classList.add('in')
+          reveal?.unobserve(entry.target)
+        }
+      }, { threshold: 0.12, rootMargin: '0px 0px -6% 0px' })
+
+      targets.forEach(el => reveal!.observe(el))
+    }
+
+    const root = document.querySelector('.k-marketing')
+    if (!root) return
+
+    const { blocks, smil } = holdAnimations(root)
+
+    // Reduced motion keeps everything held: app.css stops the CSS animations
+    // outright, and leaving the SVG timelines paused freezes the SMIL with them.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    // With nothing to report visibility, the hold would never lift.
+    if (!observable) {
+      blocks.forEach(block => release(block, smil))
       return
     }
 
-    observer = new IntersectionObserver((entries) => {
+    motion = new IntersectionObserver((entries) => {
       for (const entry of entries) {
         if (!entry.isIntersecting) continue
-        entry.target.classList.add('in')
-        observer?.unobserve(entry.target)
+        release(entry.target, smil)
+        motion?.unobserve(entry.target)
       }
-    }, { threshold: 0.12, rootMargin: '0px 0px -6% 0px' })
+    }, { threshold: 0, rootMargin: '0px 0px -8% 0px' })
 
-    targets.forEach(el => observer!.observe(el))
+    blocks.forEach(block => motion!.observe(block))
   })
 
-  onBeforeUnmount(() => observer?.disconnect())
+  onBeforeUnmount(() => {
+    reveal?.disconnect()
+    motion?.disconnect()
+  })
 }


### PR DESCRIPTION
Every animation on a marketing page ran from page load, so a reader scrolling down usually met each illustration mid-cycle or already finished. They now start when the block containing them appears. Applies to both `/` and `/V2`, since they share the composable.

## The hold has to be static CSS

An observer cannot pause what already started — by the time it runs, the animation has been going for however long hydration took. So the hold lives in the stylesheet and applies from first paint:

```css
/* website/app/app.css */
.k-marketing :not(.k-motion-run, .k-motion-run *) {
  animation-play-state: paused !important;
}
```

Two things in that selector are load-bearing:

- **`.k-motion-run *`** — releasing an ancestor frees everything inside it, including nodes rendered later. Without it, the API panes' rows (recreated on every slide change) would never match the released class and would stay paused at `opacity: 0` — a blank code pane.
- **`!important`** — a component's scoped `.foo[data-v-x] { animation: … }` is `(0,2,0)`, exactly tying this rule, and wins on source order because component styles are injected after `app.css`. Measured, not assumed: without it, `enterprise-dash`, `globe-spin`, `globe-ping`, `layer-float`, `cta-float` and `cta-tumble` all still reported `running` below the fold.

## SMIL needs its own handling

`<animate>` and `<animateMotion>` sit outside the CSS animation model, so the rule above never reaches them. Each SVG's timeline is stopped and rewound at mount, then unpaused on arrival:

```ts
// website/app/composables/useMarketingMotion.ts
for (const svg of root.querySelectorAll('svg')) {
  if (!svg.querySelector('animate, animateMotion, animateTransform')) continue
  svg.pauseAnimations()
  // Rewound as well as stopped: the timeline ran from first paint until this
  // call, so a held SVG would otherwise resume from however long hydration took.
  svg.setCurrentTime(0)
  ...
}
```

That rewind matters — before it, `.enterprise__p2p` sat frozen at `t = 0.3s` rather than `0`, and the 8-second sequence would have picked up a third of a second in.

## What gets released, and when

Blocks are discovered rather than marked, so a new illustration is covered without anyone remembering an attribute:

```ts
for (const node of root.querySelectorAll('*')) {
  if (getComputedStyle(node).animationName !== 'none') blocks.add(blockOf(node, root))
}
```

```ts
/**
 * The block an animated node is released with: its nearest containing block,
 * never the node itself. Releasing an ancestor rather than the node frees
 * siblings rendered later — the code panes replace their rows on every slide.
 */
function blockOf(node: Element, root: Element): Element {
  return node.parentElement?.closest('div, article, section') ?? root
}
```

The gate is the illustration's wrapper (`.features__visual`, `.api__code`, …), not the whole section, so each card on a stacked phone layout starts on its own. Observing the wrapper rather than the animated node also sidesteps IntersectionObserver's unreliability on SVG children.

Reduced motion holds everything permanently, which subsumes the previous `pauseAnimations()` behaviour. Without `IntersectionObserver` every block is released immediately, so the hold can never strand the page.

## The usage chart is untouched

It is a `requestAnimationFrame` walk over a seeded array with no CSS animation and no SMIL, so neither mechanism reaches it — and a continuously scrolling line has no beginning to miss:

```ts
// website/app/components/home/FeaturesComponent.vue
offset += delta * 0.001 * SCROLL_SPEED
chart.value = buildFrame()
frame = requestAnimationFrame(tick)
```

A check asserts it still runs from load, so this stays deliberate rather than becoming an oversight.

## Verification

Measured in Chromium against `bun run generate` output, on both `/` and `/V2`:

```
PASS  the hold rule survives minification
PASS  the hold rule frees descendants of a released block
PASS  nothing below the fold is animating: []
PASS  SMIL below the fold sits at frame zero: true
      held SMIL: [{"cls":"enterprise__p2p","onScreen":false,"t":0}]
PASS  the hero released on load and is running
PASS  scrolling to it releases the block
PASS  and its animation is running: "running"
PASS  the chart still runs from load, unheld
PASS  no SMIL advances under reduced motion
PASS  no CSS animation runs under reduced motion
```

The "nothing below the fold" check enumerates every element under `.k-marketing` with a computed `animation-name`, skips the ones on screen, and fails on any whose `animation-play-state` is not `paused` — it is what caught the specificity tie.

The `/V2` walkthrough suite still passes 36/36, including a new check that the released pane actually shows its rows: the row reveal fills backwards, so a pane whose block was never released would keep its geometry at `opacity: 0` and look like nothing rendered.

The one console error is `ERR_TUNNEL_CONNECTION_FAILED` on the Clarity tag, blocked by this sandbox's egress proxy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5puG89DemetMg1YWQoUAw)_