### PR TITLE
Increase LogLevelDialog width from 34rem to 52rem

### DIFF
--- a/kinotic-frontend/apps/system/src/components/LogLevelDialog.vue
+++ b/kinotic-frontend/apps/system/src/components/LogLevelDialog.vue
@@ -3,7 +3,7 @@
     v-model:visible="visible"
     modal
     :header="`Logging — ${nodeId}`"
-    :style="{ width: '34rem', maxWidth: '95vw' }"
+    :style="{ width: '52rem', maxWidth: '95vw' }"
     @show="opened"
   >
     <p class="mb-4 text-sm text-muted-color">


### PR DESCRIPTION
Expands the LogLevelDialog modal to better accommodate its content.

**Changes:**
- `kinotic-frontend/apps/system/src/components/LogLevelDialog.vue:6` — Increased dialog width from `34rem` to `52rem` while maintaining the `95vw` max-width constraint for mobile responsiveness

This provides more horizontal space for the logging configuration interface while preserving the responsive behavior on smaller viewports.

https://claude.ai/code/session_01FapNopRHm2URvihb6C8srP