### PR TITLE
Smooth the deck's handover

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -179,17 +179,11 @@ const PIPELINE_STEPS = [
   }
 
   /* Drops behind the rest of the deck for the whole fold, otherwise the card it
-     is sliding under would be the one that gets covered. The fold leads with its
-     travel so the card is clear of the front slot before the one replacing it
-     brings its own label up. */
+     is sliding under would be the one that gets covered. Nothing else belongs in
+     here: a keyframe between 72% and 80% that carried a position would restart
+     the easing and stall the card halfway through the fold. */
   72.01% {
     z-index: 0;
-    animation-timing-function: cubic-bezier(0.3, 0.85, 0.4, 1);
-  }
-
-  76% {
-    transform: translateY(32px) scale(0.96) rotateX(44deg);
-    opacity: 0.55;
   }
 
   80% {
@@ -218,8 +212,8 @@ const PIPELINE_STEPS = [
 }
 
 @keyframes envstack-fold-reveal {
-  0%, 56% { opacity: 0; }
-  59%, 80% { opacity: 1; }
+  0%, 52% { opacity: 0; }
+  60%, 80% { opacity: 1; }
   80.01%, 100% { opacity: 0; }
 }
 
@@ -282,18 +276,15 @@ const PIPELINE_STEPS = [
   }
 
   /* Under the deck, still invisible: the drop has to happen in one frame or the
-     card would be seen crossing the deck on its way down. */
+     card would be seen crossing the deck on its way down. A keyframe part-way
+     through the rise would restart the easing and stall the card mid-flight, so
+     the whole rise is left as one segment on the deck's own curve. */
   80.01%, 92% {
     transform: translateY(52px) scale(0.92) rotateX(72deg);
     opacity: 0;
     border-color: rgba(40, 254, 180, 0.8);
     box-shadow: 0 0 0 rgba(40, 254, 180, 0);
     z-index: 4;
-  }
-
-  96% {
-    transform: translateY(26px) scale(0.96) rotateX(38deg);
-    opacity: 0.75;
   }
 
   100% {
@@ -307,8 +298,8 @@ const PIPELINE_STEPS = [
 
 @keyframes envstack-rise-reveal {
   0%, 12% { opacity: 1; }
-  15%, 92% { opacity: 0; }
-  98%, 100% { opacity: 1; }
+  17%, 92% { opacity: 0; }
+  100% { opacity: 1; }
 }
 
 .envstack__icon {


### PR DESCRIPTION
Follow-up to #472. Rather than eyeball frames, I scrubbed the paused animation and read the rendered `transform` and `opacity` back per step. Two hitches showed up.

## The rise stalled halfway

A keyframe part-way up restarted the easing, so the card decelerated to a near stop at 96% and then set off again:

```
  pct       y   step        pct       y   step
   94    39.0   -7.6         94    48.3   -2.8
 94.5    31.4   -7.6       94.5    45.5   -4.3
   95    27.8   -3.6         95    41.2   -6.5
 95.5    26.4   -1.4       95.5    34.7   -8.7
   96    26.0   -0.4  ←      96    26.0   -8.7
 96.5    25.6   -0.4  ←    96.5    17.3   -8.7
   97    24.2   -1.4         97    10.8   -6.5
 97.5    20.6   -3.6       97.5     6.5   -4.3
   98    13.0   -7.6         98     3.7   -2.8
        before                      after
```

That waypoint sat within two degrees of where a single eased segment puts the card anyway (`26px/38°` vs the natural `26px/36°`), so it earns nothing:

```css
/* removed — its only effect was to break the arrival into two eased halves */
96% { transform: translateY(26px) scale(0.96) rotateX(38deg); opacity: 0.75; }
```

Both versions now cross their whole arrival in one segment, giving the symmetric bell on the right.

## The label was the abrupt part

It held at full opacity through the dwell, then blinked out in about half a second — the sharpest change anywhere in the cycle:

```
before: 0.973 → 0.851 → 0.500 → 0.149 → 0.027 → 0     peak −0.351 per step
after:  0.991 → 0.958 → 0.888 → 0.748 → 0.500 → …     peak −0.248 per step
```

```css
/* was 12% → 15%; now fades over the card's step back */
0%, 12% { opacity: 1; }
17%, 92% { opacity: 0; }
100% { opacity: 1; }
```

Stopping at 17% rather than running the full width of that move (20%) is deliberate. I tried 19% first and it looked worse: the card leaving the front slot stays uncovered until its replacement lands, so the longer tail left a legible "Push feature" ghost hanging above the arriving "Build" card. At 17% the residue is 0.042 by 16% and gone by 17% — no ghost, and the fade is still 66% longer than before.

## One piece of dead CSS

The fold's `z-index` keyframe carried a timing function that never applied — `transform` either side of it interpolates from the keyframe that *declares* it, not from an intermediate one. Removing it leaves the measured curve byte-identical, so it goes.

## Checks

Sharpest single step per 0.5% of the cycle, after:

```
translateY     8.7px  at 96.5%   (peak of a smooth bell, no stall)
card opacity   0.168  at 96.5%
label opacity  0.248  at 14.5%
```

- Both the rise and the fold now measure as monotonic accelerate-then-decelerate curves with no velocity jump.
- The 85px snap back onto the deck is unchanged and still happens at `opacity: 0`.
- Handover frames captured at 5.0s, 5.6s and 6.5s: a clean cross-dissolve mid-transition, no ghost once the incoming card lands.
- `v1` re-measured too — same smooth bell — and no console or page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_