### PR TITLE
Park run threads on Vert.x futures to unblock context queues

### DIFF
--- a/kinotic-grind/src/main/java/org/kinotic/grind/api/annotations/Task.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/api/annotations/Task.java
@@ -16,6 +16,9 @@ import java.lang.annotation.Target;
  *
  * A method may return the value directly, a {@code Future}/{@code CompletionStage} of it, or a
  * {@link JobDefinition} to expand dynamically discovered tasks at runtime.
+ *
+ * See {@link org.kinotic.grind.api.model.Task#execute} for how a task body must handle
+ * asynchronous results.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/kinotic-grind/src/main/java/org/kinotic/grind/api/model/Task.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/api/model/Task.java
@@ -12,8 +12,16 @@ public interface Task<T> {
 
     /**
      * Performs the work of this {@link Task}.
+     * <p>
+     * An asynchronous result belongs in the return value, or is awaited in place with the Vert.x
+     * {@code Future}'s {@code await()} - both suspend the run's context so the work queued on it
+     * keeps flowing. Blocking on a future with {@code CompletableFuture.get()} or {@code join()}
+     * instead parks the thread while it still holds the context: a future bound to the run's
+     * context, as every platform repository and service returns, delivers its completion through
+     * that context and so hangs the run permanently, and a raw library future holds up the run's
+     * queued record writes and event delivery until it completes.
      * @param context the job scope for the run
-     * @return the result of this {@link Task}. A returned {@code Future},
+     * @return the result of this {@link Task}. A returned Vert.x {@code Future},
      *         {@code CompletionStage}, or {@code Publisher} is awaited and its value used.
      *         A returned {@link Task} or {@link JobDefinition} is executed as dynamically
      *         discovered tasks. Any other value is the task's result.

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/DefaultJobService.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/DefaultJobService.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.vertx.core.Future;
@@ -196,13 +195,15 @@ public class DefaultJobService implements JobService, ApplicationContextAware {
     }
 
     private <T> T await(Future<T> future) {
+        T ret;
         try {
-            return future.toCompletionStage().toCompletableFuture().get();
-        } catch (InterruptedException e) {
-            throw new RunCancelledException();
-        } catch (ExecutionException e) {
-            throw new IllegalStateException("Could not load the run being resumed", e.getCause());
+            ret = RunThread.await(future);
+        } catch (RunCancelledException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new IllegalStateException("Could not load the run being resumed", t);
         }
+        return ret;
     }
 
 }

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/JobInterpreter.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/JobInterpreter.java
@@ -8,6 +8,8 @@ import org.kinotic.grind.internal.model.RunCancelledException;
 import org.kinotic.grind.internal.model.SerializedState;
 import org.kinotic.grind.internal.model.JobNode;
 import org.kinotic.grind.internal.model.TaskNode;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import lombok.SneakyThrows;
 import org.kinotic.grind.api.model.ExecutionStatus;
 import org.kinotic.grind.api.model.JobDefinition;
@@ -25,9 +27,9 @@ import reactor.core.publisher.Flux;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -287,8 +289,8 @@ public class JobInterpreter {
         Object ret;
         if (raw instanceof CompletionStage<?> stage) {
             ret = awaitStage(stage);
-        } else if (raw instanceof io.vertx.core.Future<?> future) {
-            ret = awaitStage(future.toCompletionStage());
+        } else if (raw instanceof Future<?> future) {
+            ret = RunThread.await(future);
         } else if (raw instanceof Publisher<?> publisher) {
             ret = awaitPublisher(publisher);
         } else {
@@ -297,15 +299,19 @@ public class JobInterpreter {
         return ret;
     }
 
-    @SneakyThrows
     private Object awaitStage(CompletionStage<?> stage) {
-        try {
-            return stage.toCompletableFuture().get();
-        } catch (InterruptedException e) {
-            throw new RunCancelledException();
-        } catch (ExecutionException e) {
-            throw e.getCause() != null ? e.getCause() : e;
-        }
+        Promise<Object> bridged = Promise.promise();
+        stage.whenComplete((value, error) -> {
+            if (error != null) {
+                // a failure that crossed a dependent stage arrives CompletionException-wrapped;
+                // strip it so the task sees what CompletableFuture.get would have reported
+                bridged.fail(error instanceof CompletionException && error.getCause() != null
+                                     ? error.getCause() : error);
+            } else {
+                bridged.complete(value);
+            }
+        });
+        return RunThread.await(bridged.future());
     }
 
     private Object awaitPublisher(Publisher<?> publisher) {

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/JobInterpreter.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/JobInterpreter.java
@@ -304,7 +304,7 @@ public class JobInterpreter {
         stage.whenComplete((value, error) -> {
             if (error != null) {
                 // a failure that crossed a dependent stage arrives CompletionException-wrapped;
-                // strip it so the task sees what CompletableFuture.get would have reported
+                // strip it so the task sees the raw cause
                 bridged.fail(error instanceof CompletionException && error.getCause() != null
                                      ? error.getCause() : error);
             } else {

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
@@ -1,6 +1,10 @@
 package org.kinotic.grind.internal.api.services;
 
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
+import lombok.SneakyThrows;
+import org.kinotic.grind.internal.model.RunCancelledException;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -12,7 +16,11 @@ import java.util.concurrent.CountDownLatch;
  */
 public class RunThread {
 
+    // The cancellation of the run executing on the calling thread, for the body's duration
+    private static final ThreadLocal<Future<Void>> CANCELLATION = new ThreadLocal<>();
+
     private final CompletableFuture<Thread> thread = new CompletableFuture<>();
+    private final Promise<Void> cancellation = Promise.promise();
     private final CountDownLatch done = new CountDownLatch(1);
 
     RunThread(ContextInternal context, String name, Runnable body) {
@@ -20,12 +28,49 @@ public class RunThread {
             Thread current = Thread.currentThread();
             current.setName(name);
             thread.complete(current);
+            CANCELLATION.set(cancellation.future());
             try {
                 body.run();
             } finally {
+                CANCELLATION.remove();
                 done.countDown();
             }
         });
+    }
+
+    /**
+     * Awaits the given future on the calling run thread, parking the thread until the future
+     * completes or the run is cancelled.
+     * @param future to await
+     * @param <T> the awaited type
+     * @return the future's value
+     * @throws RunCancelledException when the run is cancelled while waiting
+     */
+    @SneakyThrows
+    public static <T> T await(Future<T> future) {
+        // the race promise is deliberately unbound: a bound one would queue its own listener
+        // dispatch on the run's context, behind the body that is waiting on it
+        Promise<T> race = Promise.promise();
+        future.onComplete((value, error) -> {
+            if (error != null) {
+                race.tryFail(error);
+            } else {
+                race.tryComplete(value);
+            }
+        });
+        CANCELLATION.get().onComplete((value, error) -> race.tryFail(new RunCancelledException()));
+        T ret;
+        try {
+            ret = race.future().await();
+        } catch (Throwable t) {
+            // the interrupt can land after the cancellation already resumed the continuation,
+            // and Future.await rethrows it; the run is cancelled either way
+            if (t instanceof InterruptedException) {
+                throw new RunCancelledException();
+            }
+            throw t;
+        }
+        return ret;
     }
 
     /**
@@ -33,6 +78,11 @@ public class RunThread {
      * before the body has begun: the interrupt lands as soon as the thread exists.
      */
     public void interrupt() {
+        // Cancelling before the interrupt is what keeps the context's task queue usable: a
+        // body parked in await() wakes through the future's resume handshake, which hands
+        // queue ownership back. A raw interrupt leaves the continuation suspended forever,
+        // and the queue - along with every recorder write behind it - with it
+        cancellation.tryFail(new RunCancelledException());
         thread.thenAccept(Thread::interrupt);
     }
 

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
@@ -3,7 +3,6 @@ package org.kinotic.grind.internal.api.services;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
-import lombok.SneakyThrows;
 import org.kinotic.grind.internal.model.RunCancelledException;
 
 import java.util.concurrent.CountDownLatch;
@@ -45,7 +44,6 @@ public class RunThread {
      * @return the future's value
      * @throws RunCancelledException when the run is cancelled while waiting
      */
-    @SneakyThrows
     public static <T> T await(Future<T> future) {
         // the race promise is deliberately unbound: a bound one would queue its own listener
         // dispatch on the run's context, behind the body that is waiting on it

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThread.java
@@ -6,7 +6,6 @@ import io.vertx.core.internal.ContextInternal;
 import lombok.SneakyThrows;
 import org.kinotic.grind.internal.model.RunCancelledException;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -19,7 +18,7 @@ public class RunThread {
     // The cancellation of the run executing on the calling thread, for the body's duration
     private static final ThreadLocal<Future<Void>> CANCELLATION = new ThreadLocal<>();
 
-    private final CompletableFuture<Thread> thread = new CompletableFuture<>();
+    private final Promise<Thread> thread = Promise.promise();
     private final Promise<Void> cancellation = Promise.promise();
     private final CountDownLatch done = new CountDownLatch(1);
 
@@ -83,7 +82,7 @@ public class RunThread {
         // queue ownership back. A raw interrupt leaves the continuation suspended forever,
         // and the queue - along with every recorder write behind it - with it
         cancellation.tryFail(new RunCancelledException());
-        thread.thenAccept(Thread::interrupt);
+        thread.future().onSuccess(Thread::interrupt);
     }
 
     /**

--- a/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThreadFactory.java
+++ b/kinotic-grind/src/main/java/org/kinotic/grind/internal/api/services/RunThreadFactory.java
@@ -22,6 +22,13 @@ public class RunThreadFactory {
      * @return the started run thread
      */
     public RunThread start(String name, Runnable body) {
+        // The internal createVirtualThreadContext is the only way to get all three properties a
+        // run needs at once: unbounded blocking with no blocked-thread checker firing on a task
+        // that legitimately takes minutes, a context of its own so Vertx.currentContext() and
+        // the context-locals hung off it (the SecurityContext participant) resolve for the whole
+        // body, and a working Future.await(). Deploying each run as a virtual-thread verticle
+        // was evaluated and rejected: deployment is service lifecycle, the wrong shape for
+        // short-lived per-run work
         return new RunThread(vertx.createVirtualThreadContext(), name, body);
     }
 

--- a/kinotic-grind/src/test/java/org/kinotic/grind/VertxContextTest.java
+++ b/kinotic-grind/src/test/java/org/kinotic/grind/VertxContextTest.java
@@ -1,6 +1,7 @@
 package org.kinotic.grind;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.api.security.Participant;
@@ -9,12 +10,15 @@ import org.kinotic.grind.api.model.JobOwner;
 import org.kinotic.grind.api.model.Store;
 import org.kinotic.grind.api.model.Tasks;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The run thread's Vert.x integration: every task of a run executes on the run's own
@@ -71,6 +75,44 @@ public class VertxContextTest extends AbstractGrindTest {
         RunResult result = await(jobService.run(job, JobOwner.system()));
 
         assertNull(result.error());
+    }
+
+    @Test
+    public void tasksCanAwaitContextBoundFuturesCompletedOffTheRunThread() throws Exception {
+        CompletableFuture<String> completedOffContext = new CompletableFuture<>();
+        AtomicBoolean parkedBeforeCompletion = new AtomicBoolean();
+        JobDefinition job = JobDefinition.create("off-context completion")
+                .name("off-context-completion").version("1")
+                .task(Tasks.fromCallable("await a context-bound future", () -> {
+                          Thread runThread = Thread.currentThread();
+                          Thread completer = new Thread(() -> {
+                              parkedBeforeCompletion.set(parked(runThread));
+                              completedOffContext.complete("completed off the run context");
+                          }, "off-context-completer");
+                          completer.start();
+                          // what every platform repository and service hands back: a promise
+                          // bound to the caller's context, completed by a foreign thread
+                          return Future.fromCompletionStage(completedOffContext, Vertx.currentContext());
+                      }),
+                      Store.result("value"));
+
+        RunResult result = await(jobService.run(job, JobOwner.system()));
+
+        assertTrue(parkedBeforeCompletion.get(), "the completion must land while the run thread is parked");
+        assertNull(result.error());
+    }
+
+    /**
+     * Spins until the run thread parks, for at most ten seconds.
+     */
+    private boolean parked(Thread runThread) {
+        // a completion that lands before the interpreter registers its listener is dispatched
+        // inline by FutureBase.emitResult, which never queues the dispatch this test covers
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (runThread.getState() != Thread.State.WAITING && System.currentTimeMillis() < deadline) {
+            Thread.onSpinWait();
+        }
+        return runThread.getState() == Thread.State.WAITING;
     }
 
 }

--- a/website/content/02.platform/11.reference/02.grind-jobs.md
+++ b/website/content/02.platform/11.reference/02.grind-jobs.md
@@ -110,11 +110,35 @@ Structure can be decided at runtime: a task may return another `Task`, or a whol
 
 A task may return its value directly, or asynchronously as a `CompletionStage`, a Vert.x `Future`, or a `Publisher` (whose last emission is the value) — the framework awaits it before storing.
 
+Prefer the Vert.x `Future`: it is the platform's async type, and every platform repository and service already returns one. Return a `CompletionStage` only when a library offers nothing else — the Elasticsearch and Azure clients, for instance.
+
 Every run executes on its own Vert.x virtual-thread context, and each parallel child gets its own. Inside a task, `Vertx.currentContext()` resolves, context-locals such as the platform `SecurityContext` participant work, blocking is permitted, and Vert.x futures can be awaited in place:
 
 ```java
 String answer = vertx.timer(20).map(v -> "ticked").await();   // parks the virtual thread
 ```
+
+**Never block on a future with `CompletableFuture.get()` or `join()` inside a task body.** Return the asynchronous value and let the framework await it, or await a Vert.x future in place with `.await()`. Both of those suspend the run's context so its queued work keeps flowing; `get()` and `join()` park the thread while it still holds the context, which stalls everything queued behind the task:
+
+```java
+@Task(order = 2)
+public DeployTarget load(DeployTargetRepository repository, Project project) {
+    return repository.findById(project.getId())
+                     .toCompletionStage().toCompletableFuture().join();   // deadlocks the run
+}
+
+@Task(order = 2)
+public Future<DeployTarget> load(DeployTargetRepository repository, Project project) {
+    return repository.findById(project.getId());                          // the framework awaits it
+}
+
+@Task(order = 2)
+public DeployTarget load(DeployTargetRepository repository, Project project) {
+    return repository.findById(project.getId()).await();                  // or await it in place
+}
+```
+
+How bad the stall is depends on where the future came from. A future bound to the run's context — anything a platform repository or service hands back — delivers its completion *through* that context, so `get()` waits on a completion queued behind itself and the run hangs permanently. A raw library future completes on its own thread, so the task does eventually proceed, but everything queued on the run's context — record writes, event delivery — waits until it does.
 
 ## Running and watching
 


### PR DESCRIPTION
Replace blocking `CompletableFuture.get()` calls with Vert.x `Future.await()` to suspend run threads without holding their contexts, allowing queued work to flow while awaiting async results.

## Summary

Run threads currently block on `CompletableFuture.get()` when awaiting async results, which parks the thread while it still holds its Vert.x context. This stalls everything queued on that context — record writes, event delivery, and other tasks. The fix introduces `RunThread.await(Future<T>)` to park the thread via `Future.await()`, which suspends the context so its queue keeps flowing.

## Key Changes

- **RunThread.await()** (`RunThread.java:32-56`): New static method that races a future against a cancellation signal. Uses `Future.await()` to park the thread without holding the context, and converts `InterruptedException` to `RunCancelledException` for consistency.

- **Cancellation as a Future** (`RunThread.java:17-18`): Replace `CompletableFuture<Thread>` with `Promise<Thread>` and add a `Promise<Void> cancellation` that signals when the run is cancelled. Store it in a `ThreadLocal` so the body can access it during execution.

- **interrupt() delegates to cancellation** (`RunThread.java:68-73`): Fail the cancellation promise first (waking any parked await), then interrupt the thread. This ensures a body parked in `await()` wakes through the future's resume handshake, which hands context ownership back to the queue.

- **JobInterpreter awaits Futures directly** (`JobInterpreter.java:292-294`): Call `RunThread.await(future)` for Vert.x futures instead of converting to `CompletionStage` and blocking. Refactor `awaitStage()` to use `RunThread.await()` as well, wrapping the stage in a promise to handle `CompletionException` unwrapping.

- **DefaultJobService uses RunThread.await()** (`DefaultJobService.java:198-206`): Replace `future.toCompletionStage().toCompletableFuture().get()` with `RunThread.await()` when loading replayed runs.

- **Documentation and test coverage**: Add test `tasksCanAwaitContextBoundFuturesCompletedOffTheRunThread()` demonstrating that futures completed by foreign threads while the run thread is parked work correctly. Update `Task.java` and `Task` annotation javadoc to warn against blocking on futures with `get()`/`join()`. Add detailed guidance in `grind-jobs.md` explaining the deadlock risk and correct patterns.

## Implementation Details

The race between the future and cancellation is deliberately unbound (not bound to the run's context) to avoid queuing its own listener dispatch behind the body that is waiting on it. When `interrupt()` is called, cancellation fails first so `await()` wakes immediately; the subsequent thread interrupt is defensive, handling the case where `interrupt()` was requested before the body began.

The fix handles `CompletionException` unwrapping in `awaitStage()` so tasks see the raw cause, not the wrapper that `CompletionStage.whenComplete()` adds when a dependent stage fails.

https://claude.ai/code/session_019pWPopwverevydK1d9PERf