### PR TITLE
Hold SVG timelines until their section scrolls in, not just CSS animations

### DIFF
--- a/website/app/composables/useMarketingMotion.ts
+++ b/website/app/composables/useMarketingMotion.ts
@@ -1,7 +1,8 @@
 /**
  * Wires the shared motion behaviour of the marketing pages: elements carrying
- * `data-reveal` fade in as they scroll into view, and every SVG on the page is
- * frozen when the viewer has asked for reduced motion.
+ * `data-reveal` fade in as they scroll into view, and the illustrations inside
+ * them hold their first frame until that happens. Under reduced motion every
+ * SVG on the page stays frozen instead.
  *
  * Call once from a page's `setup`; the observer is released when that page
  * unmounts.
@@ -10,12 +11,25 @@ export function useMarketingMotion() {
   let observer: IntersectionObserver | undefined
 
   onMounted(() => {
-    // SMIL is outside the CSS animation model, so the `animation: none` rule in
-    // app.css never reaches the <animate>/<animateMotion> elements in the section
-    // illustrations, and `display: none` on them is ignored. Pausing each SVG's
-    // own timeline is what actually freezes them at their first frame.
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      document.querySelectorAll('svg').forEach(svg => svg.pauseAnimations())
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    // SMIL sits outside the CSS animation model, so neither the `animation: none`
+    // rule nor the `animation-play-state` gate in app.css reaches the
+    // <animate>/<animateMotion> elements in the section illustrations. Pausing
+    // each SVG's own timeline is what actually holds them, and seeking to zero
+    // discards the time that ran between page load and hydration.
+    const held = document.querySelectorAll<SVGSVGElement>(reduced ? 'svg' : '[data-reveal] svg')
+    held.forEach((svg) => {
+      svg.pauseAnimations()
+      svg.setCurrentTime(0)
+    })
+
+    // Reduced motion never reaches this, so those timelines stay at frame one.
+    const reveal = (target: Element) => {
+      target.classList.add('in')
+      if (!reduced) {
+        target.querySelectorAll<SVGSVGElement>('svg').forEach(svg => svg.unpauseAnimations())
+      }
     }
 
     const targets = document.querySelectorAll('[data-reveal]')
@@ -23,14 +37,14 @@ export function useMarketingMotion() {
     // Without an observer the reveal targets would stay at opacity 0 forever, so
     // show everything rather than render a blank page.
     if (!('IntersectionObserver' in window)) {
-      targets.forEach(el => el.classList.add('in'))
+      targets.forEach(reveal)
       return
     }
 
     observer = new IntersectionObserver((entries) => {
       for (const entry of entries) {
         if (!entry.isIntersecting) continue
-        entry.target.classList.add('in')
+        reveal(entry.target)
         observer?.unobserve(entry.target)
       }
     }, { threshold: 0.12, rootMargin: '0px 0px -6% 0px' })


### PR DESCRIPTION
#470 gated animations on scroll with `animation-play-state`, which reaches CSS keyframes and nothing else. The prototype-to-production illustration is SMIL:

```html
<!-- EnterpriseComponent.vue — one app crate slides from prototype to production -->
<animateMotion dur="8s" repeatCount="indefinite" keyPoints="0;0;1;1" keyTimes="0;.14;.38;1" …>
<animate attributeName="stroke" values="#5D5D66;#5D5D66;#28FEB4;#28FEB4" dur="8s" …>
```

SMIL answers to its own timeline, so it kept running from page load and was usually mid-flight or already landed on the production side by the time you scrolled to it. `useMarketingMotion` already knew this — its own comment says so, and it already pauses SVG timelines under reduced motion. That handling now applies on scroll too:

```ts
const held = document.querySelectorAll<SVGSVGElement>(reduced ? 'svg' : '[data-reveal] svg')
held.forEach((svg) => {
  svg.pauseAnimations()
  svg.setCurrentTime(0)
})

const reveal = (target: Element) => {
  target.classList.add('in')
  if (!reduced) {
    target.querySelectorAll<SVGSVGElement>('svg').forEach(svg => svg.unpauseAnimations())
  }
}
```

`setCurrentTime(0)` matters: a timeline starts at document load and the composable does not run until hydration, so without the seek the illustration resumes part-way through. Reduced motion never reaches `unpauseAnimations`, so those timelines stay at frame one as before.

## Checks

Polling `animationsPaused()` and `getCurrentTime()` from navigation through the scroll:

```
  5950ms paused=false t=5.63   in=false    ← pre-hydration, dev server
  6455ms paused=true  t=0      in=false    ← composable takes hold, seeks to 0
  8882ms paused=true  t=0      in=false    ← HELD while off-screen
  9388ms paused=false t=0.12   in=true     ← released on reveal, from the start
 11884ms paused=false t=2.62   in=true
```

- The first frame captured after reveal shows the crate still in the dashed **PROTOTYPE** box, which is the beginning of the sequence.
- Every SMIL-carrying SVG on `/` and `/V2` is inside a reveal target, so none is left ungated: `hero__pipes` (above the fold, released immediately) and `enterprise__p2p`.
- Reduced motion still reports `getCurrentTime() === 0` after scrolling the illustration into view.
- No console or page errors on either page.

An early run of this check reported the timelines free-running — that was sampling before the dev server finished hydrating, not a failure of the gate. The poll above is what settled it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_