### PR TITLE
Open the deck on a card that is still arriving

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -139,6 +139,9 @@ const PIPELINE_STEPS = [
   animation-name: envstack-fold-reveal;
 }
 
+/* Whole slots, unlike v2 below: a card folding away keeps its label the whole
+   way down, so holding this version part-way through a handover would open the
+   section with two labels on screen at once. */
 .envstack--v1 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.6); }
 .envstack--v1 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.4); }
 .envstack--v1 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.2); }
@@ -226,11 +229,17 @@ const PIPELINE_STEPS = [
   animation-name: envstack-rise-reveal;
 }
 
-.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: 0s; }
-.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.8); }
-.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.6); }
-.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.4); }
-.envstack--v2 .envstack__card:nth-child(5) { --envstack-phase: calc(var(--envstack-cycle) * -0.2); }
+/* Still a slot apart, but the whole cycle is backed up by a fifth of a slot, so
+   the first card is mid-rise when the deck is released rather than already
+   landed. Held on a whole slot it is the one card that never animates into
+   place, which reads as a mistake next to every card that follows it. The
+   fifth is what it takes for the card stepping back to have shed its label by
+   then, so only the arriving one is legible. */
+.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.96); }
+.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.76); }
+.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.56); }
+.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.36); }
+.envstack--v2 .envstack__card:nth-child(5) { --envstack-phase: calc(var(--envstack-cycle) * -0.16); }
 
 @keyframes envstack-rise {
   0%, 12% {


### PR DESCRIPTION
Follow-up to #473. The first card after scrolling in looked wrong while every card after it looked fine, and the reason is that it was the only one that never animated into place.

Dumping the deck 80ms after the reveal fired shows it already settled:

```
card1  y=  0   op=1.00  label=1.00     ← front, fully formed, never moved
card5  y=-12   op=0.72
card4  y=-23   op=0.50
card3  y=-33   op=0.30
card2  y=-42   op=0.00
```

The animations are held at their first frame until the section scrolls in, and a whole-slot phase puts the first card exactly at the start of its front dwell — landed. Every later card rises up into that slot, so the opening one is the odd one out.

Backing v2's cycle up by a fifth of a slot leaves it mid-rise instead:

```css
/* was whole slots: 0, -0.8, -0.6, -0.4, -0.2 */
.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.96); }
.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.76); }
.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.56); }
.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.36); }
.envstack--v2 .envstack__card:nth-child(5) { --envstack-phase: calc(var(--envstack-cycle) * -0.16); }
```

```
card1  y= 26   op=0.50  label=0.50     ← arriving, lands 1.3s after reveal
card5  y= -6   op=0.86  label=0.04     ← already shed its label
card4  y=-18   op=0.61
card3  y=-28   op=0.40
card2  y=-38   op=0.15
```

A fifth of a slot is the specific amount that works: it is how far the cycle has to back up for the card stepping back to have finished shedding its label. At a quarter it still reads at 0.25 and the section opens with two labels on screen.

## v1 keeps whole slots

The same shift makes v1 worse, so it stays as it was. A card folding away in that version keeps its label the whole way down by design, so holding it part-way through a handover opens with the outgoing label plainly legible below the deck:

```
v1 at the same shift:  card1 y=-6 label=0.50   card5 y=26 op=0.50 label=1.00   ← both readable
```

## Checks

- Front slot 1.4s after reveal is card1, and the order still cycles 1 → 2 → 3 → 4 → 5 → 1 over a full sweep.
- Reduced motion is untouched — the static slot poses are unchanged, so it still freezes on a settled deck with `Push feature` in front (`c1 y=0 op=1.00, c3 y=-33, c4 y=-23, c5 y=-12`).
- Frames at 60ms / 700ms / 2.5s after reveal show the card settling in rather than appearing.
- No console or page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_