### PR TITLE
Add trace log exclusion patterns for high-frequency services

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/Services.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/Services.java
@@ -5,6 +5,7 @@ package org.kinotic.gateway.internal.endpoints;
 import io.vertx.core.Vertx;
 import org.kinotic.core.api.event.EventBusService;
 import org.kinotic.core.api.event.EventStreamService;
+import org.kinotic.core.api.event.TraceLogFilter;
 import org.kinotic.core.api.security.SecurityService;
 import org.kinotic.core.internal.api.service.ExceptionConverter;
 import org.kinotic.gateway.api.config.ApiGatewayProperties;
@@ -39,6 +40,8 @@ public class Services {
     public ObjectProvider<ServiceDirectory> serviceDirectoryProvider;
     @Autowired
     public StompAuthorizerFactory stompAuthorizerFactory;
+    @Autowired
+    public TraceLogFilter traceLogFilter;
     @Autowired
     public Vertx vertx;
 }

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
@@ -10,6 +10,8 @@ import io.vertx.ext.stomp.lite.frame.InvalidConnectFrame;
 import io.vertx.ext.web.RoutingContext;
 import org.kinotic.core.api.event.CRI;
 import org.kinotic.core.api.event.Event;
+import org.kinotic.core.api.event.EventConstants;
+import org.kinotic.core.api.event.TraceLogFilter;
 import org.kinotic.gateway.internal.endpoints.Services;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,11 +30,13 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
 
     private final EndpointConnectionHandler endpointConnectionHandler;
     private final JsonMapper jsonMapper;
+    private final TraceLogFilter traceLogFilter;
 
 
     public DefaultStompServerHandler(Services services) {
         this.endpointConnectionHandler = new EndpointConnectionHandler(services);
         this.jsonMapper = services.jsonMapper;
+        this.traceLogFilter = services.traceLogFilter;
     }
 
     @Override
@@ -51,7 +55,16 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
         // We pause the client to effectively make all client requests block until the previous request is handled asynchronously
         stompServerConnection.pause();
 
-        log.trace("Send Frame received\n{}", frame.toString());
+        if(log.isTraceEnabled()){
+            if(traceLogFilter.isExcluded(frame.getDestination())){
+                // The reply this request produces is addressed to the client's reply destination and
+                // carries no service CRI of its own, so the exclusion is marked here and rides back
+                // on the reply, which persists every __ header of the request that produced it
+                frame.getHeaders().put(EventConstants.TRACE_EXCLUDED_HEADER, "true");
+            }else{
+                log.trace("Send Frame received\n{}", frame.toString());
+            }
+        }
 
         Event<byte[]> incomingEvent = new FrameEventAdapter(frame);
 
@@ -78,7 +91,7 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
 
             CRI cri = CRI.create(frame.getDestination());
 
