### PR TITLE
Hold section animations at their first frame until they scroll into view

### DIFF
--- a/website/app/app.css
+++ b/website/app/app.css
@@ -321,7 +321,7 @@ html.k-canvas-dark body {
 }
 
 /* Scroll reveal. Elements start displaced and are un-hidden by the
-   IntersectionObserver in pages/index.vue adding `.in`. */
+   IntersectionObserver in useMarketingMotion() adding `.in`. */
 [data-reveal] {
   opacity: 0;
   transform: translateY(26px);
@@ -333,6 +333,24 @@ html.k-canvas-dark body {
 [data-reveal].in {
   opacity: 1;
   transform: none;
+}
+
+/* Animations inside a reveal target are held at their first frame until that
+   target scrolls in, so each one is met at its beginning rather than part-way
+   through. Pausing keeps every animation's own delay, so a set staggered by
+   negative delays still holds its formation and resumes in step.
+
+   The `animation` shorthand resets play-state to running, so any component
+   declaring its animation that way — most of them — overrides this from its
+   own scoped rule unless the override is forced. */
+[data-reveal],
+[data-reveal] * {
+  animation-play-state: paused !important;
+}
+
+[data-reveal].in,
+[data-reveal].in * {
+  animation-play-state: running !important;
 }
 
 @media (max-width: 768px) {

--- a/website/app/components/home/CtaComponent.vue
+++ b/website/app/components/home/CtaComponent.vue
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <div class="cta__visual">
+      <div class="cta__visual" data-reveal>
         <div class="cta__glow cta__glow--red" />
         <div class="cta__glow cta__glow--mint" />
         <svg class="cta__cubes" viewBox="0 0 560 470" fill="none" preserveAspectRatio="xMidYMid meet" aria-hidden="true">


### PR DESCRIPTION
Follow-up to #467. Every animation below the fold ran from page load, so scrolling down landed you in the middle of the deck's handover or a part-rotated globe. The reveal observer already knows when a section arrives, so its targets now hold their animations until it does.

```css
/* app.css, alongside the existing [data-reveal] rules */
[data-reveal],
[data-reveal] * {
  animation-play-state: paused !important;
}

[data-reveal].in,
[data-reveal].in * {
  animation-play-state: running !important;
}
```

Pausing rather than delaying is what makes this work for the deck: a paused animation keeps its own `animation-delay`, so the five cards hold their staggered slots — front, mid, back, deep, off — and resume in formation with `PUSH · a41f9c` at the front.

## Why `!important` is load-bearing here

The first version without it silently did nothing for most of the page. `animation` is a shorthand that resets `animation-play-state` to `running`, and the components declaring their animations that way do it from a scoped rule that outranks a global `[data-reveal] *`:

```css
/* FeaturesComponent.vue — compiles to .globe__meridians[data-v-…], specificity (0,2,0) */
animation: globe-spin 34s linear infinite;   /* shorthand → play-state: running */

/* app.css — specificity (0,1,0), loses */
[data-reveal] * { animation-play-state: paused; }
```

Surveying every animation on the page caught it — `envstack-rise` (longhands, no play-state) was held, while `globe-spin`, `layer-float`, `globe-ping`, `enterprise-dash` and `enterprise-cube` all sat at `t=8016` still running. Specificity can't win this in general, since a component can always be more specific, so the override is forced — the same tool the reduced-motion block already uses.

## Two elements outside the mechanism

`.cta__visual` held the only animated illustration below the fold that wasn't inside a reveal target, so it becomes one — matching `.hero__visual` and `.features__card`, which already carry `data-reveal`.

`.hero__grid` is still ungated. It's the hero backdrop, on screen at load, so it is always seen from its first frame anyway.

## Checks

Every CSS animation on `/` and `/V2` was enumerated with `getAnimations()`, then sampled twice 2.5s apart:

```
=== / — at top of page ===
enterprise-dash    gated:true  in:false paused  t=0     HELD
envstack-rise      gated:true  in:false paused  t=0     HELD
globe-spin         gated:true  in:false paused  t=0     HELD
layer-float        gated:true  in:false paused  t=0     HELD
cta-float          gated:true  in:false paused  t=0     HELD
hero-float         gated:true  in:true   running t=1217        ← above the fold, correctly live

--- after features scroll in ---
envstack-rise      running t=167
globe-spin         running t=167
```

- The deck's first visible frame after reveal is `PUSH · a41f9c` at the front, not a mid-cycle pose.
- The usage chart is exempt as intended: it runs on its own `requestAnimationFrame` loop, which `animation-play-state` cannot touch, and measured `7.01 units/sec` while still off-screen.
- Reduced motion unaffected — zero reveal targets left hidden, nothing stuck.
- No console or page errors on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_