### PR TITLE
Reorganize GitHub config under managementApi namespace

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/EmailService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/EmailService.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletableFuture;
  * Sends transactional emails via Azure Communication Services. Bodies are rendered
  * from Handlebars templates.
  * <p>
- * When {@code kinotic.email.enabled=false}, sends are skipped and the action
+ * When {@code kinotic.domain.email.enabled=false}, sends are skipped and the action
  * URL is logged instead — useful for local development.
  */
 @Slf4j

--- a/kinotic-management-api/src/main/java/org/kinotic/management/api/config/GithubProperties.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/api/config/GithubProperties.java
@@ -11,11 +11,11 @@ import lombok.experimental.Accessors;
  * <p>
  * In production the secret values ({@link #appPrivateKey}, {@link #webhookSecret})
  * are mounted by the AKS Secret Store CSI driver as environment variables and bound
- * via Spring's relaxed property binding (e.g. {@code KINOTIC_GITHUB_APPPRIVATEKEY}).
+ * via Spring's relaxed property binding (e.g. {@code KINOTIC_MANAGEMENTAPI_GITHUB_APPPRIVATEKEY}).
  * For local dev they can also be set via {@code application.yml} or any other
  * Spring-supported source.
  * <p>
- * Bound under {@code kinotic.github.*} via {@link KinoticManagementApiProperties}; required
+ * Bound under {@code kinotic.managementApi.github.*} via {@link KinoticManagementApiProperties}; required
  * fields are validated at boot via Jakarta Bean Validation.
  */
 @Getter

--- a/kinotic-management-api/src/main/java/org/kinotic/management/api/config/KinoticManagementApiProperties.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/api/config/KinoticManagementApiProperties.java
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Contributes {@link GithubProperties} to the {@code kinotic} prefix.
+ * Contributes the {@link ManagementApiProperties} to the kinotic prefix.
+ * Configuration is accessible via {@code kinotic.managementApi.*}
  */
 @Getter
 @Setter
@@ -20,9 +21,15 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class KinoticManagementApiProperties extends KinoticProperties {
 
+    /**
+     * Management-api properties configuration.
+     */
     @Valid
     private ManagementApiProperties managementApi = new ManagementApiProperties();
 
+    /**
+     * If true, management-api functionality will not be loaded.
+     */
     private boolean disableManagement = false;
 
 }

--- a/kinotic-management-api/src/main/java/org/kinotic/management/internal/api/services/github/client/GitHubAppJwtFactory.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/internal/api/services/github/client/GitHubAppJwtFactory.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * for a 10-minute span. Forward lifetime from "now" is therefore 9 minutes — that's
  * the refresh interval, not a conservatism margin.
  * <p>
- * The key is read from {@code kinotic.github.appPrivateKey}. Both PKCS#1
+ * The key is read from {@code kinotic.managementApi.github.appPrivateKey}. Both PKCS#1
  * ({@code BEGIN RSA PRIVATE KEY}) and PKCS#8 ({@code BEGIN PRIVATE KEY}) PEM formats
  * are accepted — GitHub's download button emits PKCS#1.
  */

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -7,9 +7,10 @@ kinotic:
     # green and lets a developer publish far more definitions before hitting the cap.
     numberOfShards: 1
     numberOfReplicas: 0
-  github:
-    webhookSecret: "-"
-    appPrivateKey: "-"
+  managementApi:
+    github:
+      webhookSecret: "-"
+      appPrivateKey: "-"
   systemApi:
     deployment:
       # deployed workloads reach the dev gateway on the host

--- a/kinotic-server/src/main/resources/application.yml
+++ b/kinotic-server/src/main/resources/application.yml
@@ -9,10 +9,11 @@ kinotic:
         - https://claude.ai/oauth/claude-code-client-metadata
         # Claude web, desktop, and mobile custom connectors
         - https://claude.ai/oauth/mcp-oauth-client-metadata
-  github:
-    appId: 3584018
-    appSlug: kinotic-ai
-    repoTemplate: kinotic-ai/kinotic-tpl-isomorphic-ts
+  managementApi:
+    github:
+      appId: 3584018
+      appSlug: kinotic-ai
+      repoTemplate: kinotic-ai/kinotic-tpl-isomorphic-ts
 
 
 logging:

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/config/VmNodeProperties.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/config/VmNodeProperties.java
@@ -7,7 +7,7 @@ import lombok.experimental.Accessors;
 
 /**
  * Configuration properties for VmNode health monitoring.
- * Accessible via {@code kinotic.systemApi.node.*}
+ * Accessible via {@code kinotic.systemApi.vmNode.*}
  */
 @Getter
 @Setter

--- a/kinotic-test/src/test/resources/application.yml
+++ b/kinotic-test/src/test/resources/application.yml
@@ -24,12 +24,6 @@ kinotic:
     secretStorage:
       # Dummy Base64-encoded key for tests only; lets SecretNameDeriver start in the test context.
       masterKey: a2lub3RpYy10ZXN0LW1hc3Rlci1rZXktZHVtbXktMDA=
-  persistence:
-    enable-static-file-server: true
-    web-server-port: 8989
-    cors-allowed-origin-pattern: "*"
-    cors-allowed-headers: "*"
-    cors-allow-credentials: true
 
 logging:
   level:


### PR DESCRIPTION
Moves GitHub configuration from the top-level `kinotic.github.*` namespace to `kinotic.managementApi.github.*`, aligning with the module structure where GitHub integration is a management-api concern.

**Changes:**

- **Configuration hierarchy**: Nested `github` properties under `managementApi` in `application.yml` and `application-development.yml`
- **Property binding**: Updated `KinoticManagementApiProperties` to document the new `kinotic.managementApi.*` prefix and added JavaDoc for `managementApi` and `disableManagement` fields
- **Documentation**: Updated JavaDoc in `GithubProperties` and `GitHubAppJwtFactory` to reflect the new config path (`kinotic.managementApi.github.appPrivateKey` instead of `kinotic.github.appPrivateKey`)
- **Related fixes**: 
  - Corrected `EmailService` JavaDoc to reference `kinotic.domain.email.enabled` (was incorrectly `kinotic.email.enabled`)
  - Fixed `VmNodeProperties` JavaDoc to reference `kinotic.systemApi.vmNode.*` (was `kinotic.systemApi.node.*`)
- **Test cleanup**: Removed orphaned `persistence` configuration block from test `application.yml` that was no longer used

This change improves configuration clarity by grouping management-api-specific settings under their owning module's namespace, making the configuration structure more discoverable and maintainable.

https://claude.ai/code/session_01GM56zwXaaNLn2Jy7V8Rvvt