-            StompSubscriptionEventSubscriber subscriber = new StompSubscriptionEventSubscriber(cri.raw(), subscriptionId, stompServerConnection, jsonMapper);
+            StompSubscriptionEventSubscriber subscriber = new StompSubscriptionEventSubscriber(cri.raw(), subscriptionId, stompServerConnection, jsonMapper, traceLogFilter);
             endpointConnectionHandler.subscribe(cri, subscriptionId, subscriber);
 
         } catch (Exception e) {

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
@@ -56,14 +56,14 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
         stompServerConnection.pause();
 
         if(log.isTraceEnabled()){
-            if(traceLogFilter.isExcluded(frame.getDestination())){
-                // The reply this request produces is addressed to the client's reply destination and
-                // carries no service CRI of its own, so the exclusion is marked here and rides back
-                // on the reply, which persists every __ header of the request that produced it
-                frame.getHeaders().put(EventConstants.TRACE_EXCLUDED_HEADER, "true");
-            }else{
+            boolean excluded = traceLogFilter.isExcluded(frame.getDestination());
+            if(!excluded){
                 log.trace("Send Frame received\n{}", frame.toString());
             }
+            // The reply this request produces is addressed to the client's reply destination, which
+            // no pattern is written for, so the verdict is recorded here and rides back on the reply,
+            // which persists every __ header of the request that produced it
+            frame.getHeaders().put(EventConstants.TRACE_EXCLUDED_HEADER, Boolean.toString(excluded));
         }
 
         Event<byte[]> incomingEvent = new FrameEventAdapter(frame);

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
@@ -60,9 +60,10 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
             if(!excluded){
                 log.trace("Send Frame received\n{}", frame.toString());
             }
-            // The reply this request produces is addressed to the client's reply destination, which
-            // no pattern is written for, so the verdict is recorded here and rides back on the reply,
-            // which persists every __ header of the request that produced it
+            // The reply comes back on the client's reply destination, which no include ever names
+            // and a broad exclude like ** does match, so it has to follow the request's verdict
+            // rather than its own CRI -- false included, or an included service loses its replies.
+            // A reply persists every __ header of the request it answers, so the verdict rides back.
             frame.getHeaders().put(EventConstants.TRACE_EXCLUDED_HEADER, Boolean.toString(excluded));
         }
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
@@ -56,15 +56,14 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
         stompServerConnection.pause();
 
         if(log.isTraceEnabled()){
-            boolean excluded = traceLogFilter.isExcluded(frame.getDestination());
-            if(!excluded){
+            if(traceLogFilter.isExcluded(frame.getDestination())){
+                // The reply comes back on the client's reply destination, which names no service to
+                // match, so the exclusion is marked here and rides back on the reply, which persists
+                // every __ header of the request it answers
+                frame.getHeaders().put(EventConstants.TRACE_EXCLUDED_HEADER, "true");
+            }else{
                 log.trace("Send Frame received\n{}", frame.toString());
             }
-            // The reply comes back on the client's reply destination, which no include ever names
-            // and a broad exclude like ** does match, so it has to follow the request's verdict
-            // rather than its own CRI -- false included, or an included service loses its replies.
-            // A reply persists every __ header of the request it answers, so the verdict rides back.
-            frame.getHeaders().put(EventConstants.TRACE_EXCLUDED_HEADER, Boolean.toString(excluded));
         }
 
         Event<byte[]> incomingEvent = new FrameEventAdapter(frame);

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
@@ -25,6 +25,7 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
     private final StompServerConnection connection;
     private final JsonMapper jsonMapper;
     private final TraceLogFilter traceLogFilter;
+    private final boolean serviceSubscription;
 
     public StompSubscriptionEventSubscriber(String destination,
                                             String subscriptionId,
@@ -36,12 +37,20 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
         this.connection = connection;
         this.jsonMapper = jsonMapper;
         this.traceLogFilter = traceLogFilter;
+        this.serviceSubscription = destination.startsWith(EventConstants.SERVICE_DESTINATION_SCHEME + ":");
     }
 
     @Override
     public void handleEvent(Event<byte[]> event) {
         try {
             Frame frame = GatewayUtils.eventToStompFrame(event);
+            // The trace verdict is the server's own logging bookkeeping. Only a srv:// subscriber
+            // answers what it receives, so only it needs the verdict to ride along on its reply;
+            // every other subscription ends the exchange at this client, where it is noise the
+            // client has no business seeing.
+            if (!serviceSubscription) {
+                frame.getHeaders().remove(EventConstants.TRACE_EXCLUDED_HEADER);
+            }
             // Set Subscription ID header
             frame.getHeaders().put(Frame.SUBSCRIPTION, subscriptionId);
             // Re-expose the typed sender as a header so external clients (e.g. device RPC) still see it.

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
@@ -5,6 +5,7 @@ package org.kinotic.gateway.internal.endpoints.stomp;
 
 import org.kinotic.core.api.event.Event;
 import org.kinotic.core.api.event.EventConstants;
+import org.kinotic.core.api.event.TraceLogFilter;
 import io.vertx.ext.stomp.lite.StompServerConnection;
 import io.vertx.ext.stomp.lite.frame.Frame;
 import org.slf4j.Logger;
@@ -23,15 +24,18 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
     private final String subscriptionId;
     private final StompServerConnection connection;
     private final JsonMapper jsonMapper;
+    private final TraceLogFilter traceLogFilter;
 
     public StompSubscriptionEventSubscriber(String destination,
                                             String subscriptionId,
                                             StompServerConnection connection,
-                                            JsonMapper jsonMapper) {
+                                            JsonMapper jsonMapper,
+                                            TraceLogFilter traceLogFilter) {
         this.destination = destination;
         this.subscriptionId = subscriptionId;
         this.connection = connection;
         this.jsonMapper = jsonMapper;
+        this.traceLogFilter = traceLogFilter;
     }
 
     @Override
@@ -45,7 +49,7 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
                 frame.getHeaders().put(EventConstants.SENDER_HEADER, jsonMapper.writeValueAsString(event.sender()));
             }
 
-            if(log.isTraceEnabled()) {
+            if(log.isTraceEnabled() && !traceLogFilter.isExcluded(event)) {
                 log.trace("Sending Frame\n{}", frame);
             }
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
@@ -25,7 +25,6 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
     private final StompServerConnection connection;
     private final JsonMapper jsonMapper;
     private final TraceLogFilter traceLogFilter;
-    private final boolean serviceSubscription;
 
     public StompSubscriptionEventSubscriber(String destination,
                                             String subscriptionId,
@@ -37,7 +36,6 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
         this.connection = connection;
         this.jsonMapper = jsonMapper;
         this.traceLogFilter = traceLogFilter;
-        this.serviceSubscription = destination.startsWith(EventConstants.SERVICE_DESTINATION_SCHEME + ":");
     }
 
     @Override
@@ -51,14 +49,11 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
                 frame.getHeaders().put(EventConstants.SENDER_HEADER, jsonMapper.writeValueAsString(event.sender()));
             }
 
-            // The trace verdict is the server's own logging bookkeeping, set only while trace
-            // logging is on. Only a srv:// subscriber answers what it receives, so only it needs
-            // the verdict to ride along on its reply; every other subscription ends the exchange
-            // at this client, where it is noise the client has no business seeing.
             if(log.isTraceEnabled()) {
-                if(!serviceSubscription) {
-                    frame.getHeaders().remove(EventConstants.TRACE_EXCLUDED_HEADER);
-                }
+                // The marker is the server's own logging bookkeeping, set only while trace logging
+                // is on. It is read off the event, so dropping it here keeps it out of every frame
+                // a client receives.
+                frame.getHeaders().remove(EventConstants.TRACE_EXCLUDED_HEADER);
                 if(!traceLogFilter.isExcluded(event)) {
                     log.trace("Sending Frame\n{}", frame);
                 }

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompSubscriptionEventSubscriber.java
@@ -44,13 +44,6 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
     public void handleEvent(Event<byte[]> event) {
         try {
             Frame frame = GatewayUtils.eventToStompFrame(event);
-            // The trace verdict is the server's own logging bookkeeping. Only a srv:// subscriber
-            // answers what it receives, so only it needs the verdict to ride along on its reply;
-            // every other subscription ends the exchange at this client, where it is noise the
-            // client has no business seeing.
-            if (!serviceSubscription) {
-                frame.getHeaders().remove(EventConstants.TRACE_EXCLUDED_HEADER);
-            }
             // Set Subscription ID header
             frame.getHeaders().put(Frame.SUBSCRIPTION, subscriptionId);
             // Re-expose the typed sender as a header so external clients (e.g. device RPC) still see it.
@@ -58,8 +51,17 @@ public class StompSubscriptionEventSubscriber implements StompSubscriptionHandle
                 frame.getHeaders().put(EventConstants.SENDER_HEADER, jsonMapper.writeValueAsString(event.sender()));
             }
 
-            if(log.isTraceEnabled() && !traceLogFilter.isExcluded(event)) {
-                log.trace("Sending Frame\n{}", frame);
+            // The trace verdict is the server's own logging bookkeeping, set only while trace
+            // logging is on. Only a srv:// subscriber answers what it receives, so only it needs
+            // the verdict to ride along on its reply; every other subscription ends the exchange
+            // at this client, where it is noise the client has no business seeing.
+            if(log.isTraceEnabled()) {
+                if(!serviceSubscription) {
+                    frame.getHeaders().remove(EventConstants.TRACE_EXCLUDED_HEADER);
+                }
+                if(!traceLogFilter.isExcluded(event)) {
+                    log.trace("Sending Frame\n{}", frame);
+                }
             }
 
             connection.write(frame);

--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/KinoticProperties.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/KinoticProperties.java
@@ -9,9 +9,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  *
  * Created by Navíd Mitchell 🤪on 1/18/21
@@ -91,15 +88,10 @@ public class KinoticProperties {
     private PlatformSecretsProperties platformSecrets = new PlatformSecretsProperties();
 
     /**
-     * CRI patterns whose traffic is left out of trace logging, both the request and the reply it
-     * produces. A pattern is matched against the fully qualified CRI with Ant wildcards, where
-     * {@code *} matches within one segment and {@code **} across segments, so
-     * {@code srv://system-api~com.acme.HeartbeatService/*} drops every method of that service while
-     * {@code srv://system-api~com.acme.HeartbeatService/ping} drops only that one.
-     * Patterns are consulted only while trace logging is enabled.
+     * The CRI patterns that decide what trace logging prints.
      * This is what a node starts with; {@code LogManager} replaces the patterns on a running node.
      */
-    private List<String> traceLogExcludes = new ArrayList<>();
+    private TraceLogProperties traceLog = new TraceLogProperties();
 
 
     public void setMaxNumberOfCoresToUse(int maxNumberOfCoresToUse) {

--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/KinoticProperties.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/KinoticProperties.java
@@ -97,6 +97,7 @@ public class KinoticProperties {
      * {@code srv://system-api~com.acme.HeartbeatService/*} drops every method of that service while
      * {@code srv://system-api~com.acme.HeartbeatService/ping} drops only that one.
      * Patterns are consulted only while trace logging is enabled.
+     * This is what a node starts with; {@code LogManager} replaces the patterns on a running node.
      */
     private List<String> traceLogExcludes = new ArrayList<>();
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/KinoticProperties.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/KinoticProperties.java
@@ -9,6 +9,9 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  *
  * Created by Navíd Mitchell 🤪on 1/18/21
@@ -86,6 +89,16 @@ public class KinoticProperties {
      * through without a restart.
      */
     private PlatformSecretsProperties platformSecrets = new PlatformSecretsProperties();
+
+    /**
+     * CRI patterns whose traffic is left out of trace logging, both the request and the reply it
+     * produces. A pattern is matched against the fully qualified CRI with Ant wildcards, where
+     * {@code *} matches within one segment and {@code **} across segments, so
+     * {@code srv://system-api~com.acme.HeartbeatService/*} drops every method of that service while
+     * {@code srv://system-api~com.acme.HeartbeatService/ping} drops only that one.
+     * Patterns are consulted only while trace logging is enabled.
+     */
+    private List<String> traceLogExcludes = new ArrayList<>();
 
 
     public void setMaxNumberOfCoresToUse(int maxNumberOfCoresToUse) {

--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/TraceLogProperties.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/TraceLogProperties.java
@@ -1,0 +1,36 @@
+package org.kinotic.core.api.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The CRI patterns that decide what trace logging prints.
+ *
+ * Each pattern is matched against the fully qualified CRI with Ant wildcards, where {@code *}
+ * matches within one segment and {@code **} across segments, so
+ * {@code srv://system-api~com.acme.HeartbeatService/*} covers every method of that service and
+ * {@code srv://system-api~com.acme.HeartbeatService/ping} covers only that one.
+ * An include wins over an exclude, so {@code excludes: ["**"]} plus the handful of includes worth
+ * watching narrows trace logging to those services alone.
+ * Patterns are consulted only while trace logging is enabled.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+public class TraceLogProperties {
+
+    /**
+     * CRIs kept in trace logging whatever the excludes say. Empty leaves the excludes to decide.
+     */
+    private List<String> includes = new ArrayList<>();
+
+    /**
+     * CRIs left out of trace logging, request and reply both, unless an include covers them.
+     */
+    private List<String> excludes = new ArrayList<>();
+
+}

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
@@ -65,9 +65,11 @@ public class EventConstants {
     public static final String ORIGIN_CRI_HEADER = "__origin-cri";
 
     /**
-     * Marks an exchange the gateway matched against {@code kinotic.traceLogExcludes}. Persisted onto
-     * every reply the request produces, so a reply frame, which is addressed to the caller rather
-     * than to the service, is left out of trace logging along with the request.
+     * Whether the gateway judged this exchange excluded from trace logging, {@code true} or
+     * {@code false}. Persisted onto every reply the request produces, so a reply frame, which is
+     * addressed to the caller rather than to the service, follows the verdict reached for its
+     * request instead of being judged by a reply destination no pattern is written for. Set only
+     * while trace logging is on; an event without it is judged by its own CRI.
      */
     public static final String TRACE_EXCLUDED_HEADER = "__trace-excluded";
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
@@ -65,14 +65,13 @@ public class EventConstants {
     public static final String ORIGIN_CRI_HEADER = "__origin-cri";
 
     /**
-     * Whether the gateway judged this exchange excluded from trace logging, {@code true} or
-     * {@code false}. Persisted onto every reply the request produces, so a reply frame, which is
-     * addressed to the caller rather than to the service, follows the verdict reached for its
-     * request instead of being judged by a reply destination no pattern is written for. Set only
-     * while trace logging is on; an event without it is judged by its own CRI.
+     * Marks a request the gateway matched against {@code kinotic.traceLog}. Persisted onto every
+     * reply the request produces, so a reply frame, which is addressed to the caller and names no
+     * service to match, is left out of trace logging along with the request it answers.
      *
-     * Server-side bookkeeping: it travels between the gateway and whatever answers the request,
-     * and the gateway strips it from every frame that ends the exchange at a client.
+     * Server-side bookkeeping, set only while trace logging is on: it travels between the gateway
+     * and whatever answers the request, and the gateway strips it from every frame it writes to a
+     * client.
      */
     public static final String TRACE_EXCLUDED_HEADER = "__trace-excluded";
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
@@ -65,6 +65,13 @@ public class EventConstants {
     public static final String ORIGIN_CRI_HEADER = "__origin-cri";
 
     /**
+     * Marks an exchange the gateway matched against {@code kinotic.traceLogExcludes}. Persisted onto
+     * every reply the request produces, so a reply frame, which is addressed to the caller rather
+     * than to the service, is left out of trace logging along with the request.
+     */
+    public static final String TRACE_EXCLUDED_HEADER = "__trace-excluded";
+
+    /**
      * Denotes that something caused an error. Will contain a brief message about the error.
      */
     public static final String ERROR_HEADER = "error";

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
@@ -70,6 +70,9 @@ public class EventConstants {
      * addressed to the caller rather than to the service, follows the verdict reached for its
      * request instead of being judged by a reply destination no pattern is written for. Set only
      * while trace logging is on; an event without it is judged by its own CRI.
+     *
+     * Server-side bookkeeping: it travels between the gateway and whatever answers the request,
+     * and the gateway strips it from every frame that ends the exchange at a client.
      */
     public static final String TRACE_EXCLUDED_HEADER = "__trace-excluded";
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
@@ -1,0 +1,56 @@
+package org.kinotic.core.api.event;
+
+import org.kinotic.core.api.config.KinoticProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+
+import java.util.List;
+
+/**
+ * Answers whether traffic addressed to a given {@link CRI} is excluded from trace logging by
+ * {@code kinotic.traceLogExcludes}.
+ *
+ * Call sites test {@code log.isTraceEnabled()} first, so the patterns cost nothing unless trace
+ * logging is on.
+ */
+@Component
+public class TraceLogFilter {
+
+    private final AntPathMatcher matcher = new AntPathMatcher();
+    private final List<String> patterns;
+
+    public TraceLogFilter(KinoticProperties kinoticProperties) {
+        this.patterns = List.copyOf(kinoticProperties.getTraceLogExcludes());
+    }
+
+    /**
+     * Whether the event belongs to an exchange excluded from trace logging.
+     * A reply carries the exclusion of the request it answers, so this holds for both directions of
+     * an excluded invocation.
+     *
+     * @param event the event about to be logged
+     * @return true if the event must not be trace logged
+     */
+    public boolean isExcluded(Event<?> event) {
+        return event.metadata().contains(EventConstants.TRACE_EXCLUDED_HEADER)
+                || isExcluded(event.cri().raw());
+    }
+
+    /**
+     * Whether the given {@link CRI} matches one of the configured exclusion patterns.
+     *
+     * @param rawCri the fully qualified {@link CRI} the traffic is addressed to
+     * @return true if traffic addressed to the {@link CRI} must not be trace logged
+     */
+    public boolean isExcluded(String rawCri) {
+        boolean ret = false;
+        for (String pattern : patterns) {
+            if (matcher.match(pattern, rawCri)) {
+                ret = true;
+                break;
+            }
+        }
+        return ret;
+    }
+
+}

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
@@ -1,8 +1,8 @@
 package org.kinotic.core.api.event;
 
-import lombok.Getter;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.config.KinoticProperties;
+import org.kinotic.core.api.config.TraceLogProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 
@@ -11,47 +11,81 @@ import java.util.List;
 /**
  * Answers whether traffic addressed to a given {@link CRI} is excluded from trace logging.
  *
- * The patterns start as {@code kinotic.traceLogExcludes} and can be replaced while the node runs.
+ * The patterns start as {@code kinotic.traceLog} and can be replaced while the node runs.
  * Call sites test {@code log.isTraceEnabled()} first, so they cost nothing unless trace logging is on.
  */
 @Component
 public class TraceLogFilter {
 
     private final AntPathMatcher matcher = new AntPathMatcher();
-
-    /**
-     * -- GETTER --
-     *  The CRI patterns currently excluded from trace logging on this node.
-     */
-    @Getter
-    private volatile List<String> excludes;
+    private volatile TraceLogProperties patterns;
 
     public TraceLogFilter(KinoticProperties kinoticProperties) {
-        this.excludes = List.copyOf(kinoticProperties.getTraceLogExcludes());
+        setPatterns(kinoticProperties.getTraceLog());
+    }
+
+    /**
+     * @return the patterns currently deciding what this node trace logs
+     */
+    public TraceLogProperties getPatterns() {
+        return copyOf(patterns);
     }
 
     /**
      * Whether the event belongs to an exchange excluded from trace logging.
-     * A reply carries the exclusion of the request it answers, so this holds for both directions of
-     * an excluded invocation.
+     * A reply carries the verdict reached for the request it answers, so an exchange is logged or
+     * dropped as a whole rather than judged again by the reply destination it came back on.
      *
      * @param event the event about to be logged
      * @return true if the event must not be trace logged
      */
     public boolean isExcluded(Event<?> event) {
-        return event.metadata().contains(EventConstants.TRACE_EXCLUDED_HEADER)
-                || isExcluded(event.cri().raw());
+        boolean ret;
+        String verdict = event.metadata().get(EventConstants.TRACE_EXCLUDED_HEADER);
+        if (verdict != null) {
+            ret = Boolean.parseBoolean(verdict);
+        } else {
+            ret = isExcluded(event.cri().raw());
+        }
+        return ret;
     }
 
     /**
-     * Whether the given {@link CRI} matches one of the configured exclusion patterns.
+     * Whether the given {@link CRI} is excluded from trace logging: it matches one of the exclude
+     * patterns and none of the include patterns.
      *
      * @param rawCri the fully qualified {@link CRI} the traffic is addressed to
      * @return true if traffic addressed to the {@link CRI} must not be trace logged
      */
     public boolean isExcluded(String rawCri) {
+        // One read, so includes and excludes are always weighed as the single setting they were set as
+        TraceLogProperties current = patterns;
+        boolean ret;
+        if (matchesAny(current.getIncludes(), rawCri)) {
+            ret = false;
+        } else {
+            ret = matchesAny(current.getExcludes(), rawCri);
+        }
+        return ret;
+    }
+
+    /**
+     * Replaces the patterns deciding what this node trace logs, effective on the next event logged.
+     * The patterns live only in the running process, so a restart returns to the
+     * {@code kinotic.traceLog} the node was configured with.
+     *
+     * @param patterns the include and exclude patterns to apply
+     */
+    public void setPatterns(TraceLogProperties patterns) {
+        Validate.notNull(patterns, "patterns must not be null");
+        // Swapped as one immutable value, so an isExcluded scan running concurrently weighs the
+        // includes and excludes it started on rather than a half-applied change
+        this.patterns = copyOf(patterns);
+    }
+
+    private boolean matchesAny(List<String> patterns, String rawCri) {
         boolean ret = false;
-        for (String pattern : excludes) {
+        for (String pattern : patterns) {
             if (matcher.match(pattern, rawCri)) {
                 ret = true;
                 break;
@@ -60,21 +94,17 @@ public class TraceLogFilter {
         return ret;
     }
 
-    /**
-     * Replaces the CRI patterns excluded from trace logging, effective on the next event logged.
-     * The patterns live only in the running process, so a restart returns to the
-     * {@code kinotic.traceLogExcludes} the node was configured with.
-     *
-     * @param excludes the patterns to exclude, or empty to exclude nothing
-     */
-    public void setExcludes(List<String> excludes) {
-        Validate.notNull(excludes, "excludes must not be null");
-        for (String pattern : excludes) {
-            Validate.notBlank(pattern, "A trace log exclude pattern must not be blank");
+    private static TraceLogProperties copyOf(TraceLogProperties source) {
+        return new TraceLogProperties().setIncludes(validated(source.getIncludes()))
+                                       .setExcludes(validated(source.getExcludes()));
+    }
+
+    private static List<String> validated(List<String> patterns) {
+        Validate.notNull(patterns, "Trace log patterns must not be null");
+        for (String pattern : patterns) {
+            Validate.notBlank(pattern, "A trace log pattern must not be blank");
         }
-        // Replaced wholesale with an immutable copy, so an isExcluded scan running concurrently
-        // finishes against the list it started on rather than seeing a half-applied change
-        this.excludes = List.copyOf(excludes);
+        return List.copyOf(patterns);
     }
 
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
@@ -1,5 +1,7 @@
 package org.kinotic.core.api.event;
 
+import lombok.Getter;
+import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.config.KinoticProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
@@ -7,20 +9,25 @@ import org.springframework.util.AntPathMatcher;
 import java.util.List;
 
 /**
- * Answers whether traffic addressed to a given {@link CRI} is excluded from trace logging by
- * {@code kinotic.traceLogExcludes}.
+ * Answers whether traffic addressed to a given {@link CRI} is excluded from trace logging.
  *
- * Call sites test {@code log.isTraceEnabled()} first, so the patterns cost nothing unless trace
- * logging is on.
+ * The patterns start as {@code kinotic.traceLogExcludes} and can be replaced while the node runs.
+ * Call sites test {@code log.isTraceEnabled()} first, so they cost nothing unless trace logging is on.
  */
 @Component
 public class TraceLogFilter {
 
     private final AntPathMatcher matcher = new AntPathMatcher();
-    private final List<String> patterns;
+
+    /**
+     * -- GETTER --
+     *  The CRI patterns currently excluded from trace logging on this node.
+     */
+    @Getter
+    private volatile List<String> excludes;
 
     public TraceLogFilter(KinoticProperties kinoticProperties) {
-        this.patterns = List.copyOf(kinoticProperties.getTraceLogExcludes());
+        this.excludes = List.copyOf(kinoticProperties.getTraceLogExcludes());
     }
 
     /**
@@ -44,13 +51,30 @@ public class TraceLogFilter {
      */
     public boolean isExcluded(String rawCri) {
         boolean ret = false;
-        for (String pattern : patterns) {
+        for (String pattern : excludes) {
             if (matcher.match(pattern, rawCri)) {
                 ret = true;
                 break;
             }
         }
         return ret;
+    }
+
+    /**
+     * Replaces the CRI patterns excluded from trace logging, effective on the next event logged.
+     * The patterns live only in the running process, so a restart returns to the
+     * {@code kinotic.traceLogExcludes} the node was configured with.
+     *
+     * @param excludes the patterns to exclude, or empty to exclude nothing
+     */
+    public void setExcludes(List<String> excludes) {
+        Validate.notNull(excludes, "excludes must not be null");
+        for (String pattern : excludes) {
+            Validate.notBlank(pattern, "A trace log exclude pattern must not be blank");
+        }
+        // Replaced wholesale with an immutable copy, so an isExcluded scan running concurrently
+        // finishes against the list it started on rather than seeing a half-applied change
+        this.excludes = List.copyOf(excludes);
     }
 
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
@@ -44,18 +44,18 @@ public class TraceLogFilter {
     }
 
     /**
-     * Whether the given service {@link CRI} is excluded from trace logging: it matches one of the
-     * exclude patterns and none of the include patterns. Any other scheme is never excluded.
+     * Whether the given {@link CRI} is excluded from trace logging: it matches one of the exclude
+     * patterns and none of the include patterns. A reply destination is decided instead by the
+     * marker its request carried, which {@link #isExcluded(Event)} reads.
      *
      * @param rawCri the fully qualified {@link CRI} the traffic is addressed to
      * @return true if traffic addressed to the {@link CRI} must not be trace logged
      */
     public boolean isExcluded(String rawCri) {
         boolean ret = false;
-        // Patterns name services. A reply destination belongs to a connected client and names no
-        // service, so matching one would let an exclude of ** drop replies the includes meant to
-        // keep; a reply is judged by the marker its request carried instead
-        if (rawCri.startsWith(EventConstants.SERVICE_DESTINATION_SCHEME + ":")) {
+        // A reply destination belongs to a connected client rather than naming what was invoked, so
+        // matching one would let an exclude of ** drop replies the includes meant to keep
+        if (!rawCri.startsWith(EventConstants.REPLY_DESTINATION_SCHEME + ":")) {
             // One read, so includes and excludes are weighed as the single setting they were set as
             TraceLogProperties current = patterns;
             ret = !matchesAny(current.getIncludes(), rawCri) && matchesAny(current.getExcludes(), rawCri);

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/TraceLogFilter.java
@@ -32,39 +32,33 @@ public class TraceLogFilter {
     }
 
     /**
-     * Whether the event belongs to an exchange excluded from trace logging.
-     * A reply carries the verdict reached for the request it answers, so an exchange is logged or
-     * dropped as a whole rather than judged again by the reply destination it came back on.
+     * Whether the event belongs to an exchange excluded from trace logging: it was marked excluded
+     * when the request entered, or its own {@link CRI} matches.
      *
      * @param event the event about to be logged
      * @return true if the event must not be trace logged
      */
     public boolean isExcluded(Event<?> event) {
-        boolean ret;
-        String verdict = event.metadata().get(EventConstants.TRACE_EXCLUDED_HEADER);
-        if (verdict != null) {
-            ret = Boolean.parseBoolean(verdict);
-        } else {
-            ret = isExcluded(event.cri().raw());
-        }
-        return ret;
+        return event.metadata().contains(EventConstants.TRACE_EXCLUDED_HEADER)
+                || isExcluded(event.cri().raw());
     }
 
     /**
-     * Whether the given {@link CRI} is excluded from trace logging: it matches one of the exclude
-     * patterns and none of the include patterns.
+     * Whether the given service {@link CRI} is excluded from trace logging: it matches one of the
+     * exclude patterns and none of the include patterns. Any other scheme is never excluded.
      *
      * @param rawCri the fully qualified {@link CRI} the traffic is addressed to
      * @return true if traffic addressed to the {@link CRI} must not be trace logged
      */
     public boolean isExcluded(String rawCri) {
-        // One read, so includes and excludes are always weighed as the single setting they were set as
-        TraceLogProperties current = patterns;
-        boolean ret;
-        if (matchesAny(current.getIncludes(), rawCri)) {
-            ret = false;
-        } else {
-            ret = matchesAny(current.getExcludes(), rawCri);
+        boolean ret = false;
+        // Patterns name services. A reply destination belongs to a connected client and names no
+        // service, so matching one would let an exclude of ** drop replies the includes meant to
+        // keep; a reply is judged by the marker its request carried instead
+        if (rawCri.startsWith(EventConstants.SERVICE_DESTINATION_SCHEME + ":")) {
+            // One read, so includes and excludes are weighed as the single setting they were set as
+            TraceLogProperties current = patterns;
+            ret = !matchesAny(current.getIncludes(), rawCri) && matchesAny(current.getExcludes(), rawCri);
         }
         return ret;
     }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
@@ -10,6 +10,7 @@ import org.kinotic.core.api.RpcServiceProxyHandle;
 import org.kinotic.core.api.ServiceRegistry;
 import org.kinotic.core.api.annotations.Proxy;
 import org.kinotic.core.api.event.EventBusService;
+import org.kinotic.core.api.event.TraceLogFilter;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.core.api.service.ServiceDescriptor;
 import org.kinotic.core.api.service.FunctionInstanceProvider;
@@ -63,6 +64,8 @@ public class DefaultServiceRegistry implements ServiceRegistry {
     private SecurityContext securityContext;
     @Autowired
     private OpenTelemetry openTelemetry;
+    @Autowired
+    private TraceLogFilter traceLogFilter;
 
     @Override
     public Future<Void> register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance) {
@@ -90,7 +93,8 @@ public class DefaultServiceRegistry implements ServiceRegistry {
                                                 reactiveAdapterRegistry,
                                                 vertx,
                                                 securityContext,
-                                                openTelemetry);
+                                                openTelemetry,
+                                                traceLogFilter);
 
                                         serviceInvocationSupervisor
                                                 .start()
@@ -125,7 +129,8 @@ public class DefaultServiceRegistry implements ServiceRegistry {
                                                   securityContext,
                                                   vertx,
                                                   Thread.currentThread().getContextClassLoader(),
-                                                  openTelemetry);
+                                                  openTelemetry,
+                                                  traceLogFilter);
     }
 
     @Override
@@ -142,7 +147,8 @@ public class DefaultServiceRegistry implements ServiceRegistry {
                                                   securityContext,
                                                   vertx,
                                                   Thread.currentThread().getContextClassLoader(),
-                                                  openTelemetry);
+                                                  openTelemetry,
+                                                  traceLogFilter);
     }
 
     @Override

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/HandlerMethod.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/HandlerMethod.java
@@ -4,8 +4,6 @@ package org.kinotic.core.internal.api.service.invoker;
 
 import lombok.Getter;
 import org.apache.commons.lang3.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.BridgeMethodResolver;
 import org.springframework.core.MethodParameter;
 import org.springframework.util.ClassUtils;
@@ -25,8 +23,6 @@ import java.util.stream.IntStream;
  * Created by Navid Mitchell on 2019-03-25.
  */
 public class HandlerMethod {
-
-    private static final Logger log = LoggerFactory.getLogger(HandlerMethod.class);
 
     /**
      * -- GETTER --
@@ -118,10 +114,6 @@ public class HandlerMethod {
         Method method = getBridgedMethod();
         ReflectionUtils.makeAccessible(method);
         try {
-            if(log.isTraceEnabled()){
-                log.trace(formatInvokeMessage("Invoking ", args));
-            }
-
             return method.invoke(getBean(), args);
         }
         catch (IllegalArgumentException ex) {

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -69,6 +69,7 @@ public class ServiceInvocationSupervisor {
     private final ReturnValueConverter returnValueConverter;
     private final ServiceDescriptor serviceDescriptor;
     private final TextMapPropagator propagator;
+    private final TraceLogFilter traceLogFilter;
     private final Tracer tracer;
     private final Vertx vertx;
 
@@ -90,7 +91,8 @@ public class ServiceInvocationSupervisor {
                                        ReactiveAdapterRegistry reactiveAdapterRegistry,
                                        Vertx vertx,
                                        SecurityContext securityContext,
-                                       OpenTelemetry openTelemetry) {
+                                       OpenTelemetry openTelemetry,
+                                       TraceLogFilter traceLogFilter) {
 
         Validate.notNull(serviceDescriptor, "ServiceDescriptor must not be null");
         Validate.notNull(instanceProvider, "FunctionInstanceProvider must not be null");
@@ -102,6 +104,7 @@ public class ServiceInvocationSupervisor {
         Validate.notNull(vertx, "vertx must not be null");
         Validate.notNull(securityContext, "securityContext must not be null");
         Validate.notNull(openTelemetry, "openTelemetry must not be null");
+        Validate.notNull(traceLogFilter, "traceLogFilter must not be null");
 
         this.serviceDescriptor = serviceDescriptor;
         this.argumentResolver = argumentResolver;
@@ -111,6 +114,7 @@ public class ServiceInvocationSupervisor {
         this.securityContext = securityContext;
         this.reactiveAdapterRegistry = reactiveAdapterRegistry;
         this.vertx = vertx;
+        this.traceLogFilter = traceLogFilter;
         this.tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
         this.propagator = openTelemetry.getPropagators().getTextMapPropagator();
 
@@ -264,7 +268,9 @@ public class ServiceInvocationSupervisor {
     private void processEvent(Event<byte[]> incomingEvent){
         boolean isControl = incomingEvent.metadata().contains(EventConstants.CONTROL_HEADER);
 
-        log.trace("Service {} requested for {}", isControl ? "Control" : "Invocation", incomingEvent.cri());
+        if(log.isTraceEnabled() && !traceLogFilter.isExcluded(incomingEvent)){
+            log.trace("Service {} requested for {}", isControl ? "Control" : "Invocation", incomingEvent.cri());
+        }
 
         if(exceptionConverter.supports(incomingEvent.metadata())) {
             try {
@@ -338,6 +344,10 @@ public class ServiceInvocationSupervisor {
                 try (Scope ignored = span.makeCurrent()) {
 
                     Object[] arguments = argumentResolver.resolveArguments(incomingEvent, handlerMethod);
+
+                    if(log.isTraceEnabled() && !traceLogFilter.isExcluded(incomingEvent)){
+                        log.trace(handlerMethod.formatInvokeMessage("Invoking ", arguments));
+                    }
 
                     // separate try catch since we do not want to log invocation errors
                     Object result = null;
@@ -635,7 +645,7 @@ public class ServiceInvocationSupervisor {
 
         @Override
         protected void hookOnNext(@NonNull Object value) {
-            if(log.isTraceEnabled()){
+            if(log.isTraceEnabled() && !traceLogFilter.isExcluded(originCri)){
                 log.trace("Next stream value {}", value);
             }
             convertAndSend(incomingMetadata, handlerMethod, value, originCri);

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
@@ -61,6 +61,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
     private final SecurityContext securityContext;
     private final TextMapPropagator propagator;
     private final Tracer tracer;
+    private final TraceLogFilter traceLogFilter;
     private final Vertx vertx;
 
     private final Map<Method, Integer> methodsWithScopeAnnotation = new HashMap<>();
@@ -82,7 +83,8 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
                                         SecurityContext securityContext,
                                         Vertx vertx,
                                         ClassLoader classLoader,
-                                        OpenTelemetry openTelemetry) {
+                                        OpenTelemetry openTelemetry,
+                                        TraceLogFilter traceLogFilter) {
 
         Validate.notNull(serviceIdentifier, "serviceIdentifier must not be null");
         Validate.notBlank(nodeName, "nodeName must not be blank");
@@ -94,6 +96,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
         Validate.notNull(vertx, "vertx must not be null");
         Validate.notNull(classLoader, "classLoader must not be null");
         Validate.notNull(openTelemetry, "openTelemetry must not be null");
+        Validate.notNull(traceLogFilter, "traceLogFilter must not be null");
 
         this.serviceIdentifier = serviceIdentifier;
         this.nodeName = nodeName;
@@ -105,6 +108,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
         this.securityContext = securityContext;
         this.tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
         this.propagator = openTelemetry.getPropagators().getTextMapPropagator();
+        this.traceLogFilter = traceLogFilter;
         this.vertx = vertx;
 
         this.handlerCRI = CRI.create(EventConstants.REPLY_DESTINATION_SCHEME, encodedNodeName + ":" + UUID.randomUUID(), KinoticUtil.safeEncodeURI(serviceClass.getName())+"RpcProxyResponseHandler");
@@ -243,10 +247,6 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
 
         }else if(!released.get()){
 
-            if(log.isTraceEnabled()){
-                log.trace("Proxy for {} Method Invoked {}", serviceClass.getSimpleName(), method.toString());
-            }
-
             // Get all data for remote invocation. If anything fails in this step the error automatically props up
             // This way no ReturnValueHandler is created until message is ready to get dispatched to remote end
 
@@ -284,6 +284,10 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
                                         serviceIdentifier.qualifiedName(),
                                         "/" + method.getName(),
                                         serviceIdentifier.version());
+
+            if(log.isTraceEnabled() && !traceLogFilter.isExcluded(requestCri.raw())){
+                log.trace("Proxy for {} Method Invoked {}", serviceClass.getSimpleName(), method.toString());
+            }
 
             // Propagate the participant active on the calling context so the callee sees the originator.
             Event<byte[]> rpcOutboundEvent = Event.create(requestCri,

--- a/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
@@ -1,0 +1,72 @@
+package org.kinotic.core.api.event;
+
+import org.junit.jupiter.api.Test;
+import org.kinotic.core.api.config.KinoticProperties;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins how {@code kinotic.traceLogExcludes} patterns resolve against the CRIs they are written for.
+ */
+public class TraceLogFilterTest {
+
+    private static final String SERVICE = "srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService";
+
+    @Test
+    public void wildcardPatternExcludesEveryMethodOfTheService() {
+        TraceLogFilter filter = filterFor(SERVICE + "/*");
+
+        assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
+        assertTrue(filter.isExcluded(SERVICE + "/registerNode"));
+    }
+
+    @Test
+    public void rawPatternExcludesOnlyTheMethodItNames() {
+        TraceLogFilter filter = filterFor(SERVICE + "/heartbeat");
+
+        assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
+        assertFalse(filter.isExcluded(SERVICE + "/registerNode"));
+    }
+
+    @Test
+    public void anotherServiceInTheSameZoneIsNotExcluded() {
+        TraceLogFilter filter = filterFor(SERVICE + "/*");
+
+        assertFalse(filter.isExcluded("srv://system-api~org.kinotic.system.api.services.KinoticClusterInfoService/findAll"));
+    }
+
+    @Test
+    public void aScopedInvocationNeedsTheScopeWildcard() {
+        String scopedCri = "srv://dev-node-1@system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/heartbeat";
+
+        assertFalse(filterFor(SERVICE + "/*").isExcluded(scopedCri));
+        assertTrue(filterFor("srv://*@system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/*").isExcluded(scopedCri));
+    }
+
+    @Test
+    public void nothingIsExcludedWhenNoPatternsAreConfigured() {
+        TraceLogFilter filter = new TraceLogFilter(new KinoticProperties());
+
+        assertFalse(filter.isExcluded(SERVICE + "/heartbeat"));
+    }
+
+    @Test
+    public void aReplyIsExcludedByTheMarkerItCarriesRatherThanByItsOwnCri() {
+        TraceLogFilter filter = filterFor(SERVICE + "/*");
+        String replyCri = "reply://0b5b4516:a8a95015@kinotic.js.EventBus/replyHandler";
+
+        assertFalse(filter.isExcluded(replyCri));
+
+        Metadata metadata = Metadata.create();
+        metadata.put(EventConstants.TRACE_EXCLUDED_HEADER, "true");
+        assertTrue(filter.isExcluded(Event.create(replyCri, metadata, new byte[0])));
+    }
+
+    private TraceLogFilter filterFor(String... patterns) {
+        return new TraceLogFilter(new KinoticProperties().setTraceLogExcludes(List.of(patterns)));
+    }
+
+}

--- a/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
@@ -6,6 +6,7 @@ import org.kinotic.core.api.config.KinoticProperties;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -63,6 +64,27 @@ public class TraceLogFilterTest {
         Metadata metadata = Metadata.create();
         metadata.put(EventConstants.TRACE_EXCLUDED_HEADER, "true");
         assertTrue(filter.isExcluded(Event.create(replyCri, metadata, new byte[0])));
+    }
+
+    @Test
+    public void patternsCanBeReplacedWhileTheNodeRuns() {
+        TraceLogFilter filter = filterFor(SERVICE + "/heartbeat");
+        assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
+
+        filter.setExcludes(List.of(SERVICE + "/registerNode"));
+        assertFalse(filter.isExcluded(SERVICE + "/heartbeat"));
+        assertTrue(filter.isExcluded(SERVICE + "/registerNode"));
+
+        filter.setExcludes(List.of());
+        assertFalse(filter.isExcluded(SERVICE + "/registerNode"));
+    }
+
+    @Test
+    public void aBlankPatternIsRejected() {
+        TraceLogFilter filter = filterFor(SERVICE + "/heartbeat");
+
+        assertThrows(IllegalArgumentException.class, () -> filter.setExcludes(List.of("   ")));
+        assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
     }
 
     private TraceLogFilter filterFor(String... patterns) {

--- a/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
@@ -17,6 +17,7 @@ public class TraceLogFilterTest {
 
     private static final String SERVICE = "srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService";
     private static final String OTHER_SERVICE = "srv://system-api~org.kinotic.system.api.services.KinoticClusterInfoService";
+    private static final String REPLY_CRI = "reply://0b5b4516:a8a95015@kinotic.js.EventBus/replyHandler";
 
     @Test
     public void wildcardPatternExcludesEveryMethodOfTheService() {
@@ -70,7 +71,14 @@ public class TraceLogFilterTest {
 
         assertFalse(filter.isExcluded(SERVICE + "/heartbeat"));
         assertTrue(filter.isExcluded(OTHER_SERVICE + "/findAll"));
-        assertTrue(filter.isExcluded("reply://0b5b4516:a8a95015@kinotic.js.EventBus/replyHandler"));
+    }
+
+    @Test
+    public void onlyServiceDestinationsAreMatchedAtAll() {
+        TraceLogFilter filter = filterFor(List.of(), List.of("**"));
+
+        assertFalse(filter.isExcluded(REPLY_CRI));
+        assertFalse(filter.isExcluded("stream://org.kinotic.tests.SomeEvent"));
     }
 
     @Test
@@ -106,18 +114,19 @@ public class TraceLogFilterTest {
     }
 
     @Test
-    public void aReplyFollowsTheVerdictReachedForItsRequest() {
+    public void aReplyIsExcludedOnlyByTheMarkerItsRequestCarried() {
         TraceLogFilter filter = filterFor(List.of(SERVICE + "/**"), List.of("**"));
-        String replyCri = "reply://0b5b4516:a8a95015@kinotic.js.EventBus/replyHandler";
 
-        assertFalse(filter.isExcluded(replyTo(replyCri, false)));
-        assertTrue(filter.isExcluded(replyTo(replyCri, true)));
+        assertFalse(filter.isExcluded(reply(false)));
+        assertTrue(filter.isExcluded(reply(true)));
     }
 
-    private Event<byte[]> replyTo(String replyCri, boolean excluded) {
+    private Event<byte[]> reply(boolean marked) {
         Metadata metadata = Metadata.create();
-        metadata.put(EventConstants.TRACE_EXCLUDED_HEADER, Boolean.toString(excluded));
-        return Event.create(replyCri, metadata, new byte[0]);
+        if (marked) {
+            metadata.put(EventConstants.TRACE_EXCLUDED_HEADER, "true");
+        }
+        return Event.create(REPLY_CRI, metadata, new byte[0]);
     }
 
     private TraceLogFilter excluding(String... excludes) {

--- a/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
@@ -74,11 +74,11 @@ public class TraceLogFilterTest {
     }
 
     @Test
-    public void onlyServiceDestinationsAreMatchedAtAll() {
+    public void everyDestinationButAReplyIsMatched() {
         TraceLogFilter filter = filterFor(List.of(), List.of("**"));
 
+        assertTrue(filter.isExcluded("stream://org.kinotic.tests.SomeEvent"));
         assertFalse(filter.isExcluded(REPLY_CRI));
-        assertFalse(filter.isExcluded("stream://org.kinotic.tests.SomeEvent"));
     }
 
     @Test

--- a/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/event/TraceLogFilterTest.java
@@ -2,6 +2,7 @@ package org.kinotic.core.api.event;
 
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.api.config.KinoticProperties;
+import org.kinotic.core.api.config.TraceLogProperties;
 
 import java.util.List;
 
@@ -10,15 +11,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Pins how {@code kinotic.traceLogExcludes} patterns resolve against the CRIs they are written for.
+ * Pins how {@code kinotic.traceLog} patterns resolve against the CRIs they are written for.
  */
 public class TraceLogFilterTest {
 
     private static final String SERVICE = "srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService";
+    private static final String OTHER_SERVICE = "srv://system-api~org.kinotic.system.api.services.KinoticClusterInfoService";
 
     @Test
     public void wildcardPatternExcludesEveryMethodOfTheService() {
-        TraceLogFilter filter = filterFor(SERVICE + "/*");
+        TraceLogFilter filter = excluding(SERVICE + "/*");
 
         assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
         assertTrue(filter.isExcluded(SERVICE + "/registerNode"));
@@ -26,7 +28,7 @@ public class TraceLogFilterTest {
 
     @Test
     public void rawPatternExcludesOnlyTheMethodItNames() {
-        TraceLogFilter filter = filterFor(SERVICE + "/heartbeat");
+        TraceLogFilter filter = excluding(SERVICE + "/heartbeat");
 
         assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
         assertFalse(filter.isExcluded(SERVICE + "/registerNode"));
@@ -34,17 +36,17 @@ public class TraceLogFilterTest {
 
     @Test
     public void anotherServiceInTheSameZoneIsNotExcluded() {
-        TraceLogFilter filter = filterFor(SERVICE + "/*");
+        TraceLogFilter filter = excluding(SERVICE + "/*");
 
-        assertFalse(filter.isExcluded("srv://system-api~org.kinotic.system.api.services.KinoticClusterInfoService/findAll"));
+        assertFalse(filter.isExcluded(OTHER_SERVICE + "/findAll"));
     }
 
     @Test
     public void aScopedInvocationNeedsTheScopeWildcard() {
         String scopedCri = "srv://dev-node-1@system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/heartbeat";
 
-        assertFalse(filterFor(SERVICE + "/*").isExcluded(scopedCri));
-        assertTrue(filterFor("srv://*@system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/*").isExcluded(scopedCri));
+        assertFalse(excluding(SERVICE + "/*").isExcluded(scopedCri));
+        assertTrue(excluding("srv://*@system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/*").isExcluded(scopedCri));
     }
 
     @Test
@@ -55,40 +57,76 @@ public class TraceLogFilterTest {
     }
 
     @Test
-    public void aReplyIsExcludedByTheMarkerItCarriesRatherThanByItsOwnCri() {
-        TraceLogFilter filter = filterFor(SERVICE + "/*");
-        String replyCri = "reply://0b5b4516:a8a95015@kinotic.js.EventBus/replyHandler";
+    public void anIncludeWinsOverAnExcludeThatAlsoMatches() {
+        TraceLogFilter filter = filterFor(List.of(SERVICE + "/heartbeat"), List.of(SERVICE + "/*"));
 
-        assertFalse(filter.isExcluded(replyCri));
+        assertFalse(filter.isExcluded(SERVICE + "/heartbeat"));
+        assertTrue(filter.isExcluded(SERVICE + "/registerNode"));
+    }
 
-        Metadata metadata = Metadata.create();
-        metadata.put(EventConstants.TRACE_EXCLUDED_HEADER, "true");
-        assertTrue(filter.isExcluded(Event.create(replyCri, metadata, new byte[0])));
+    @Test
+    public void excludingEverythingLeavesOnlyTheIncludes() {
+        TraceLogFilter filter = filterFor(List.of(SERVICE + "/**"), List.of("**"));
+
+        assertFalse(filter.isExcluded(SERVICE + "/heartbeat"));
+        assertTrue(filter.isExcluded(OTHER_SERVICE + "/findAll"));
+        assertTrue(filter.isExcluded("reply://0b5b4516:a8a95015@kinotic.js.EventBus/replyHandler"));
     }
 
     @Test
     public void patternsCanBeReplacedWhileTheNodeRuns() {
-        TraceLogFilter filter = filterFor(SERVICE + "/heartbeat");
+        TraceLogFilter filter = excluding(SERVICE + "/heartbeat");
         assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
 
-        filter.setExcludes(List.of(SERVICE + "/registerNode"));
+        filter.setPatterns(new TraceLogProperties().setExcludes(List.of(SERVICE + "/registerNode")));
         assertFalse(filter.isExcluded(SERVICE + "/heartbeat"));
         assertTrue(filter.isExcluded(SERVICE + "/registerNode"));
 
-        filter.setExcludes(List.of());
+        filter.setPatterns(new TraceLogProperties());
         assertFalse(filter.isExcluded(SERVICE + "/registerNode"));
     }
 
     @Test
-    public void aBlankPatternIsRejected() {
-        TraceLogFilter filter = filterFor(SERVICE + "/heartbeat");
+    public void replacingPatternsDoesNotExposeTheFiltersOwnState() {
+        TraceLogFilter filter = excluding(SERVICE + "/heartbeat");
 
-        assertThrows(IllegalArgumentException.class, () -> filter.setExcludes(List.of("   ")));
+        TraceLogProperties read = filter.getPatterns();
+        read.setExcludes(List.of("**"));
+
+        assertFalse(filter.isExcluded(OTHER_SERVICE + "/findAll"));
+    }
+
+    @Test
+    public void aBlankPatternIsRejected() {
+        TraceLogFilter filter = excluding(SERVICE + "/heartbeat");
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> filter.setPatterns(new TraceLogProperties().setExcludes(List.of("   "))));
         assertTrue(filter.isExcluded(SERVICE + "/heartbeat"));
     }
 
-    private TraceLogFilter filterFor(String... patterns) {
-        return new TraceLogFilter(new KinoticProperties().setTraceLogExcludes(List.of(patterns)));
+    @Test
+    public void aReplyFollowsTheVerdictReachedForItsRequest() {
+        TraceLogFilter filter = filterFor(List.of(SERVICE + "/**"), List.of("**"));
+        String replyCri = "reply://0b5b4516:a8a95015@kinotic.js.EventBus/replyHandler";
+
+        assertFalse(filter.isExcluded(replyTo(replyCri, false)));
+        assertTrue(filter.isExcluded(replyTo(replyCri, true)));
+    }
+
+    private Event<byte[]> replyTo(String replyCri, boolean excluded) {
+        Metadata metadata = Metadata.create();
+        metadata.put(EventConstants.TRACE_EXCLUDED_HEADER, Boolean.toString(excluded));
+        return Event.create(replyCri, metadata, new byte[0]);
+    }
+
+    private TraceLogFilter excluding(String... excludes) {
+        return filterFor(List.of(), List.of(excludes));
+    }
+
+    private TraceLogFilter filterFor(List<String> includes, List<String> excludes) {
+        TraceLogProperties traceLog = new TraceLogProperties().setIncludes(includes).setExcludes(excludes);
+        return new TraceLogFilter(new KinoticProperties().setTraceLog(traceLog));
     }
 
 }

--- a/kinotic-frontend/apps/system/src/components/LogLevelDialog.vue
+++ b/kinotic-frontend/apps/system/src/components/LogLevelDialog.vue
@@ -2,28 +2,73 @@
   <Dialog
     v-model:visible="visible"
     modal
-    :header="`Log level — ${nodeId}`"
-    :style="{ width: '28rem', maxWidth: '95vw' }"
+    :header="`Logging — ${nodeId}`"
+    :style="{ width: '34rem', maxWidth: '95vw' }"
     @show="opened"
   >
     <p class="mb-4 text-sm text-muted-color">
-      Changes the level of a logger on this node immediately, without a restart. The change
-      lasts until the node restarts.
+      Changes logging on this node immediately, without a restart. Changes last until the node
+      restarts.
     </p>
 
+    <h3 class="mb-2 text-sm font-semibold">Log level</h3>
     <div class="flex flex-col gap-3">
       <InputText
         v-model="loggerName"
         placeholder="Logger name (e.g. org.kinotic)"
         autofocus
-        @keyup.enter="apply"
+        @keyup.enter="applyLevel"
       />
       <Select v-model="level" :options="levels" placeholder="Level" />
+      <div>
+        <Button label="Set level" size="small" :disabled="!canApplyLevel" :loading="applyingLevel"
+                @click="applyLevel" />
+      </div>
+    </div>
+
+    <Divider />
+
+    <h3 class="mb-2 text-sm font-semibold">Trace log filters</h3>
+    <p class="mb-3 text-xs text-muted-color">
+      CRI patterns deciding what TRACE prints, so a chatty service does not bury the log. One
+      pattern per line, matched against the whole CRI — <code>*</code> within a segment,
+      <code>**</code> across segments. An include wins over an exclude, so excluding
+      <code>**</code> and listing a few includes narrows TRACE to those services alone.
+    </p>
+
+    <Message v-if="traceLogError" severity="error" :closable="false" class="mb-3">{{ traceLogError }}</Message>
+
+    <div class="flex flex-col gap-3">
+      <div>
+        <label class="mb-1 block text-xs text-muted-color" for="trace-log-excludes">Excludes</label>
+        <Textarea
+          id="trace-log-excludes"
+          v-model="excludes"
+          class="w-full font-mono text-xs"
+          rows="3"
+          :disabled="loadingTraceLog"
+          placeholder="srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/*"
+        />
+      </div>
+      <div>
+        <label class="mb-1 block text-xs text-muted-color" for="trace-log-includes">Includes</label>
+        <Textarea
+          id="trace-log-includes"
+          v-model="includes"
+          class="w-full font-mono text-xs"
+          rows="3"
+          :disabled="loadingTraceLog"
+          placeholder="srv://app.acme-org.orders-app~com.acme.OrderService/**"
+        />
+      </div>
+      <div>
+        <Button label="Save filters" size="small" :disabled="loadingTraceLog" :loading="savingTraceLog"
+                @click="saveTraceLog" />
+      </div>
     </div>
 
     <template #footer>
-      <Button label="Cancel" severity="secondary" outlined @click="visible = false" />
-      <Button label="Apply" :disabled="!canApply" :loading="applying" @click="apply" />
+      <Button label="Close" severity="secondary" outlined @click="visible = false" />
     </template>
   </Dialog>
 </template>
@@ -32,12 +77,15 @@
 import { computed, ref } from 'vue'
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
+import Divider from 'primevue/divider'
 import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
 import Select from 'primevue/select'
+import Textarea from 'primevue/textarea'
 import { useToast } from 'primevue/usetoast'
 
 import { Kinotic } from '@kinotic-ai/core'
-import { LogLevel } from '@kinotic-ai/system-api'
+import { LogLevel, TraceLogProperties } from '@kinotic-ai/system-api'
 import { showErrorToast } from '@kinotic-ai/frontend-common'
 
 const props = defineProps<{
@@ -50,22 +98,47 @@ const toast = useToast()
 
 const loggerName = ref('')
 const level = ref<LogLevel | null>(null)
-const applying = ref(false)
+const applyingLevel = ref(false)
+
+const includes = ref('')
+const excludes = ref('')
+const loadingTraceLog = ref(false)
+const savingTraceLog = ref(false)
+const traceLogError = ref<string | null>(null)
 
 const levels = Object.values(LogLevel)
 
-const canApply = computed(() => loggerName.value.trim() !== '' && level.value !== null)
+const canApplyLevel = computed(() => loggerName.value.trim() !== '' && level.value !== null)
 
 function opened() {
   loggerName.value = ''
   level.value = null
+  loadTraceLog()
 }
 
-async function apply() {
-  if (!canApply.value) {
+function toPatterns(text: string): string[] {
+  return text.split('\n').map(line => line.trim()).filter(line => line !== '')
+}
+
+async function loadTraceLog() {
+  loadingTraceLog.value = true
+  traceLogError.value = null
+  try {
+    const traceLog = await Kinotic.logManager.traceLog(props.nodeId)
+    includes.value = traceLog.includes.join('\n')
+    excludes.value = traceLog.excludes.join('\n')
+  } catch (err) {
+    traceLogError.value = `Could not read the trace log filters: ${err}`
+  } finally {
+    loadingTraceLog.value = false
+  }
+}
+
+async function applyLevel() {
+  if (!canApplyLevel.value) {
     return
   }
-  applying.value = true
+  applyingLevel.value = true
   try {
     await Kinotic.logManager.configureLogLevel(props.nodeId, loggerName.value.trim(), level.value!)
     toast.add({
@@ -78,7 +151,27 @@ async function apply() {
   } catch (err) {
     showErrorToast(toast, 'Failed to set log level', err)
   } finally {
-    applying.value = false
+    applyingLevel.value = false
+  }
+}
+
+async function saveTraceLog() {
+  savingTraceLog.value = true
+  try {
+    const traceLog = new TraceLogProperties()
+    traceLog.includes = toPatterns(includes.value)
+    traceLog.excludes = toPatterns(excludes.value)
+    await Kinotic.logManager.configureTraceLog(props.nodeId, traceLog)
+    toast.add({
+      severity: 'success',
+      summary: 'Trace log filters saved',
+      detail: `${traceLog.includes.length} include(s), ${traceLog.excludes.length} exclude(s) on ${props.nodeId}`,
+      life: 4000
+    })
+  } catch (err) {
+    showErrorToast(toast, 'Failed to save trace log filters', err)
+  } finally {
+    savingTraceLog.value = false
   }
 }
 </script>

--- a/kinotic-frontend/apps/system/src/pages/Dashboard.vue
+++ b/kinotic-frontend/apps/system/src/pages/Dashboard.vue
@@ -61,7 +61,7 @@
                 <Tag v-if="node.local" severity="info" value="serving request" />
               </td>
               <td class="border-b border-surface px-2 py-1.5 text-right">
-                <Button label="Log level" icon="pi pi-sliders-h" severity="secondary" text size="small"
+                <Button label="Logging" icon="pi pi-sliders-h" severity="secondary" text size="small"
                         @click="openLogLevel(node.nodeId)" />
               </td>
             </tr>

--- a/kinotic-frontend/package.json
+++ b/kinotic-frontend/package.json
@@ -21,7 +21,7 @@
       "@kinotic-ai/idl": "^5.0.0-beta.1",
       "@kinotic-ai/management-api": "^5.0.0-beta.23",
       "@kinotic-ai/persistence": "^5.0.0-beta.8",
-      "@kinotic-ai/system-api": "^5.0.0-beta.6"
+      "@kinotic-ai/system-api": "^5.0.0-beta.8"
     }
   }
 }

--- a/kinotic-js/workspace/bun.lock
+++ b/kinotic-js/workspace/bun.lock
@@ -108,7 +108,7 @@
     },
     "packages/system-api": {
       "name": "@kinotic-ai/system-api",
-      "version": "5.0.0-beta.7",
+      "version": "5.0.0-beta.8",
       "dependencies": {
         "@kinotic-ai/management-api": "workspace:*",
       },

--- a/kinotic-js/workspace/packages/system-api/package.json
+++ b/kinotic-js/workspace/packages/system-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/system-api",
-  "version": "5.0.0-beta.7",
+  "version": "5.0.0-beta.8",
   "type": "module",
   "description": "Client API for the Kinotic platform's system plane: the workload and node orchestration services platform machines and operators use.",
   "files": [

--- a/kinotic-js/workspace/packages/system-api/src/api/services/ILogManager.ts
+++ b/kinotic-js/workspace/packages/system-api/src/api/services/ILogManager.ts
@@ -54,4 +54,23 @@ export interface ILogManager {
      * @param level the {@link LogLevel} to set for the logger with the given name
      */
     configureLogLevel(nodeId: string, name: string, level: LogLevel): Promise<void>
+
+    /**
+     * @param nodeId the kinotic node to get the trace log excludes from
+     * @return the CRI patterns currently excluded from trace logging on the node
+     */
+    traceLogExcludes(nodeId: string): Promise<string[]>
+
+    /**
+     * Configures the CRI patterns excluded from trace logging, silencing a service that would
+     * otherwise bury the log while trace logging is on. Each pattern is matched against the fully
+     * qualified CRI with Ant wildcards, so `srv://system-api~com.acme.HeartbeatService/*` covers
+     * every method of that service and a raw CRI covers only the method it names.
+     * The patterns replace whatever the node is using and last until it restarts, which returns it
+     * to the `kinotic.traceLogExcludes` it was configured with.
+     *
+     * @param nodeId the kinotic node to set the trace log excludes on
+     * @param excludes the CRI patterns to exclude, or empty to exclude nothing
+     */
+    configureTraceLogExcludes(nodeId: string, excludes: string[]): Promise<void>
 }

--- a/kinotic-js/workspace/packages/system-api/src/api/services/ILogManager.ts
+++ b/kinotic-js/workspace/packages/system-api/src/api/services/ILogManager.ts
@@ -30,6 +30,23 @@ export class LoggersDescriptor {
 }
 
 /**
+ * The CRI patterns that decide what trace logging prints.
+ *
+ * Each pattern is matched against the fully qualified CRI with Ant wildcards, where `*` matches
+ * within one segment and `**` across segments, so
+ * `srv://system-api~com.acme.HeartbeatService/*` covers every method of that service and
+ * `srv://system-api~com.acme.HeartbeatService/ping` covers only that one.
+ * An include wins over an exclude, so `excludes: ['**']` plus the handful of includes worth
+ * watching narrows trace logging to those services alone.
+ */
+export class TraceLogProperties {
+    /** CRIs kept in trace logging whatever the excludes say. Empty leaves the excludes to decide. */
+    public includes: string[] = []
+    /** CRIs left out of trace logging, request and reply both, unless an include covers them. */
+    public excludes: string[] = []
+}
+
+/**
  * Provides the ability to manage loggers
  */
 export interface ILogManager {
@@ -56,21 +73,19 @@ export interface ILogManager {
     configureLogLevel(nodeId: string, name: string, level: LogLevel): Promise<void>
 
     /**
-     * @param nodeId the kinotic node to get the trace log excludes from
-     * @return the CRI patterns currently excluded from trace logging on the node
+     * @param nodeId the kinotic node to get the trace log patterns from
+     * @return the CRI patterns currently deciding what the node trace logs
      */
-    traceLogExcludes(nodeId: string): Promise<string[]>
+    traceLog(nodeId: string): Promise<TraceLogProperties>
 
     /**
-     * Configures the CRI patterns excluded from trace logging, silencing a service that would
-     * otherwise bury the log while trace logging is on. Each pattern is matched against the fully
-     * qualified CRI with Ant wildcards, so `srv://system-api~com.acme.HeartbeatService/*` covers
-     * every method of that service and a raw CRI covers only the method it names.
+     * Configures the CRI patterns deciding what the node trace logs, silencing a service that
+     * would otherwise bury the log while trace logging is on.
      * The patterns replace whatever the node is using and last until it restarts, which returns it
-     * to the `kinotic.traceLogExcludes` it was configured with.
+     * to the `kinotic.traceLog` it was configured with.
      *
-     * @param nodeId the kinotic node to set the trace log excludes on
-     * @param excludes the CRI patterns to exclude, or empty to exclude nothing
+     * @param nodeId the kinotic node to set the trace log patterns on
+     * @param traceLog the include and exclude patterns to apply
      */
-    configureTraceLogExcludes(nodeId: string, excludes: string[]): Promise<void>
+    configureTraceLog(nodeId: string, traceLog: TraceLogProperties): Promise<void>
 }

--- a/kinotic-js/workspace/packages/system-api/src/api/services/LogManager.ts
+++ b/kinotic-js/workspace/packages/system-api/src/api/services/LogManager.ts
@@ -36,5 +36,13 @@ export class LogManager implements ILogManager {
     configureLogLevel(nodeId: string, name: string, level: LogLevel): Promise<void> {
         return this.serviceProxy.invoke('configureLogLevel', [name, level], nodeId)
     }
+
+    traceLogExcludes(nodeId: string): Promise<string[]> {
+        return this.serviceProxy.invoke('traceLogExcludes', null, nodeId)
+    }
+
+    configureTraceLogExcludes(nodeId: string, excludes: string[]): Promise<void> {
+        return this.serviceProxy.invoke('configureTraceLogExcludes', [excludes], nodeId)
+    }
 }
 

--- a/kinotic-js/workspace/packages/system-api/src/api/services/LogManager.ts
+++ b/kinotic-js/workspace/packages/system-api/src/api/services/LogManager.ts
@@ -5,7 +5,8 @@ import {
     LoggersDescriptor,
     LoggerLevelsDescriptor,
     SingleLoggerLevelsDescriptor,
-    GroupLoggerLevelsDescriptor} from './ILogManager'
+    GroupLoggerLevelsDescriptor,
+    TraceLogProperties} from './ILogManager'
 import {type IKinotic, type IServiceProxy} from '@kinotic-ai/core'
 
 export class LogManager implements ILogManager {
@@ -37,12 +38,15 @@ export class LogManager implements ILogManager {
         return this.serviceProxy.invoke('configureLogLevel', [name, level], nodeId)
     }
 
-    traceLogExcludes(nodeId: string): Promise<string[]> {
-        return this.serviceProxy.invoke('traceLogExcludes', null, nodeId)
+    async traceLog(nodeId: string): Promise<TraceLogProperties> {
+        const data: any = await this.serviceProxy.invoke('traceLog', null, nodeId)
+        const ret = new TraceLogProperties()
+        Object.assign(ret, data)
+        return ret
     }
 
-    configureTraceLogExcludes(nodeId: string, excludes: string[]): Promise<void> {
-        return this.serviceProxy.invoke('configureTraceLogExcludes', [excludes], nodeId)
+    configureTraceLog(nodeId: string, traceLog: TraceLogProperties): Promise<void> {
+        return this.serviceProxy.invoke('configureTraceLog', [traceLog], nodeId)
     }
 }
 

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -1,6 +1,11 @@
 # YAML Reference http://www.yaml.org/refcard.html
 kinotic:
   debug: true
+  traceLog:
+    # org.kinotic runs at TRACE below, and every vm-manager heartbeat prints its STOMP frame, its
+    # invocation, its argument values and its reply frame. Drop those and the rest of TRACE is readable.
+    excludes:
+      - "srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/heartbeat"
   persistence:
     # A single-node dev cluster cannot assign replicas, and every published EntityDefinition costs
     # numberOfShards * (1 + numberOfReplicas) against the 1000-shard default. 1/0 keeps the cluster

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -2,8 +2,6 @@
 kinotic:
   debug: true
   traceLog:
-    # org.kinotic runs at TRACE below, and every vm-manager heartbeat prints its STOMP frame, its
-    # invocation, its argument values and its reply frame. Drop those and the rest of TRACE is readable.
     excludes:
       - "srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/heartbeat"
   persistence:

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/LogManager.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/LogManager.java
@@ -1,14 +1,13 @@
 package org.kinotic.system.api.services;
 
 import org.kinotic.core.api.annotations.Publish;
+import org.kinotic.core.api.config.TraceLogProperties;
 import org.kinotic.core.api.annotations.Scope;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.system.api.model.log.LogLevel;
 import org.kinotic.system.api.model.log.LoggerLevelsDescriptor;
 import org.kinotic.system.api.model.log.LoggersDescriptor;
 import org.kinotic.domain.api.utils.DomainUtil;
-
-import java.util.List;
 
 /**
  * Interface providing the ability to work with runtime logging configuration per node
@@ -41,20 +40,18 @@ public interface LogManager {
     void configureLogLevel(String name, LogLevel level);
 
     /**
-     * @return the CRI patterns currently excluded from trace logging on this node
+     * @return the CRI patterns currently deciding what this node trace logs
      */
-    List<String> traceLogExcludes();
+    TraceLogProperties traceLog();
 
     /**
-     * Configures the CRI patterns excluded from trace logging, silencing a service that would
-     * otherwise bury the log while trace logging is on. Each pattern is matched against the fully
-     * qualified CRI with Ant wildcards, so {@code srv://system-api~com.acme.HeartbeatService/*}
-     * covers every method of that service and a raw CRI covers only the method it names.
+     * Configures the CRI patterns deciding what this node trace logs, silencing a service that
+     * would otherwise bury the log while trace logging is on.
      * The patterns replace whatever this node is using and last until it restarts, which returns it
-     * to the {@code kinotic.traceLogExcludes} it was configured with.
+     * to the {@code kinotic.traceLog} it was configured with.
      *
-     * @param excludes the CRI patterns to exclude, or empty to exclude nothing
+     * @param traceLog the include and exclude patterns to apply
      */
-    void configureTraceLogExcludes(List<String> excludes);
+    void configureTraceLog(TraceLogProperties traceLog);
 
 }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/LogManager.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/LogManager.java
@@ -8,6 +8,8 @@ import org.kinotic.system.api.model.log.LoggerLevelsDescriptor;
 import org.kinotic.system.api.model.log.LoggersDescriptor;
 import org.kinotic.domain.api.utils.DomainUtil;
 
+import java.util.List;
+
 /**
  * Interface providing the ability to work with runtime logging configuration per node
  *
@@ -37,5 +39,22 @@ public interface LogManager {
      * @param level the {@link LogLevel} to set for the logger with the given name
      */
     void configureLogLevel(String name, LogLevel level);
+
+    /**
+     * @return the CRI patterns currently excluded from trace logging on this node
+     */
+    List<String> traceLogExcludes();
+
+    /**
+     * Configures the CRI patterns excluded from trace logging, silencing a service that would
+     * otherwise bury the log while trace logging is on. Each pattern is matched against the fully
+     * qualified CRI with Ant wildcards, so {@code srv://system-api~com.acme.HeartbeatService/*}
+     * covers every method of that service and a raw CRI covers only the method it names.
+     * The patterns replace whatever this node is using and last until it restarts, which returns it
+     * to the {@code kinotic.traceLogExcludes} it was configured with.
+     *
+     * @param excludes the CRI patterns to exclude, or empty to exclude nothing
+     */
+    void configureTraceLogExcludes(List<String> excludes);
 
 }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultLogManager.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultLogManager.java
@@ -4,6 +4,7 @@ package org.kinotic.system.internal.api.services;
 
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.Kinotic;
+import org.kinotic.core.api.config.TraceLogProperties;
 import org.kinotic.core.api.event.TraceLogFilter;
 import org.kinotic.system.api.model.log.GroupLoggerLevelsDescriptor;
 import org.kinotic.system.api.model.log.LogLevel;
@@ -86,12 +87,12 @@ public class DefaultLogManager implements LogManager {
         this.loggingSystem.setLogLevel(name, bootLevel);
     }
 
-    public List<String> traceLogExcludes() {
-        return this.traceLogFilter.getExcludes();
+    public TraceLogProperties traceLog() {
+        return this.traceLogFilter.getPatterns();
     }
 
-    public void configureTraceLogExcludes(List<String> excludes) {
-        this.traceLogFilter.setExcludes(excludes);
+    public void configureTraceLog(TraceLogProperties traceLog) {
+        this.traceLogFilter.setPatterns(traceLog);
     }
 
     private NavigableSet<LogLevel> getLevels() {

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultLogManager.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultLogManager.java
@@ -4,6 +4,7 @@ package org.kinotic.system.internal.api.services;
 
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.Kinotic;
+import org.kinotic.core.api.event.TraceLogFilter;
 import org.kinotic.system.api.model.log.GroupLoggerLevelsDescriptor;
 import org.kinotic.system.api.model.log.LogLevel;
 import org.kinotic.system.api.model.log.LoggerLevelsDescriptor;
@@ -31,15 +32,18 @@ public class DefaultLogManager implements LogManager {
     private final Kinotic kinotic;
     private final LoggingSystem loggingSystem;
     private final LoggerGroups loggerGroups;
+    private final TraceLogFilter traceLogFilter;
 
 
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public DefaultLogManager(Kinotic kinotic,
                              LoggingSystem loggingSystem,
-                             LoggerGroups loggerGroups) {
+                             LoggerGroups loggerGroups,
+                             TraceLogFilter traceLogFilter) {
         this.kinotic = kinotic;
         this.loggingSystem = loggingSystem;
         this.loggerGroups = loggerGroups;
+        this.traceLogFilter = traceLogFilter;
     }
 
     @Override
@@ -80,6 +84,14 @@ public class DefaultLogManager implements LogManager {
             return;
         }
         this.loggingSystem.setLogLevel(name, bootLevel);
+    }
+
+    public List<String> traceLogExcludes() {
+        return this.traceLogFilter.getExcludes();
+    }
+
+    public void configureTraceLogExcludes(List<String> excludes) {
+        this.traceLogFilter.setExcludes(excludes);
     }
 
     private NavigableSet<LogLevel> getLevels() {

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -200,9 +200,10 @@ kinotic:
       - srv://app.acme-org.orders-app~com.acme.OrderService/**
 ```
 
-Patterns are matched against `srv://` destinations only. A reply comes back on a destination
-belonging to the client connection, which names no service, so it is never matched — an excluded
-request is marked as it enters the gateway and its reply is dropped from the log along with it.
+Patterns are matched against every destination but one. A reply comes back on a destination
+belonging to the client connection rather than naming what was invoked, so it is never matched —
+an excluded request is marked as it enters the gateway and its reply is dropped from the log along
+with it.
 An excluded CRI therefore drops the whole exchange: the request frame, the invocation and its
 arguments, the values a streaming result emits, and the reply frame the client receives. The
 patterns are consulted only while trace logging is enabled, and cost nothing at any other level.

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -192,3 +192,6 @@ values a streaming result emits, and the reply frame the client receives — whi
 the client rather than to the service, and so is suppressed by a marker the gateway puts on the
 request. The patterns are consulted only while trace logging is enabled, and cost nothing at any
 other level.
+
+`traceLogExcludes` is what a node starts with. `LogManager` replaces the patterns on a running node
+the same way it sets log levels — see [Observability](/platform/observability#application-logs).

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -172,13 +172,14 @@ invoker dispatches, and the arguments each invoked method received. That is what
 during development and what makes a high-frequency service — a heartbeat, a poll — drown out
 everything else in the log.
 
-`kinotic.traceLogExcludes` names the CRIs that stay out of it:
+`kinotic.traceLog` names the CRIs that stay out of it, and the ones that stay in:
 
 ```yaml
 kinotic:
-  traceLogExcludes:
-    - srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/*
-    - srv://system-api~org.kinotic.system.api.services.KinoticClusterInfoService/findClusterInfo
+  traceLog:
+    excludes:
+      - srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/*
+      - srv://system-api~org.kinotic.system.api.services.KinoticClusterInfoService/findClusterInfo
 ```
 
 Each entry is matched against the fully qualified CRI with Ant wildcards — `*` matches within one
@@ -187,11 +188,25 @@ covers just that one method. A scoped invocation carries its scope in the CRI, s
 must cover one needs the scope wildcard as well:
 `srv://*@system-api~com.acme.NodeService/*`.
 
+An include wins over an exclude that also matches, which turns the filter around: exclude
+everything and name what is worth watching.
+
+```yaml
+kinotic:
+  traceLog:
+    excludes:
+      - '**'
+    includes:
+      - srv://app.acme-org.orders-app~com.acme.OrderService/**
+```
+
 An excluded CRI drops the whole exchange: the request frame, the invocation and its arguments, the
 values a streaming result emits, and the reply frame the client receives — which is addressed to
-the client rather than to the service, and so is suppressed by a marker the gateway puts on the
+the client rather than to the service, and so follows the verdict the gateway records on the
 request. The patterns are consulted only while trace logging is enabled, and cost nothing at any
 other level.
 
-`traceLogExcludes` is what a node starts with. `LogManager` replaces the patterns on a running node
-the same way it sets log levels — see [Observability](/platform/observability#application-logs).
+`kinotic.traceLog` is what a node starts with. The system console's **Logging** dialog, on each
+node in the Dashboard's server node table, edits the patterns on a running node the same way it
+sets log levels — see [Observability](/platform/observability#application-logs). Those edits last
+until the node restarts, which returns it to its configured `kinotic.traceLog`.

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -164,3 +164,31 @@ A workload writes to two places the node must bound: the directories it mounts, 
 | `logPolicy.maxFiles` | How many rotated files are kept alongside the current one |
 
 `sizeLimitMb` applies to writable mounts; a mount declared `readOnly` is already unwritable. It is enforced by an XFS project quota, so the host filesystem refuses the write once the cap is reached whatever the workload does — which requires the mount to live on an XFS filesystem mounted with `prjquota`, on a node running either provider. The two providers differ only in what a node that cannot enforce a cap does with it. A `CLOUD_HYPERVISOR` node is provisioned for quotas, so it refuses the workload and reports the condition on its heartbeat until it is fixed. A `BOXLITE` node may have no project quotas at all — on macOS it cannot have them — so it enforces the cap wherever the filesystem holding the mount carries them, exactly as a `CLOUD_HYPERVISOR` node does, and only runs a mount uncapped when that filesystem has none; it warns at startup when its workload data directory is on such a filesystem. A node that had project quotas and lost them reports it on its heartbeat and stops taking workloads, whichever provider it runs. A workload's logs occupy at most `maxSizeMb * (maxFiles + 1)`, and the limits are applied by the VM provider rather than by the workload, so a workload cannot raise its own ceiling.
+
+## Trace logging
+
+Trace logging prints every STOMP frame the gateway reads and writes, every service invocation the
+invoker dispatches, and the arguments each invoked method received. That is what makes it useful
+during development and what makes a high-frequency service — a heartbeat, a poll — drown out
+everything else in the log.
+
+`kinotic.traceLogExcludes` names the CRIs that stay out of it:
+
+```yaml
+kinotic:
+  traceLogExcludes:
+    - srv://system-api~org.kinotic.system.api.services.VmNodeOrchestrationService/*
+    - srv://system-api~org.kinotic.system.api.services.KinoticClusterInfoService/findClusterInfo
+```
+
+Each entry is matched against the fully qualified CRI with Ant wildcards — `*` matches within one
+segment, `**` across segments — so a trailing `/*` covers every method of a service and a raw CRI
+covers just that one method. A scoped invocation carries its scope in the CRI, so a pattern that
+must cover one needs the scope wildcard as well:
+`srv://*@system-api~com.acme.NodeService/*`.
+
+An excluded CRI drops the whole exchange: the request frame, the invocation and its arguments, the
+values a streaming result emits, and the reply frame the client receives — which is addressed to
+the client rather than to the service, and so is suppressed by a marker the gateway puts on the
+request. The patterns are consulted only while trace logging is enabled, and cost nothing at any
+other level.

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -200,11 +200,12 @@ kinotic:
       - srv://app.acme-org.orders-app~com.acme.OrderService/**
 ```
 
-An excluded CRI drops the whole exchange: the request frame, the invocation and its arguments, the
-values a streaming result emits, and the reply frame the client receives — which is addressed to
-the client rather than to the service, and so follows the verdict the gateway records on the
-request. The patterns are consulted only while trace logging is enabled, and cost nothing at any
-other level.
+Patterns are matched against `srv://` destinations only. A reply comes back on a destination
+belonging to the client connection, which names no service, so it is never matched — an excluded
+request is marked as it enters the gateway and its reply is dropped from the log along with it.
+An excluded CRI therefore drops the whole exchange: the request frame, the invocation and its
+arguments, the values a streaming result emits, and the reply frame the client receives. The
+patterns are consulted only while trace logging is enabled, and cost nothing at any other level.
 
 `kinotic.traceLog` is what a node starts with. The system console's **Logging** dialog, on each
 node in the Dashboard's server node table, edits the patterns on a running node the same way it

--- a/website/content/02.platform/08.observability.md
+++ b/website/content/02.platform/08.observability.md
@@ -33,6 +33,8 @@ Track platform activity including:
 
 View microservice logs directly from the dashboard with the ability to temporarily adjust logging levels for debugging. Increase verbosity on a running service to investigate an issue, then restore normal levels when done — no redeployment required.
 
+The same dialog edits a node's [trace log filters](/platform/configuration#trace-logging), so turning a logger up to TRACE does not have to mean drowning in whatever service talks most. Both changes last until the node restarts.
+
 ## Workload Logs
 
 Logs from micro VM workloads (builds, deploys, and application containers) are shipped to Grafana Loki and can be tailed live or queried historically, per workload.


### PR DESCRIPTION
Adds configurable exclusion patterns to suppress trace logging for high-frequency services like heartbeats and polls that would otherwise drown out useful debug output.

## Summary

Introduces `kinotic.traceLogExcludes` configuration to selectively disable trace logging for specified CRI patterns. Excluded exchanges are suppressed at both request and reply, with the exclusion marker persisted across the request-reply boundary so replies (which are addressed to the client rather than the service) are also suppressed.

## Key Changes

- **TraceLogFilter** (`kinotic-core`): New component that matches CRIs against Ant-pattern exclusions using `AntPathMatcher`. Supports both service-level (`srv://.../*`) and method-level (`srv://.../method`) patterns, with scope wildcards for scoped invocations.

- **Configuration**: Added `traceLogExcludes` list property to `KinoticProperties` with documentation explaining pattern syntax and behavior.

- **Gateway integration** (`DefaultStompServerHandler`): When a SEND frame matches an exclusion pattern, marks it with `__trace-excluded` header before processing. This header rides back on the reply frame, suppressing both directions of the exchange.

- **Service invocation** (`ServiceInvocationSupervisor`): Checks exclusion filter before logging service invocation requests and method arguments.

- **RPC proxy** (`DefaultRpcServiceProxyHandle`): Removed unconditional trace log of proxy method invocations; now respects exclusion filter.

- **Subscription events** (`StompSubscriptionEventSubscriber`): Checks exclusion filter before logging streamed event values.

- **EventConstants**: Added `TRACE_EXCLUDED_HEADER` constant for the exclusion marker.

## Implementation Details

The exclusion check is only performed when `log.isTraceEnabled()` is true, so there is zero cost when trace logging is disabled. The `__trace-excluded` header is persisted through the event metadata chain, allowing reply frames (which have their own CRI unrelated to the service) to inherit the exclusion decision from the request that produced them. Patterns use Spring's `AntPathMatcher` semantics: `*` matches within a segment, `**` across segments.

Includes comprehensive test coverage (`TraceLogFilterTest`) validating wildcard patterns, scoped invocations, and reply suppression behavior.

https://claude.ai/code/session_01LDoxKNGj2iiqo9VVHpoEgH