### PR TITLE
Open the deck on a settled frame, not mid-handover

### DIFF
--- a/website/app/components/home/EnvStack.vue
+++ b/website/app/components/home/EnvStack.vue
@@ -230,17 +230,16 @@ const PIPELINE_STEPS = [
   animation-name: envstack-rise-reveal;
 }
 
-/* Still a slot apart, but the whole cycle is backed up a little, so the first
-   card is still climbing when the deck is released rather than already landed.
-   Held on a whole slot it is the one card that never animates into place, which
-   reads as a mistake next to every card that follows it. How far back is set by
-   the two labels: any earlier and the card being replaced still has a readable
-   label, so the section would open on the wrong one. */
-.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.94); }
-.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.74); }
-.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.54); }
-.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.34); }
-.envstack--v2 .envstack__card:nth-child(5) { --envstack-phase: calc(var(--envstack-cycle) * -0.14); }
+/* Whole slots, so the deck is released on a settled frame. Backing the cycle up
+   to catch the first card mid-rise puts the handover on screen instead, and a
+   handover has a card that has shed its label on its way out of the front slot —
+   which is a lit, empty card sitting where the label should be. The arriving card
+   still animates in: the section's own reveal fades and lifts the whole card. */
+.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: 0s; }
+.envstack--v2 .envstack__card:nth-child(2) { --envstack-phase: calc(var(--envstack-cycle) * -0.8); }
+.envstack--v2 .envstack__card:nth-child(3) { --envstack-phase: calc(var(--envstack-cycle) * -0.6); }
+.envstack--v2 .envstack__card:nth-child(4) { --envstack-phase: calc(var(--envstack-cycle) * -0.4); }
+.envstack--v2 .envstack__card:nth-child(5) { --envstack-phase: calc(var(--envstack-cycle) * -0.2); }
 
 @keyframes envstack-rise {
   0%, 12% {


### PR DESCRIPTION
Follow-up to #483. The first cycle after the section scrolled in was jerky: an empty card border rose past the deck and faded before the animation settled. Dumping the held frame — the one frozen on screen until the reveal fires — shows why:

```
card1  Push feature       y= 22   op=0.70  label=1   z=4   ← arriving, labelled
card5  Deploy to prod     y= -1   op=0.98  label=0   z=3   ← lit, EMPTY, in the front slot
card4  Integration tests  y=-13   op=0.70  label=0   z=3
card3  Unit tests         y=-24   op=0.49  label=0   z=2
card2  Build              y=-34   op=0.28  label=0   z=1
```

`card5` is the empty border. #474 backed the cycle up by a fifth of a slot so the first card would still be climbing when the deck was released — but that lands the hold **mid-handover**, and a handover always contains a card that has shed its label on its way out of the front slot. Frozen there, that reads as a lit, empty card sitting exactly where the label should be. On release it recedes past the deck and fades, which is the border that pops up and disappears.

Porting the slide in #483 made it plain: the arriving card now holds lower and more transparent (`y=22 op=0.70` versus `y=15 op=0.86` under the fold), so it no longer covered the empty card behind it.

```css
/* was: backed up a fifth of a slot, holding mid-handover */
.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: calc(var(--envstack-cycle) * -0.94); }

/* now: whole slots, released on a settled frame */
.envstack--v2 .envstack__card:nth-child(1) { --envstack-phase: 0s; }
```

```
card1  Push feature       y=  0   op=1.00  label=1   front
card5  Deploy to prod     y=-12   op=0.72  label=0   mid
card4  Integration tests  y=-23   op=0.50  label=0   back
card3  Unit tests         y=-33   op=0.30  label=0   deep
```

## On losing #474's entrance

#474 existed because the first card was "the only one that never animates into place". That was overstated — it does animate in, via the section's own `[data-reveal]` fade and lift, the same entrance every other illustration on the page gets. The deck-level entrance was gilding, and it cost a visibly broken opening frame. A mid-rise hold and a clean opening frame cannot both be had here: the outgoing card is only clear of the front slot once the arriving one has landed.

## Checks

- No card anywhere in the deck is lit-and-empty at the front on `/`, `/V2`, or under reduced motion.
- Sweeping the cycle at 0.25% steps: 0/401 frames carry two legible labels, sharpest travel step 8.1px per 81ms.
- The five windows where no label passes a 0.4 threshold are the handover crossfades themselves — the outgoing label has cleared and the riser's is fading up with it, ~0.5s each. Not a gap; the arriving label is visible and climbing throughout.
- No console or page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QjJvrtsVVehxwmG9PK3xm)_