### PR TITLE
Point the frontend at system-api 5.0.0-beta.8 and drop the duplicate catalog

### DIFF
--- a/kinotic-frontend/package.json
+++ b/kinotic-frontend/package.json
@@ -10,18 +10,5 @@
     "build:dev": "pnpm -r build:dev",
     "build:kind": "pnpm -r build:kind",
     "dev:system": "pnpm --filter kinotic-system-console dev"
-  },
-  "workspaces": {
-    "packages": [
-      "apps/*",
-      "packages/*"
-    ],
-    "catalog": {
-      "@kinotic-ai/core": "^5.0.0-beta.8",
-      "@kinotic-ai/idl": "^5.0.0-beta.1",
-      "@kinotic-ai/management-api": "^5.0.0-beta.23",
-      "@kinotic-ai/persistence": "^5.0.0-beta.8",
-      "@kinotic-ai/system-api": "^5.0.0-beta.8"
-    }
   }
 }

--- a/kinotic-frontend/pnpm-lock.yaml
+++ b/kinotic-frontend/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^5.0.0-beta.9
       version: 5.0.0-beta.9
     '@kinotic-ai/system-api':
-      specifier: ^5.0.0-beta.7
-      version: 5.0.0-beta.7
+      specifier: ^5.0.0-beta.8
+      version: 5.0.0-beta.8
 
 importers:
 
@@ -169,7 +169,7 @@ importers:
         version: 5.0.0-beta.24(@kinotic-ai/core@5.0.0-beta.9)
       '@kinotic-ai/system-api':
         specifier: 'catalog:'
-        version: 5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.9)
+        version: 5.0.0-beta.8(@kinotic-ai/core@5.0.0-beta.9)
       '@primeuix/themes':
         specifier: ^2.0.3
         version: 2.0.3
@@ -361,8 +361,8 @@ packages:
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.9'
 
-  '@kinotic-ai/system-api@5.0.0-beta.7':
-    resolution: {integrity: sha512-K3ngicqU0+M6CiVDwUxa7Qi0WVSuti3vOpw/0xiiWewLNnnS6z39CnCbIFlTZ6LV23ZZsISVwc3846rxEZeQGA==}
+  '@kinotic-ai/system-api@5.0.0-beta.8':
+    resolution: {integrity: sha512-0YkHIXJovYvRkowa8k/ACbtWEJ16ssMynY+t7MqdrDQpht/HJJIwOEKGjXkLBKfw091rnvSsAkHDdBZ9eHDn6w==}
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.9'
 
@@ -1751,7 +1751,7 @@ snapshots:
       '@kinotic-ai/idl': 5.0.0-beta.1
       rxjs: 7.8.2
 
-  '@kinotic-ai/system-api@5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.9)':
+  '@kinotic-ai/system-api@5.0.0-beta.8(@kinotic-ai/core@5.0.0-beta.9)':
     dependencies:
       '@kinotic-ai/core': 5.0.0-beta.9
       '@kinotic-ai/management-api': 5.0.0-beta.24(@kinotic-ai/core@5.0.0-beta.9)

--- a/kinotic-frontend/pnpm-workspace.yaml
+++ b/kinotic-frontend/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   '@kinotic-ai/idl': ^5.0.0-beta.1
   '@kinotic-ai/management-api': ^5.0.0-beta.24
   '@kinotic-ai/persistence': ^5.0.0-beta.9
-  '@kinotic-ai/system-api': ^5.0.0-beta.7
+  '@kinotic-ai/system-api': ^5.0.0-beta.8
 
 allowBuilds:
   '@tailwindcss/oxide': true


### PR DESCRIPTION
Follow-up to #497, which landed the trace log filter but left the system console unable to resolve the client methods it calls. `@kinotic-ai/system-api@5.0.0-beta.8` is now published, so the catalog can move to it.

## The catalog pnpm actually reads

pnpm resolves `catalog:` from `pnpm-workspace.yaml`. The `workspaces.catalog` block in `package.json` is bun/yarn syntax that pnpm ignores, and it had drifted to a different pin on four of its five entries:

```
package.json (ignored)          pnpm-workspace.yaml (authoritative)
  core            ^5.0.0-beta.8   core            ^5.0.0-beta.9
  idl             ^5.0.0-beta.1   idl             ^5.0.0-beta.1
  management-api  ^5.0.0-beta.23  management-api  ^5.0.0-beta.24
  persistence     ^5.0.0-beta.8   persistence     ^5.0.0-beta.9
  system-api      ^5.0.0-beta.8   system-api      ^5.0.0-beta.7   ← what actually resolved
```

Nothing in the tree reads that block — its only occurrence is its own declaration — and the `packages` list beside it duplicates `pnpm-workspace.yaml` as well, so the whole `workspaces` block goes rather than being re-synced.

## The bump

```yaml
# kinotic-frontend/pnpm-workspace.yaml
-  '@kinotic-ai/system-api': ^5.0.0-beta.7
+  '@kinotic-ai/system-api': ^5.0.0-beta.8
```

beta.8 carries `traceLog(nodeId)` and `configureTraceLog(nodeId, traceLog)` on `ILogManager`, plus `TraceLogProperties` — what `LogLevelDialog.vue`'s trace log filter section calls.

## Verification

`pnpm install` resolves `@kinotic-ai/system-api 5.0.0-beta.8` and `pnpm-lock.yaml` is regenerated against it. `vue-tsc -b --force` is clean for both `apps/system` and `apps/portal` against the published packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDoxKNGj2iiqo9VVHpoEgH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDoxKNGj2iiqo9VVHpoEgH)_