### PR TITLE
Suspend context execution while awaiting futures on run threads

### DIFF
--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/DefaultJobService.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/DefaultJobService.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.vertx.core.Future;
@@ -197,11 +196,11 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
 
     private <T> T await(Future<T> future) {
         try {
-            return future.toCompletionStage().toCompletableFuture().get();
-        } catch (InterruptedException e) {
-            throw new RunCancelledException();
-        } catch (ExecutionException e) {
-            throw new IllegalStateException("Could not load the run being resumed", e.getCause());
+            return RunThread.await(future);
+        } catch (RunCancelledException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not load the run being resumed", e);
         }
     }
 

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/JobInterpreter.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/JobInterpreter.java
@@ -22,12 +22,14 @@ import org.springframework.context.ConfigurableApplicationContext;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 
+import io.vertx.core.Promise;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -288,7 +290,7 @@ public class JobInterpreter {
         if (raw instanceof CompletionStage<?> stage) {
             ret = awaitStage(stage);
         } else if (raw instanceof io.vertx.core.Future<?> future) {
-            ret = awaitStage(future.toCompletionStage());
+            ret = RunThread.await(future);
         } else if (raw instanceof Publisher<?> publisher) {
             ret = awaitPublisher(publisher);
         } else {
@@ -297,15 +299,19 @@ public class JobInterpreter {
         return ret;
     }
 
-    @SneakyThrows
     private Object awaitStage(CompletionStage<?> stage) {
-        try {
-            return stage.toCompletableFuture().get();
-        } catch (InterruptedException e) {
-            throw new RunCancelledException();
-        } catch (ExecutionException e) {
-            throw e.getCause() != null ? e.getCause() : e;
-        }
+        Promise<Object> bridge = Promise.promise();
+        stage.whenComplete((value, error) -> {
+            if (error == null) {
+                bridge.tryComplete(value);
+            } else {
+                // a failure that crossed a dependent stage arrives CompletionException-wrapped;
+                // deliver the raw cause, as CompletableFuture.get's unwrap would
+                bridge.tryFail(error instanceof CompletionException && error.getCause() != null
+                                       ? error.getCause() : error);
+            }
+        });
+        return RunThread.await(bridge.future());
     }
 
     private Object awaitPublisher(Publisher<?> publisher) {

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
@@ -1,6 +1,10 @@
 package org.kinotic.grind.internal.api.services;
 
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
+import lombok.SneakyThrows;
+import org.kinotic.grind.internal.model.RunCancelledException;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -12,17 +16,25 @@ import java.util.concurrent.CountDownLatch;
  */
 public class RunThread {
 
+    // The cancellation future of the run thread executing the calling code; await races the
+    // awaited future against it so cancellation wakes a parked await through the future's
+    // own resume handshake rather than through the interrupt alone
+    private static final ThreadLocal<Future<Void>> CURRENT_CANCELLATION = new ThreadLocal<>();
+
     private final CompletableFuture<Thread> thread = new CompletableFuture<>();
     private final CountDownLatch done = new CountDownLatch(1);
+    private final Promise<Void> cancellation = Promise.promise();
 
     RunThread(ContextInternal context, String name, Runnable body) {
         context.runOnContext(v -> {
             Thread current = Thread.currentThread();
             current.setName(name);
             thread.complete(current);
+            CURRENT_CANCELLATION.set(cancellation.future());
             try {
                 body.run();
             } finally {
+                CURRENT_CANCELLATION.remove();
                 done.countDown();
             }
         });
@@ -33,6 +45,11 @@ public class RunThread {
      * before the body has begun: the interrupt lands as soon as the thread exists.
      */
     public void interrupt() {
+        // fail the cancellation future before interrupting: a thread parked in await has
+        // suspended its context execution, and only a completion resumes the suspension
+        // handshake cleanly - an interrupt alone would unwind the thread and leave the
+        // context's task queue owned by a continuation that never runs again
+        cancellation.tryFail(new RunCancelledException());
         thread.thenAccept(Thread::interrupt);
     }
 
@@ -42,6 +59,35 @@ public class RunThread {
      */
     public void join() throws InterruptedException {
         done.await();
+    }
+
+    /**
+     * Awaits the future on the calling run thread, suspending the thread's context execution
+     * while parked so queued context tasks - the completions of context-bound futures among
+     * them - keep flowing. Returns the result, rethrows the failure cause, or throws
+     * {@link RunCancelledException} when the run is cancelled while parked.
+     */
+    @SneakyThrows
+    public static <T> T await(Future<T> future) {
+        Promise<T> race = Promise.promise();
+        future.onComplete(ar -> {
+            if (ar.succeeded()) {
+                race.tryComplete(ar.result());
+            } else {
+                race.tryFail(ar.cause());
+            }
+        });
+        Future<Void> cancellation = CURRENT_CANCELLATION.get();
+        if (cancellation != null) {
+            cancellation.onComplete(ar -> race.tryFail(new RunCancelledException()));
+        }
+        try {
+            return race.future().await();
+        } catch (Throwable t) {
+            // an interrupt racing ahead of the cancellation future's resume still surfaces
+            // from the park as an unchecked InterruptedException
+            throw t instanceof InterruptedException ? new RunCancelledException() : t;
+        }
     }
 
 }

--- a/kinotic-grind/src/test/java/org/kinotic/grind/VertxContextTest.java
+++ b/kinotic-grind/src/test/java/org/kinotic/grind/VertxContextTest.java
@@ -83,9 +83,18 @@ public class VertxContextTest extends AbstractGrindTest {
                     // the shape every repository call hands a task (CrudServiceTemplate.toFuture):
                     // a pending future whose handlers dispatch on the run's context, completed by
                     // a client transport thread foreign to that context
+                    Thread runThread = Thread.currentThread();
                     CompletableFuture<String> clientResponse = new CompletableFuture<>();
                     Future<String> bound = Future.fromCompletionStage(clientResponse, Vertx.currentContext());
-                    new Thread(() -> clientResponse.complete("hit"), "client-transport").start();
+                    new Thread(() -> {
+                        // respond only once the interpreter has parked awaiting the result; an
+                        // immediate response can beat the await's listener registration, and an
+                        // already-completed future delivers inline instead of through the context
+                        while (runThread.getState() != Thread.State.WAITING) {
+                            Thread.onSpinWait();
+                        }
+                        clientResponse.complete("hit");
+                    }, "client-transport").start();
                     return bound;
                 }));
 

--- a/kinotic-grind/src/test/java/org/kinotic/grind/VertxContextTest.java
+++ b/kinotic-grind/src/test/java/org/kinotic/grind/VertxContextTest.java
@@ -1,6 +1,7 @@
 package org.kinotic.grind;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.api.security.Participant;
@@ -9,6 +10,7 @@ import org.kinotic.grind.api.model.JobOwner;
 import org.kinotic.grind.api.model.Store;
 import org.kinotic.grind.api.model.Tasks;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,6 +69,25 @@ public class VertxContextTest extends AbstractGrindTest {
                                          // event loop completes the timer
                                          () -> new Widget(vertx.timer(20).map(v -> "ticked").await())),
                       Store.result("widget"));
+
+        RunResult result = await(jobService.run(job, JobOwner.system()));
+
+        assertNull(result.error());
+    }
+
+    @Test
+    public void taskResultFuturesBoundToTheRunContextCompleteTheRun() throws Exception {
+        JobDefinition job = JobDefinition.create("repository-shaped result")
+                .name("repository-shaped-result").version("1")
+                .task(Tasks.fromCallable("query", () -> {
+                    // the shape every repository call hands a task (CrudServiceTemplate.toFuture):
+                    // a pending future whose handlers dispatch on the run's context, completed by
+                    // a client transport thread foreign to that context
+                    CompletableFuture<String> clientResponse = new CompletableFuture<>();
+                    Future<String> bound = Future.fromCompletionStage(clientResponse, Vertx.currentContext());
+                    new Thread(() -> clientResponse.complete("hit"), "client-transport").start();
+                    return bound;
+                }));
 
         RunResult result = await(jobService.run(job, JobOwner.system()));
 


### PR DESCRIPTION
## Summary

Refactor future/stage awaiting on run threads to suspend context execution while parked, allowing queued context tasks to continue flowing. This prevents deadlocks when context-bound futures (like repository responses) complete on foreign threads while the run thread is blocked.

## Key Changes

- **RunThread.await(Future<T>)**: New static method that races the awaited future against a cancellation future, suspending the calling thread's context execution via `future.await()` rather than blocking. Converts `InterruptedException` to `RunCancelledException` for consistent cancellation semantics.

- **RunThread.interrupt()**: Now fails the cancellation promise before interrupting the thread. This ensures a parked await wakes cleanly through the future's completion handshake rather than leaving the context's task queue orphaned by an interrupt-unwound continuation.

- **JobInterpreter.awaitValue()**: Routes Vert.x futures through `RunThread.await()` instead of converting to `CompletionStage` and blocking. Routes `CompletionStage` through a new `awaitStage()` that bridges to a Vert.x promise and calls `RunThread.await()`.

- **JobInterpreter.awaitStage()**: New method that wraps a `CompletionStage` in a Vert.x promise and awaits it via `RunThread.await()`, unwrapping `CompletionException` to match `CompletableFuture.get()` semantics.

- **DefaultJobService.await()**: Simplified to delegate to `RunThread.await()`, removing duplicate blocking logic.

- **VertxContextTest.taskResultFuturesBoundToTheRunContextCompleteTheRun()**: New test verifying that futures bound to the run context (the shape repository calls use) complete the run without deadlock, even when the response arrives on a foreign thread after the interpreter has parked.

## Implementation Details

The core issue: when a run thread blocks on `CompletableFuture.get()` awaiting a context-bound future that completes on a foreign thread, the context's task queue stalls because the run thread's continuation never resumes to drain it. The fix suspends the context execution (via Vert.x's `future.await()`) so queued tasks keep flowing while parked.

The cancellation future races against the awaited future; if cancellation wins, `RunThread.await()` throws `RunCancelledException`. The interrupt path fails the cancellation promise before interrupting to ensure the park's resume handshake completes cleanly rather than leaving the context suspended indefinitely.

https://claude.ai/code/session_01A36zKXN6UUCebCHt4X3RvZ