### PR TITLE
Prune staged test images from ghcr.io on a schedule

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -24,8 +24,35 @@ jobs:
     name: Prune Staged Images
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       packages: write
     steps:
+      # A run stages sha-<commit> in build/migration_image and pulls it back in the suites that
+      # follow, so any commit whose run has not finished is still live no matter how old the image
+      # is. older-than alone does not settle this: it filters on the package version's updated_at,
+      # and a rebuild of an unchanged commit does not always advance that. Archives are byte
+      # identical for identical inputs (java-common-conventions.gradle sets preserveFileTimestamps
+      # and reproducibleFileOrder) and CNB pins the image creation date, so the nightly rebuild of a
+      # branch tip that has not moved re-pushes the digest already on the tag — a no-op push, and
+      # updated_at can still read from the first build a month earlier. Hence both branch tips are
+      # protected too: they are what the next scheduled run, or a re-run of the last one, will pull.
+      - name: Collect the tags a pipeline could still pull
+        id: live
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          runs="repos/${GITHUB_REPOSITORY}/actions/runs"
+          # Each capture is its own assignment so that -e aborts the step on a failed call. Piping
+          # the four together instead would swallow the failure and quietly protect fewer tags.
+          in_progress=$(gh api "${runs}?status=in_progress&per_page=100" --jq '.workflow_runs[].head_sha')
+          queued=$(gh api "${runs}?status=queued&per_page=100" --jq '.workflow_runs[].head_sha')
+          develop=$(gh api "repos/${GITHUB_REPOSITORY}/branches/develop" --jq '.commit.sha')
+          main=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')
+          tags=$(printf '%s\n' $in_progress $queued $develop $main | sort -u | sed 's/^/sha-/' | paste -sd, -)
+          echo "Protected from this sweep: ${tags}"
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
       # ghcr.io/kinotic-ai/workload-runner is intentionally absent: unlike the two staging packages
       # its tags are consumed outside CI — DeploymentProperties.workloadRunnerImage pulls :latest.
       - name: Delete staged images past the re-run window
@@ -34,8 +61,10 @@ jobs:
           packages: kinotic-migration,kinotic-server
           # Untagged versions here are prior builds of a sha the workflow built twice, orphaned when
           # the re-run pushed the same tag to a new digest. Both packages are single-platform, so no
-          # untagged version is a multi-arch child of a tag being kept.
+          # untagged version is a multi-arch child of a tag being kept. Nothing resolves a staged
+          # image by digest, so an untagged one is unreachable and needs no exclusion.
           delete-tags: 'sha-*'
           delete-untagged: true
+          exclude-tags: ${{ steps.live.outputs.tags }}
           older-than: 7 days
           dry-run: ${{ inputs.dry_run == true }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,41 @@
+name: GHCR Cleanup
+
+# Every push to develop or main stages kinotic-server and kinotic-migration on ghcr.io under
+# sha-<commit> (see gradle-build.yml), and nothing outside that workflow ever reads those tags —
+# what ships is promoted to Docker Hub. So a staged image is dead weight as soon as no one is going
+# to re-run the jobs of the run that produced it, and without this job they accumulate forever.
+#
+# Deliberately not done inline at the end of a build: re-running a failed suite pulls the staged
+# image again, so deleting it the moment the run finishes would break the retry. Sweeping on a delay
+# also collects the images left behind by runs that never reached the results job — the ones
+# cancel-in-progress superseded, and those that failed before promotion.
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log what would be deleted without deleting anything
+        type: boolean
+        default: false
+
+jobs:
+  cleanup:
+    name: Prune Staged Images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # ghcr.io/kinotic-ai/workload-runner is intentionally absent: unlike the two staging packages
+      # its tags are consumed outside CI — DeploymentProperties.workloadRunnerImage pulls :latest.
+      - name: Delete staged images past the re-run window
+        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        with:
+          packages: kinotic-migration,kinotic-server
+          # Untagged versions here are prior builds of a sha the workflow built twice, orphaned when
+          # the re-run pushed the same tag to a new digest. Both packages are single-platform, so no
+          # untagged version is a multi-arch child of a tag being kept.
+          delete-tags: 'sha-*'
+          delete-untagged: true
+          older-than: 7 days
+          dry-run: ${{ inputs.dry_run == true }}

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -32,7 +32,8 @@ env:
 
 # Application images are staged on ghcr.io under sha-<commit> and promoted to Docker Hub by the
 # results job only after every suite passes, so the tags outside CI consume are never advanced to an
-# unvalidated build. Nothing reads the staged tags except this workflow.
+# unvalidated build. Nothing reads the staged tags except this workflow; ghcr-cleanup.yml prunes
+# them once they are past the window in which a run's jobs might still be re-run.
 jobs:
   # Only the jar and the image — kinotic-migration's tests run in the `build` job with every other
   # module's. Kept separate from `build` because nothing here depends on the main build, so this


### PR DESCRIPTION
Every push to develop or main stages kinotic-server and kinotic-migration
under sha-<commit> so the test jobs run against the image built from that
commit. Nothing outside gradle-build.yml reads those tags — what ships is
promoted to Docker Hub — but nothing deleted them either, so a month of
per-commit images had piled up in the org's packages.

Sweep them daily once they are past the window in which a run's jobs might
still be re-run, rather than deleting inline at the end of a build: a retry
of a failed suite pulls the staged image again, and the delayed sweep also
collects images left behind by runs that never reached the results job.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RSpcH9bn3iRSr1S9gcXuMx