### PR TITLE
Add native transport support and document gateway sizing work

### DIFF
--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -169,6 +169,19 @@ dependencies {
     implementation 'io.opentelemetry:opentelemetry-api'
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations'
 
+    // reactor-netty, pulled in by the Azure SDK, pins these three natives to x86 classifiers only, so on
+    // Apple Silicon and arm64 Linux NativeLibraryLoader looks up the *_aarch_64 library and finds none.
+    // MacOSDnsServerAddressStreamProvider reports that as an UnsatisfiedLinkError and Netty drops to
+    // resolv.conf parsing that ignores the VPN and per-domain resolvers; epoll and kqueue just fall back
+    // to NIO. Declaring both classifiers of each keeps one build correct on either architecture. There is
+    // no macOS-style DNS native for Linux, netty reads resolv.conf in pure Java there.
+    runtimeOnly 'io.netty:netty-resolver-dns-native-macos::osx-aarch_64'
+    runtimeOnly 'io.netty:netty-resolver-dns-native-macos::osx-x86_64'
+    runtimeOnly 'io.netty:netty-transport-native-epoll::linux-aarch_64'
+    runtimeOnly 'io.netty:netty-transport-native-epoll::linux-x86_64'
+    runtimeOnly 'io.netty:netty-transport-native-kqueue::osx-aarch_64'
+    runtimeOnly 'io.netty:netty-transport-native-kqueue::osx-x86_64'
+
     implementation 'jakarta.annotation:jakarta.annotation-api'
 
     implementation 'org.apache.commons:commons-lang3'

--- a/docs/NavidNotes.md
+++ b/docs/NavidNotes.md
@@ -219,6 +219,26 @@ is a healthy-looking pod quietly dropping arbitrary connections while clients re
 which is exactly what sent us chasing a client bug at the start of this. Pair the log alert with a
 gauge on `jvm.buffer.memory.used{pool=direct}` approaching `MaxDirectMemorySize`.
 
+### Re-measure gateway sizing with `preferNativeTransport` on
+
+`KinoticVertxConfig.vertx` never calls `setPreferNativeTransport(true)`, so Vert.x runs on NIO. The
+epoll and kqueue natives are now on the classpath for both x86 and aarch64, so turning it on is one
+line — but every direct-memory number in `docs/future-prompts/Gateway memory sizing validation.md`
+was measured against the NIO allocator. The finding that direct memory is flat in connection count
+(byte-identical 9,992 KB at 1k/5k/10k) rests on Netty's magazines being bounded by
+`MAX_STRIPES = availableProcessors() * 2`; epoll allocates on its own path, so both that finding and
+the `-XX:MaxDirectMemorySize=512m` in `org.kinotic.java-application-conventions.gradle` may not
+describe the server once the flag is on.
+
+Re-derive the direct-memory and heap figures the way that doc describes, with the flag on, at the
+same 1k/5k/10k connection counts. Then update its table, its "Direct memory does not scale with
+connections" finding and the sizing artifact, and decide from the numbers whether the flag stays.
+
+Assert the transport actually took, do not infer it from the flag: when the native is unavailable
+`VertxBootstrapImpl.instantiateVertx` swaps in `NioTransport.INSTANCE` and only stashes the cause,
+so a run with the flag set and no native looks identical to a run without it. Check it with
+`Transport.EPOLL.available()`.
+
 ### Sign the session cookie (`SessionHandler.setSigningSecret`)
 
 Deferred until the platform-secret layout in Azure is reworked — this needs one more secret and it


### PR DESCRIPTION
## Summary

This PR adds Netty native transport libraries for multiple architectures and documents planned work to re-measure gateway sizing with native transports enabled.

## Changes

**buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle**
- Added runtime dependencies for Netty native transports across architectures:
  - `netty-resolver-dns-native-macos` for both `osx-aarch_64` and `osx-x86_64`
  - `netty-transport-native-epoll` for both `linux-aarch_64` and `linux-x86_64`
  - `netty-transport-native-kqueue` for both `osx-aarch_64` and `osx-x86_64`

These declarations ensure the correct native library is available regardless of build architecture. Without them, `NativeLibraryLoader` fails to locate architecture-specific natives (e.g., aarch64 on Apple Silicon), causing fallback to pure-Java implementations that may have degraded behavior (e.g., DNS resolution ignoring VPN settings).

**docs/NavidNotes.md**
- Added section documenting the need to re-measure gateway sizing with `preferNativeTransport` enabled
- Notes that current measurements in `docs/future-prompts/Gateway memory sizing validation.md` were taken against the NIO allocator
- Identifies that direct memory scaling findings depend on Netty's magazine-bounded allocation (`MAX_STRIPES = availableProcessors() * 2`), which may not hold under epoll's separate allocation path
- Specifies validation approach: re-derive direct-memory and heap figures at 1k/5k/10k connection counts with the flag enabled, then update the sizing document and decide whether to keep the flag
- Emphasizes verifying the transport actually loaded via `Transport.EPOLL.available()` rather than inferring from the flag, since `VertxBootstrapImpl.instantiateVertx` silently falls back to NIO when natives are unavailable

## Implementation Notes

The native library declarations use the `::classifier` syntax to explicitly select architecture-specific artifacts. This prevents resolution failures on non-x86 platforms and ensures both architectures can build successfully from the same source.

The documentation captures the dependency between the native transport flag and the validity of existing performance measurements, establishing the work needed before the flag can be safely enabled in production.

https://claude.ai/code/session_01C8CkbNJsi9FrafGcoa8rvX