### PR TITLE
Publish entities on sync and update zone naming

### DIFF
--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -162,7 +162,7 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://system-api~kinotic-ai.vm-manager.VmManager#0.1.0")));
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@system-api~kinotic-ai.vm-manager.VmManager#0.1.0")));
 
-        // os-api and app-api are hosted in-process only, so not even system may subscribe to them
+        // management-api and app-api are hosted in-process only, so not even system may subscribe to them
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://management-api~org.kinotic.some.PlatformService#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.some.DataService#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
@@ -194,7 +194,7 @@ public class StompAuthorizerFactoryTest {
         // a scope carrying the zone delimiter cannot even be constructed (see CRITests)
         assertThrows(IllegalArgumentException.class,
                      () -> CRI.create("srv://app.acme-org.orders-app~x@app.acme-org.other-app~OrderService/create#1.0.0"));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@os-api~org.kinotic.management.api.services.iam.MemberService/inviteMember#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@management-api~org.kinotic.management.api.services.iam.MemberService/inviteMember#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app~OrderService#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.x@app.acme-org.other-app~OrderEvents")));
     }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
@@ -44,7 +44,7 @@ public interface ServiceDirectory {
 
     /**
      * Returns the online MCP tools the given scope may call, mirroring the zone send rules enforced at call time:
-     * a system scope (both ids null) sees all tools, an organization scope sees {@code os-api}- and
+     * a system scope (both ids null) sees all tools, an organization scope sees {@code management-api}- and
      * {@code app-api}-zone tools, and an application scope sees its own {@code app.<org>.<app>}-zone tools plus
      * {@code app-api}-zone tools.
      * @param organizationId the calling scope's organization, or null for a system scope

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/CRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/CRI.java
@@ -48,7 +48,7 @@ public interface CRI {
      * The zone this {@link CRI} is addressed in, or null if un-zoned
      *
      * The zone is the isolation boundary routing is validated against, such as
-     * {@code app.acme-org.orders-app} or {@code os-api}.
+     * {@code app.acme-org.orders-app} or {@code management-api}.
      *
      * For the following CRI zone would be the portion specified by zone
      *

--- a/kinotic-core/src/main/java/org/kinotic/core/api/utils/KinoticUtil.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/utils/KinoticUtil.java
@@ -27,7 +27,7 @@ public class KinoticUtil {
      * This means the tool name called by an LLM will always be an allowed character set and should never collide with other tools.
      * Tool names are minted here and never parsed back apart.
      * @param qualifiedName the service's qualified name, as {@code ServiceIdentifier.qualifiedName()} returns
-     *                      it, such as {@code os-api~org.kinotic.management.api.services.ProjectService}
+     *                      it, such as {@code management-api~org.kinotic.management.api.services.ProjectService}
      * @param functionName the name of the function the tool calls
      * @return the tool name, made only of {@code [0-9a-z]}
      */

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/ZoneRules.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/ZoneRules.java
@@ -33,10 +33,10 @@ public class ZoneRules {
     /**
      * Derives the zone rules for the given participant. Application participants send to the {@code app-api}
      * data plane and their own {@code app.<organizationId>.<applicationId>} zone and subscribe in no zone at
-     * all. Organization participants send to the {@code os-api} management surface, {@code app-api}, and their
-     * own {@code app.<organizationId>} zones, and subscribe within those same app zones — an application's
-     * runtime authenticates as an organization participant to host and call its services. System participants
-     * send everywhere and subscribe in the {@code system} zone.
+     * all. Organization participants send to the {@code management-api} management surface, {@code app-api},
+     * and their own {@code app.<organizationId>} zones, and subscribe within those same app zones — an
+     * application's runtime authenticates as an organization participant to host and call its services.
+     * System participants send everywhere and subscribe in the {@code system-api} zone.
      * @param participant the authenticated participant
      * @return the participant's zone rules
      */
@@ -48,8 +48,8 @@ public class ZoneRules {
         }
         return switch (scopedParticipant) {
 
-            // os-api and app-api are hosted in-process only, so no connection may ever subscribe
-            // to them; the system zone stays subscribable for the vm-manager nodes that host there
+            // management-api and app-api are hosted in-process only, so no connection may ever
+            // subscribe to them; system-api stays subscribable for the vm-manager nodes that host there
             case SystemParticipant _ -> new ZoneRules(true, Set.of(), Set.of(DomainUtil.SYSTEM_API_ZONE));
 
             // appZone validates the ids, so an id that could shift the zone's label structure

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ServiceDirectoryEntryRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ServiceDirectoryEntryRepository.java
@@ -206,7 +206,7 @@ public class ServiceDirectoryEntryRepository extends AbstractRepository<ServiceD
     }
 
     // The listing view of the zone send rules enforced at dispatch time by ZoneRules: system sees all zones,
-    // an organization sees os-api + app-api, an application sees its own app.<org>.<app> zone + app-api.
+    // an organization sees management-api + app-api, an application sees its own app.<org>.<app> zone + app-api.
     private Query zoneVisibilityFilter(String organizationId, String applicationId) {
         Query ret;
         if (organizationId == null) {

--- a/kinotic-js/workload-runner/README.md
+++ b/kinotic-js/workload-runner/README.md
@@ -15,7 +15,7 @@ bun src/sync.ts                               bun src/supervise.ts   (image defa
 mounts <checkout> read-write                  mounts <checkout> read-only
 fetch + checkout GIT_REF                      runs the project's microservice entry
 bun install                                   polls .kinotic/reload for changes
-entity definition sync                        restarts the process when it changes
+entity sync + publish                         restarts the process when it changes
 write .kinotic/reload  ←──────────────────────┘
 ```
 
@@ -37,10 +37,13 @@ micro VMs sharing a host mount, and inotify events do not cross the VM boundary.
 | `KINOTIC_SERVER_HOST/PORT/USE_SSL`, `KINOTIC_CLIENT_ID`, `KINOTIC_CLIENT_SECRET`, `KINOTIC_ORGANIZATION_ID` | machine identity and server the CLI connects with; sync is skipped when no credentials are present | — |
 | `KINOTIC_CLI_BIN` | overrides the kinotic CLI entry script (development/tests) | resolved from the image install |
 
-Entity sync runs `kinotic sync` over the checkout. The projects have no CI of their own —
-this deploy run is their pipeline — so the CLI's generation step recompiles the entity
-sources (a project that does not build never reaches the server) and pushes the fresh
+Entity sync runs `kinotic sync --publish` over the checkout. The projects have no CI of
+their own — this deploy run is their pipeline — so the CLI's generation step recompiles the
+entity sources (a project that does not build never reaches the server) and pushes the fresh
 definitions and migrations, authenticated by the machine identity in the environment.
+`--publish` creates the backing index for each entity the deploy introduces, so a pushed
+entity is usable for data operations without anyone publishing it by hand; entities already
+published are left alone.
 
 The git token travels as a per-invocation `http.extraheader`, never written to
 `.git/config` or embedded in the remote URL — the checkout is a shared host directory and

--- a/kinotic-js/workload-runner/src/sync.ts
+++ b/kinotic-js/workload-runner/src/sync.ts
@@ -71,12 +71,13 @@ function syncSource(workspaceDir: string, cloneUrl: string, ref: string, token: 
 }
 
 /**
- * Runs `kinotic sync` over the checkout: generation compiles the entity sources and
- * refreshes the definitions — the projects have no CI of their own, so this deploy run is
- * where a project that does not build gets stopped — then the definitions and migrations
- * are pushed. The CLI authenticates with the machine identity in the environment; the sync
- * is skipped entirely when no credentials are present, so the checkout itself still works
- * against a server the workload cannot reach yet.
+ * Runs `kinotic sync --publish` over the checkout: generation compiles the entity sources
+ * and refreshes the definitions — the projects have no CI of their own, so this deploy run
+ * is where a project that does not build gets stopped — then the definitions and migrations
+ * are pushed and every entity is published, leaving it usable for data operations. The CLI
+ * authenticates with the machine identity in the environment; the sync is skipped entirely
+ * when no credentials are present, so the checkout itself still works against a server the
+ * workload cannot reach yet.
  */
 function syncEntities(workspaceDir: string): void {
     if (!process.env.KINOTIC_CLIENT_ID && !process.env.KINOTIC_TOKEN) {
@@ -92,7 +93,11 @@ function syncEntities(workspaceDir: string): void {
     // bun runs the CLI's entry script directly, so its node shebang never matters
     const cliEntry = process.env.KINOTIC_CLI_BIN
         ?? Bun.resolveSync('@kinotic-ai/kinotic-cli/bin/run.js', import.meta.dir)
-    run('bun', [cliEntry, 'sync', '--server', serverUrlFromEnv()], workspaceDir)
+    // --publish creates the backing index for an entity the deploy just introduced; without
+    // it the definition lands unpublished and every repository call against it fails. The
+    // flag only acts on definitions that are not published yet, so redeploys are a no-op for
+    // entities already serving data.
+    run('bun', [cliEntry, 'sync', '--publish', '--server', serverUrlFromEnv()], workspaceDir)
 }
 
 function serverUrlFromEnv(): string {

--- a/kinotic-js/workload-runner/test/sync.test.ts
+++ b/kinotic-js/workload-runner/test/sync.test.ts
@@ -122,7 +122,7 @@ describe('sync entrypoint', () => {
 
         expect(result.status).toBe(0)
         expect(readFileSync(join(baseDir, 'cli-invocations.log'), 'utf-8').trim())
-            .toBe('sync --server http://kinotic.example:58503')
+            .toBe('sync --publish --server http://kinotic.example:58503')
         expect(readFileSync(join(workspaceDir, '.kinotic', 'reload'), 'utf-8')).toBe(sha)
     }, 30_000)
 

--- a/kinotic-management-api/src/test/java/org/kinotic/management/api/services/McpServiceSchemaTest.java
+++ b/kinotic-management-api/src/test/java/org/kinotic/management/api/services/McpServiceSchemaTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 /**
- * Verifies every MCP-exposed os-api service converts to a ServiceDefinition with the same converter set
+ * Verifies every MCP-exposed management-api service converts to a ServiceDefinition with the same converter set
  * the server wires at startup — an unconvertible type anywhere in a signature silently drops the whole
  * service from the directory, and with it every tool it provides.
  */

--- a/website/content/01.apps/02.quick-start.md
+++ b/website/content/01.apps/02.quick-start.md
@@ -91,7 +91,7 @@ Kinotic OS reads entity definitions from the connected GitHub repository and syn
 The provisioned repository ships a starter microservice at `packages/microservices/main` that already sets the zone and connects. Extend its `src/main.ts` to try the repository out:
 
 ```typescript
-import { Kinotic } from '@kinotic-ai/core'
+import { Kinotic, Pageable } from '@kinotic-ai/core'
 import { PersistencePlugin } from '@kinotic-ai/persistence'
 import { PersonRepository } from '@my-app/domain'
 import { appZone } from '@kinotic-ai/management-api'
@@ -117,7 +117,7 @@ const person = await personRepository.save({
 console.log('Saved:', person)
 
 // Find all people
-const page = await personRepository.findAll({ page: 0, size: 10 })
+const page = await personRepository.findAll(Pageable.create(0, 10))
 console.log('People:', page.content)
 ```
 

--- a/website/content/01.apps/07.deployment/03.push-to-deploy.md
+++ b/website/content/01.apps/07.deployment/03.push-to-deploy.md
@@ -26,9 +26,11 @@ Deployment page (and, like any job, on the Jobs page):
 2. **Sync project source** — a short-lived, sandboxed build VM brings the checkout to the
    pushed commit (an incremental fetch, not a fresh clone — installs stay warm), installs
    dependencies, and compiles the project. This step is the build gate: a commit that does
-   not build never reaches your running services, and your entity definitions are
-   synchronized to the server. Only after everything succeeded does it signal the runtime
-   to reload.
+   not build never reaches your running services. Your entity definitions are synchronized
+   and published here, so an entity added in this commit has its backing storage created
+   and is ready for data operations; entities already published keep serving. Pending
+   migrations in `./migrations` are applied in the same step. Only after everything
+   succeeded does it signal the runtime to reload.
 3. **Ensure runtime workload** — the first deployment starts the long-lived VM that runs
    your project's microservices from the checkout (mounted read-only). Later deployments
    skip this step: the running supervisor sees the reload signal and restarts your


### PR DESCRIPTION
Adds `--publish` flag to entity sync operations and updates documentation and API references to use `management-api` instead of the deprecated `os-api` naming.

## Changes

**Entity Publishing:**
- `kinotic-js/workload-runner/src/sync.ts:96` — Add `--publish` flag to `kinotic sync` invocation so entities introduced in a deploy have their backing index created immediately and are ready for data operations without manual publishing
- `kinotic-js/workload-runner/test/sync.test.ts:125` — Update test expectation to verify `--publish` flag is passed
- `kinotic-js/workload-runner/README.md:40,40-46` — Document the `--publish` behavior: it creates backing storage for new entities while leaving already-published entities alone

**Zone Naming Updates:**
- `kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/ZoneRules.java:36-39,51-52` — Update Javadoc and comments from `os-api` to `management-api`
- `kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java:165,197` — Update test comments from `os-api` to `management-api`
- `kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java:47` — Update Javadoc from `os-api` to `management-api`
- `kinotic-core/src/main/java/org/kinotic/core/api/event/CRI.java:51` — Update Javadoc example from `os-api` to `management-api`
- `kinotic-core/src/main/java/org/kinotic/core/api/utils/KinoticUtil.java:30` — Update Javadoc example from `os-api` to `management-api`
- `kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/ServiceDirectoryEntryRepository.java:209` — Update comment from `os-api` to `management-api`
- `kinotic-management-api/src/test/java/org/kinotic/management/api/services/McpServiceSchemaTest.java:44` — Update Javadoc from `os-api` to `management-api`

**Documentation:**
- `website/content/01.apps/07.deployment/03.push-to-deploy.md:29-32` — Clarify that entity definitions are synchronized and published during the sync step, with new entities ready for data operations and pending migrations applied
- `website/content/01.apps/02.quick-start.md:94,120` — Update quick-start example to import `Pageable` and use `Pageable.create(0, 10)` instead of inline object literal for repository queries

## Implementation Details

The `--publish` flag ensures entities are immediately usable after deployment without requiring manual intervention. The flag is idempotent — it only acts on unpublished definitions, so redeploys of existing entities are unaffected. This aligns with the deployment pipeline's goal of making pushed code immediately operational.

The zone naming change from `os-api` to `management-api` reflects the actual API zone identifier used throughout the system and improves consistency across documentation and code comments.

https://claude.ai/code/session_01DH1YoW6zNkZPtm4w3j6EFH