### PR TITLE
Give the arriving card a decelerating rise

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -229,17 +229,17 @@ const PIPELINE_STEPS = [
   animation-name: envstack-rise-reveal;
 }
 
-/* Still a slot apart, but the whole cycle is backed up by a fifth of a slot, so
-   the first card is mid-rise when the deck is released rather than already
-   landed. Held on a whole slot it is the one card that never animates into
-   place, which reads as a mistake next to every card that follows it. The
-   fifth is what it takes for the card stepping back to have shed its label by
-   then, so only the arriving one is legible. */
-.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.96); }
-.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.76); }
-.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.56); }
-.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.36); }
-.envstack--v2 .envstack__card:nth-child(5) { --envstack-phase: calc(var(--envstack-cycle) * -0.16); }
+/* Still a slot apart, but the whole cycle is backed up a little, so the first
+   card is still climbing when the deck is released rather than already landed.
+   Held on a whole slot it is the one card that never animates into place, which
+   reads as a mistake next to every card that follows it. How far back is set by
+   the two labels: any earlier and the card being replaced still has a readable
+   label, so the section would open on the wrong one. */
+.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.94); }
+.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.74); }
+.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.54); }
+.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.34); }
+.envstack--v2 .envstack__card:nth-child(5) { --envstack-phase: calc(var(--envstack-cycle) * -0.14); }
 
 @keyframes envstack-rise {
   0%, 12% {
@@ -287,13 +287,17 @@ const PIPELINE_STEPS = [
   /* Under the deck, still invisible: the drop has to happen in one frame or the
      card would be seen crossing the deck on its way down. A keyframe part-way
      through the rise would restart the easing and stall the card mid-flight, so
-     the whole rise is left as one segment on the deck's own curve. */
+     the whole rise is one segment. It decelerates rather than easing in and out:
+     a card dealt up from under the deck should leave with intent and settle, and
+     the curve carries opacity too, so it is legible while it travels instead of
+     only once it lands. */
   80.01%, 92% {
     transform: translateY(52px) scale(0.92) rotateX(72deg);
     opacity: 0;
     border-color: rgba(40, 254, 180, 0.8);
     box-shadow: 0 0 0 rgba(40, 254, 180, 0);
     z-index: 4;
+    animation-timing-function: cubic-bezier(0.2, 0.8, 0.3, 1);
   }
 
   100% {
@@ -305,9 +309,13 @@ const PIPELINE_STEPS = [
   }
 }
 
+/* Both ends are set by the card climbing over the one it replaces. It is still
+   part transparent on the way up, so the outgoing label has to be gone before it
+   passes over it or the two read through each other, and the arriving label has
+   to wait until the card is opaque enough to cover what is behind it. */
 @keyframes envstack-rise-reveal {
   0%, 12% { opacity: 1; }
-  17%, 92% { opacity: 0; }
+  15%, 92% { opacity: 0; }
   100% { opacity: 1; }
 }
 

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,7 @@
   "name": "Kinotic",
   "private": true,
   "scripts": {
+    "postinstall": "nuxt prepare",
     "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate"


### PR DESCRIPTION
Follow-up to #474. Removing the waypoint that stalled the rise (#473) left it on a symmetric ease-in-out, and that is the wrong shape for a card being dealt up from under a deck. It crept:

```
 prog      y   step   cardOp        prog      y   step   cardOp
   92%     52    0.0        0         92%     52    0.0        0
 92.5%   51.8   -0.2    0.003       92.5%   39.5  -12.5     0.24
   93%   51.2   -0.6    0.014         93%   28.8  -10.7    0.445
   94%   48.3   -1.8    0.071         94%   14.6   -6.0    0.719
   95%   41.2   -4.3    0.208         95%    7.4   -3.0    0.858
   96%     26   -8.7      0.5         96%    3.6   -1.6     0.93
   98%    3.7   -2.8    0.929         98%    0.6   -0.4    0.988
  100%      0   -0.2        1        100%      0    0.0        1
      symmetric (worse)                   decelerating (now)
```

6px of 52 travelled in the first 1.3s, under half opacity the whole time — the card hung dim, then rushed. It now leaves with intent and settles:

```css
80.01%, 92% { … animation-timing-function: cubic-bezier(0.2, 0.8, 0.3, 1); }
```

Still one segment, so the stall #473 removed does not come back.

## What that changed for the labels

Putting the label on the same curve so it arrives with its card seemed obvious. It is worse — the card is still part transparent while it climbs over the card it replaces, so both labels read straight through each other:

```
incoming 93%: card 0.445, label 0.445   ← "Push feature"
outgoing 13%: card 0.996, label 0.958   ← "Deploy to prod", showing through
```

Two stage names superimposed, neither legible. So the labels keep their own timing, set by that occlusion rather than by the motion: the outgoing one clears **before** the card passes over it (back to 15%, from the 17% #473 moved it to), and the arriving one waits until the card is opaque enough to cover what is behind it.

## Entry offset retuned

#474 backed the cycle up a fifth of a slot so the first card is still climbing when the section reveals. Against the old curve that put it at `y=26`; against this one the same offset is `y=3.6` — 4px from home, no entrance at all. Now `-0.94` per card, which holds it at `y=15`.

## Checks

Sweeping the whole cycle at 0.25% steps:

```
sharpest travel step   6.4px per 81ms   (smooth, no discontinuity)
sharpest opacity step  0.123
frames with two legible labels   0
```

- Entrance frames at 50ms / 500ms / 1.2s after reveal show the card settling into its slot.
- `/V2` carries all of it — same `EnvStack`, same `32.5s` cycle, same held phases — since every fix in this series lives in the shared component, `app.css`, or `useMarketingMotion`.
- No console or page errors.

## Unrelated one-liner

```json
"postinstall": "nuxt prepare"
```

`.nuxt/` is gitignored and `tsconfig.json` extends `./.nuxt/tsconfig.json`, so a fresh clone has no types for any Nuxt auto-import until something generates them — which is the `TS2304: Cannot find name definePageMeta` an IDE reports before the dev server has been run. Happy to split this out if you would rather keep the PR to the animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_