### PR TITLE
Slide the arriving card up instead of folding it under

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -5,7 +5,8 @@
  * card while a fifth is off-deck, and each pipeline stage takes the front slot in turn.
  *
  * `v1` folds the front card down and under the deck. `v2` runs that in reverse:
- * the next stage rises up in front while the cards already there recede.
+ * the next stage rises up in front while the cards already there recede, with no
+ * fold — the card simply slides into the slot.
  */
 defineProps<{ version: 'v1' | 'v2' }>()
 
@@ -243,7 +244,7 @@ const PIPELINE_STEPS = [
 
 @keyframes envstack-rise {
   0%, 12% {
-    transform: translateY(0) scale(1) rotateX(0deg);
+    transform: translateY(0) scale(1);
     opacity: 1;
     border-color: rgba(40, 254, 180, 0.8);
     box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
@@ -257,7 +258,7 @@ const PIPELINE_STEPS = [
   }
 
   20%, 32% {
-    transform: translateY(-12px) scale(0.94) rotateX(0deg);
+    transform: translateY(-12px) scale(0.94);
     opacity: 0.72;
     border-color: rgba(40, 254, 180, 0.45);
     box-shadow: 0 0 0 rgba(40, 254, 180, 0);
@@ -265,43 +266,42 @@ const PIPELINE_STEPS = [
   }
 
   40%, 52% {
-    transform: translateY(-23px) scale(0.885) rotateX(0deg);
+    transform: translateY(-23px) scale(0.885);
     opacity: 0.5;
     border-color: rgba(40, 254, 180, 0.3);
     z-index: 2;
   }
 
   60%, 72% {
-    transform: translateY(-33px) scale(0.83) rotateX(0deg);
+    transform: translateY(-33px) scale(0.83);
     opacity: 0.3;
     border-color: rgba(40, 254, 180, 0.2);
     z-index: 1;
   }
 
   80% {
-    transform: translateY(-42px) scale(0.78) rotateX(0deg);
+    transform: translateY(-42px) scale(0.78);
     opacity: 0;
     z-index: 1;
   }
 
-  /* Under the deck, still invisible: the drop has to happen in one frame or the
+  /* Below the deck, still invisible: the drop has to happen in one frame or the
      card would be seen crossing the deck on its way down. A keyframe part-way
      through the rise would restart the easing and stall the card mid-flight, so
-     the whole rise is one segment. It decelerates rather than easing in and out:
-     a card dealt up from under the deck should leave with intent and settle, and
-     the curve carries opacity too, so it is legible while it travels instead of
-     only once it lands. */
+     the whole rise is one segment, decelerating — the card leaves with intent
+     and settles, and the curve carries opacity too, so it is legible while it
+     travels instead of only once it lands. */
   80.01%, 92% {
-    transform: translateY(52px) scale(0.92) rotateX(72deg);
+    transform: translateY(74px) scale(1);
     opacity: 0;
     border-color: rgba(40, 254, 180, 0.8);
     box-shadow: 0 0 0 rgba(40, 254, 180, 0);
     z-index: 4;
-    animation-timing-function: cubic-bezier(0.2, 0.8, 0.3, 1);
+    animation-timing-function: cubic-bezier(0.22, 0.78, 0.3, 1);
   }
 
   100% {
-    transform: translateY(0) scale(1) rotateX(0deg);
+    transform: translateY(0) scale(1);
     opacity: 1;
     border-color: rgba(40, 254, 180, 0.8);
     box-shadow: 0 0 34px rgba(40, 254, 180, 0.18);
@@ -309,14 +309,17 @@ const PIPELINE_STEPS = [
   }
 }
 
-/* Both ends are set by the card climbing over the one it replaces. It is still
-   part transparent on the way up, so the outgoing label has to be gone before it
-   passes over it or the two read through each other, and the arriving label has
-   to wait until the card is opaque enough to cover what is behind it. */
+/* The arriving label is switched on at the foot of the rise and travels up with
+   the card, so the card carries its stage in rather than filling it in once it
+   lands. Switching rather than fading is safe there: the card is still fully
+   transparent at that point. That leaves the outgoing label with nowhere to hide,
+   since the riser is legible from the first moments of its travel — so it clears
+   during the tail of its own dwell, before the card underneath starts moving. Any
+   later and the two labels interleave halfway up the rise. */
 @keyframes envstack-rise-reveal {
-  0%, 12% { opacity: 1; }
-  15%, 92% { opacity: 0; }
-  100% { opacity: 1; }
+  0%, 9% { opacity: 1; }
+  12.5%, 91.9% { opacity: 0; }
+  92%, 100% { opacity: 1; }
 }
 
 .envstack__icon {


### PR DESCRIPTION
The team picked **Slide up** from the motion study, so it goes in. The card rises straight into the front slot from below — no rotation, no scale:

```css
/* was: the fold */
80.01%, 92% { transform: translateY(52px) scale(0.92) rotateX(72deg); … }

/* now */
80.01%, 92% {
  transform: translateY(74px) scale(1);
  animation-timing-function: cubic-bezier(0.22, 0.78, 0.3, 1);
}
```

Nothing in `v2` rotates any more, so `rotateX(0deg)` comes off all five of its keyframes and the transform lists say what they mean. `v1` keeps the fold, untouched.

The measured arrival, a clean decelerating slide:

```
 prog     y   op    legible labels
   92%    74     0
 92.5%  57.9  0.22  Push feature@y58=0.22
   93%  43.3  0.41  Push feature@y43=0.41
   94%  22.5   0.7  Push feature@y22=0.7
   96%   5.6  0.92  Push feature@y6=0.92
  100%     0     1  Push feature@y0=1
```

## The label change this forced

The study had the label ride up with the card rather than appear once it lands, and that is what was liked about it. Porting only the motion would have lost it, so the label is switched on at the foot of the rise — safe there, since the card is still fully transparent.

That left the outgoing label nowhere to hide. The riser is legible from the first moments of its travel, so both were readable at once and **interleaved halfway up** — four lines of text in two overlapping boxes:

```
prog 93.5%  →  Push feature@y31=0.58  +  Deploy to prod@y0=0.49
```

The outgoing label now clears during the tail of its own dwell, before the card underneath starts moving:

```css
@keyframes envstack-rise-reveal {
  0%, 9% { opacity: 1; }          /* was 0%, 12% */
  12.5%, 91.9% { opacity: 0; }    /* was 15% */
  92%, 100% { opacity: 1; }
}
```

Sweeping the whole cycle at 0.25% steps, **no frame carries two legible labels**, and the sharpest travel step is 8.1px per 81ms — no discontinuity.

## Checks

- Entry hold from #474/#477 still lands mid-rise on the new curve: `held y=22 op=0.70 paused`, and card 1 is the front card after reveal.
- Reduced motion unchanged — `c1 y=0 op=1.00, c3 y=-33, c4 y=-23, c5 y=-12`, front label `Push feature`.
- Both `/` and `/V2` reveal the deck under real scrolling. Programmatic `scrollIntoView` does not reliably fire the observer in headless Chromium, which looked like a `/V2` bug until I scrolled the way a person would — worth knowing if anyone scripts against this.
- No console or page errors.

The study stays published for the record: https://claude.ai/code/artifact/61fc68f8-de75-4159-964a-0211289fbbc8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_