### PR TITLE
Publish the workload-runner image to Docker Hub

### DIFF
--- a/.github/workflows/workload-runner-docker.yml
+++ b/.github/workflows/workload-runner-docker.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
       statuses: write
     steps:
       - name: Cancel Previous Runs
@@ -23,12 +22,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -39,9 +37,9 @@ jobs:
           context: ./kinotic-js/workload-runner
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/kinotic-ai/workload-runner:latest
-          cache-from: type=registry,ref=ghcr.io/kinotic-ai/workload-runner:buildcache
-          cache-to: type=registry,ref=ghcr.io/kinotic-ai/workload-runner:buildcache,mode=max
+          tags: kinoticai/workload-runner:latest
+          cache-from: type=registry,ref=kinoticai/workload-runner:buildcache
+          cache-to: type=registry,ref=kinoticai/workload-runner:buildcache,mode=max
 
       - name: Add status to Commit
         uses: guibranco/github-status-action-v2@v1.2.4

--- a/kinotic-js/workload-runner/Dockerfile
+++ b/kinotic-js/workload-runner/Dockerfile
@@ -3,7 +3,7 @@
 # The sync workload runs `bun src/sync.ts` (set as the workload entrypoint) and the
 # runtime workload runs the default supervisor entrypoint.
 #
-# Build from this directory: docker build -t ghcr.io/kinotic-ai/workload-runner .
+# Build from this directory: docker build -t kinoticai/workload-runner .
 FROM oven/bun:1-slim
 
 # git for the checkout, ca-certificates for https to github.com and the Kinotic server

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/config/DeploymentProperties.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/config/DeploymentProperties.java
@@ -23,7 +23,7 @@ public class DeploymentProperties {
      * OCI image the sync and runtime workloads run — the workload-runner image holding the
      * checkout/sync entrypoint and the microservice supervisor.
      */
-    private String workloadRunnerImage = "ghcr.io/kinotic-ai/workload-runner:latest";
+    private String workloadRunnerImage = "kinoticai/workload-runner:latest";
 
     /**
      * Host the deployed workloads use to reach the api-gateway ({@code KINOTIC_SERVER_HOST}

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -127,7 +127,7 @@ under `kinotic.systemApi.deployment.*`:
 | `serverHost` | **required** | Host the deployed workloads use to reach the api-gateway (`KINOTIC_SERVER_HOST` in the guest). The server has no advertised address of its own, so startup fails without it |
 | `serverPort` | `58503` | Port the deployed workloads use to reach the api-gateway |
 | `serverUseSsl` | `false` | Whether the deployed workloads reach the api-gateway over TLS |
-| `workloadRunnerImage` | `ghcr.io/kinotic-ai/workload-runner:latest` | OCI image both workloads run — the checkout/sync entrypoint and the microservice supervisor |
+| `workloadRunnerImage` | `kinoticai/workload-runner:latest` | OCI image both workloads run — the checkout/sync entrypoint and the microservice supervisor |
 | `syncAllowedHosts` | `[]` | Destinations (IPv4 addresses or CIDRs) the sync workload may reach beyond the gateway — the repository host's ranges, so `git fetch` works under default-deny egress |
 | `runtimeAllowedHosts` | `[]` | Destinations the runtime workload may reach beyond the gateway |
 | `serverAllowedHosts` | `[]` | Destinations that resolve the gateway itself, granted to both workloads on top of the lists above |


### PR DESCRIPTION
Moves the workload-runner's distribution image from ghcr.io to Docker Hub, matching the repo's registry convention: ghcr is CI-internal staging (see gradle-build.yml's stage-then-promote flow), Docker Hub is where validated public images live.

- `workload-runner-docker.yml` logs into Docker Hub with the existing `DOCKER_HUB_USERNAME`/`DOCKER_HUB_PASSWORD` secrets and pushes `kinoticai/workload-runner:latest` (build cache follows; the now-unneeded `packages: write` permission is dropped).
- `DeploymentProperties.workloadRunnerImage` default becomes `kinoticai/workload-runner:latest`, so nodes pull from Docker Hub — public by default, no package-visibility step required for anonymous pulls.
- The configuration doc's property row and the Dockerfile's build-command comment follow.

Merging this fires the workflow (it touches `kinotic-js/workload-runner/**`) and publishes the first Docker Hub image, built from the lockfile pinned to kinotic-cli 5.2.0-beta.11. The image the previous ghcr run published is superseded and its package can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g82eKh6C9XF6BYkAveHaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011g82eKh6C9XF6BYkAveHaJ)_