### PR TITLE
Lead each deck card with its stage rather than the branch

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -9,13 +9,17 @@
  */
 defineProps<{ version: 'v1' | 'v2' }>()
 
-/** The stages a pushed branch moves through, one per card in the deck. */
+/**
+ * The stages a pushed branch moves through, one per card in the deck. The stage
+ * is what the card leads with — it is the only line that changes for most of the
+ * run, so the branch it is working on rides underneath as context.
+ */
 const PIPELINE_STEPS = [
-  { branch: 'feature/checkout', stage: 'PUSH · a41f9c', icon: 'Folder', live: false },
-  { branch: 'feature/checkout', stage: 'BUILD · 3 SERVICES', icon: 'Cog', live: false },
-  { branch: 'feature/checkout', stage: 'UNIT TESTS · 248 OK', icon: 'ThLarge', live: false },
-  { branch: 'feature/checkout', stage: 'INTEGRATION · 36 OK', icon: 'Database', live: false },
-  { branch: 'main', stage: 'DEPLOY · PRODUCTION', icon: 'Refresh', live: true },
+  { stage: 'Push feature', context: 'feature/checkout', icon: 'Folder', live: false },
+  { stage: 'Build', context: 'feature/checkout', icon: 'Cog', live: false },
+  { stage: 'Unit tests', context: 'feature/checkout', icon: 'ThLarge', live: false },
+  { stage: 'Integration tests', context: 'feature/checkout', icon: 'Database', live: false },
+  { stage: 'Deploy to prod', context: 'main · production', icon: 'Refresh', live: true },
 ] as const
 </script>
 
@@ -25,8 +29,8 @@ const PIPELINE_STEPS = [
       <span class="envstack__body">
         <span class="envstack__icon"><KinoticIcon :name="step.icon" :size="16" /></span>
         <span class="envstack__meta">
-          <span class="envstack__branch">{{ step.branch }}</span>
-          <span class="envstack__tags">{{ step.stage }}</span>
+          <span class="envstack__stage">{{ step.stage }}</span>
+          <span class="envstack__context">{{ step.context }}</span>
         </span>
         <span class="k-livedot envstack__dot" :class="{ 'envstack__dot--live': step.live }" />
       </span>
@@ -323,15 +327,16 @@ const PIPELINE_STEPS = [
   flex: 1;
 }
 
-.envstack__branch {
+.envstack__stage {
   display: block;
   font-family: var(--font-k-mono);
   font-size: 13.5px;
   font-weight: 600;
   color: var(--color-k-text);
+  white-space: nowrap;
 }
 
-.envstack__tags {
+.envstack__context {
   display: block;
   font-family: var(--font-k-mono);
   font-size: 9.5px;


### PR DESCRIPTION
Follow-up to #470. Four of the five cards carried `feature/checkout` in the prominent line, so the deck read as one card sitting still — the only thing changing was small print no one looks at. The two lines swap roles.

```ts
/* before — the line that draws the eye is identical on 4 of 5 cards */
{ branch: 'feature/checkout', stage: 'PUSH · a41f9c',       … }
{ branch: 'feature/checkout', stage: 'BUILD · 3 SERVICES',  … }
{ branch: 'feature/checkout', stage: 'UNIT TESTS · 248 OK', … }

/* after — the stage leads, and the branch repeats underneath where repeating is the point */
{ stage: 'Push feature',      context: 'feature/checkout', … }
{ stage: 'Build',             context: 'feature/checkout', … }
{ stage: 'Unit tests',        context: 'feature/checkout', … }
{ stage: 'Integration tests', context: 'feature/checkout', … }
{ stage: 'Deploy to prod',    context: 'main · production', … }
```

The bold line now reads Push feature → Build → Unit tests → Integration tests → Deploy to prod as the deck cycles, and the last card's context flips to `main · production` alongside its mint dot, so the promotion still lands.

The two spans are renamed to match what they now hold:

```html
<span class="envstack__stage">{{ step.stage }}</span>      <!-- was __branch -->
<span class="envstack__context">{{ step.context }}</span>  <!-- was __tags -->
```

A class called `__branch` wrapping the text "Unit tests" is a trap for whoever reads this next.

## What was dropped

The per-stage detail (`a41f9c`, `3 SERVICES`, `248 OK`, `36 OK`) is gone. The context line has ~150px, and `feature/checkout · 248 OK` needs about 166px at the mono face and letter-spacing this line uses — it would have overflowed or wrapped. The branch alone is the constant worth keeping there; the counts were texture, and the stage name says more.

## Checks

- Both lines measured on every card: no overflow (`scrollWidth === clientWidth`) and single-line heights throughout (20px stage, 14px context), so nothing wraps into the card's fixed 72px.
- All five stages captured mid-dwell from the paused timeline; each reaches the front slot in order with its own label.
- No stale references to the old class names anywhere in the repo.
- No console or page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_