### PR TITLE
Let the walkthrough run with the pointer resting over the panel

### DIFF
--- a/website/app/components/home/ApiConversationComponent.vue
+++ b/website/app/components/home/ApiConversationComponent.vue
@@ -221,10 +221,11 @@ const attended = ref(false)
 // isn't burning frames.
 const advancing = computed(() => playing.value && onscreen.value && !attended.value)
 
-// Pointer or focus on the play control is an instruction to run, so it must not
-// register as attention the way the rail and the transcript do. Hence mouseover
-// rather than mouseenter: it reports the element actually under the pointer.
-function onAttend(event: Event) {
+// Only focus counts as attention, never the pointer: the panel covers most of the
+// viewport, so a cursor left resting anywhere over it would hold the walkthrough
+// for as long as someone read — which is exactly when it should be running.
+// Focusing the play control is an instruction to run, so it is excluded.
+function onAttend(event: FocusEvent) {
   attended.value = !(event.target as HTMLElement).closest('.api__play')
 }
 
@@ -347,8 +348,6 @@ onBeforeUnmount(() => {
       <div
         class="api__panel"
         data-reveal
-        @mouseover="onAttend"
-        @mouseleave="attended = false"
         @focusin="onAttend"
         @focusout="attended = false"
       >

--- a/website/app/components/home/ApiStoryComponent.vue
+++ b/website/app/components/home/ApiStoryComponent.vue
@@ -326,10 +326,11 @@ const attended = ref(false)
 // isn't burning frames.
 const advancing = computed(() => playing.value && onscreen.value && !attended.value)
 
-// Pointer or focus on the play control is an instruction to run, so it must not
-// register as attention the way the rail and the code pane do. Hence mouseover
-// rather than mouseenter: it reports the element actually under the pointer.
-function onAttend(event: Event) {
+// Only focus counts as attention, never the pointer: the panel covers most of the
+// viewport, so a cursor left resting anywhere over it would hold the walkthrough
+// for as long as someone read — which is exactly when it should be running.
+// Focusing the play control is an instruction to run, so it is excluded.
+function onAttend(event: FocusEvent) {
   attended.value = !(event.target as HTMLElement).closest('.api__play')
 }
 
@@ -452,8 +453,6 @@ onBeforeUnmount(() => {
       <div
         class="api__panel"
         data-reveal
-        @mouseover="onAttend"
-        @mouseleave="attended = false"
         @focusin="onAttend"
         @focusout="attended = false"
       >


### PR DESCRIPTION
The cards never turned on their own, on `/V2` or `/V3`, even with the control showing Pause.

## What was happening

Hovering the panel paused rotation. The panel covers most of the viewport, so scrolling down with a wheel leaves the cursor somewhere over it — and it stays there for as long as someone reads, which is exactly when the walkthrough should be running.

Driving it the way a person does — wheel down with the pointer at the centre of the page — reproduces it on both pages:

```
/V2  before {"panel":"story-panel-describe","slide":0,"playLabel":"Pause the walkthrough","progress":"0.0047"}
     after  {"panel":"story-panel-describe","slide":0,"playLabel":"Pause the walkthrough","progress":"0.0047"}
     advanced: false
```

`playing` is true and the label says Pause, but `--k-progress` is frozen at 0.0047 — the clock ran about 33ms, then the pointer crossed the panel and `attended` latched on.

## The fix

```diff
-        @mouseover="onAttend"
-        @mouseleave="attended = false"
         @focusin="onAttend"
         @focusout="attended = false"
```

```ts
// Only focus counts as attention, never the pointer: the panel covers most of the
// viewport, so a cursor left resting anywhere over it would hold the walkthrough
// for as long as someone read — which is exactly when it should be running.
// Focusing the play control is an instruction to run, so it is excluded.
function onAttend(event: FocusEvent) {
  attended.value = !(event.target as HTMLElement).closest('.api__play')
}
```

Focus is deliberate — you tabbed there — so it still holds. Everything else that stops rotation is unchanged: clicking a step or a dot hands control over for good, the play/pause control works, it does not run off screen, and reduced motion never starts it. WCAG 2.2.2 is still satisfied by the explicit control.

Same one-line change in both components, since both carry the behaviour.

## Verification

The same reproduction, against the fix:

```
/V2  before slide 0, progress 0.0119  →  after slide 1, progress 0.2976   advanced: true
/V3  before slide 0, progress 0.0095  →  after slide 1, progress 0.2929   advanced: true
```

That reproduction replaced the two hover-pause checks in the suite, so the case that was broken is now the one being guarded:

```
PASS  advances with the pointer resting over the panel: true
```

Worth naming why this got through: every earlier check called `p.mouse.move(20, 20)` before waiting, parking the pointer off the panel. The suite proved rotation worked under a condition no reader is ever in. 34/34 pass now, including that one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5puG89DemetMg1YWQoUAw)_