### PR TITLE
Refactor EntityContext to expose organization and tenant IDs directly

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/NamedJsonArgumentResolver.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/NamedJsonArgumentResolver.java
@@ -28,14 +28,11 @@ import java.util.Set;
 @Component
 public class NamedJsonArgumentResolver extends AbstractJacksonSupport implements ArgumentResolver {
 
-    private final SecurityContext securityContext;
-
     public NamedJsonArgumentResolver(JsonMapper jsonMapper,
                                      ReactiveAdapterRegistry reactiveAdapterRegistry,
                                      KinoticProperties kinoticProperties,
                                      SecurityContext securityContext) {
         super(jsonMapper, reactiveAdapterRegistry, kinoticProperties, securityContext);
-        this.securityContext = securityContext;
     }
 
     @Override
@@ -50,11 +47,7 @@ public class NamedJsonArgumentResolver extends AbstractJacksonSupport implements
 
             // A Participant parameter comes from the Vert.x context, never from the body
             if (Participant.class.isAssignableFrom(methodParameter.getParameterType())) {
-                Participant participant = securityContext.currentParticipant();
-                if (participant == null) {
-                    throw new IllegalArgumentException("Participant parameter is required but no Participant is available in the Vert.x context");
-                }
-                ret.add(participant);
+                ret.add(resolveParticipant(methodParameter));
             } else {
                 // IdlUtil.parameterName is the shared naming rule, so the name bound here is
                 // the name the emitted schema declared

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/json/AbstractJacksonSupport.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/json/AbstractJacksonSupport.java
@@ -72,6 +72,26 @@ public abstract class AbstractJacksonSupport {
     }
 
     /**
+     * Resolves a {@link Participant} parameter from the current Vert.x context, narrowed to the
+     * {@link Participant} subtype the parameter declares.
+     *
+     * @param methodParameter the {@link Participant} parameter being resolved
+     * @return the participant bound to the current Vert.x context
+     * @throws IllegalStateException if no participant is bound to the current Vert.x context
+     * @throws org.kinotic.core.api.exceptions.AuthorizationException if the participant is not of
+     *         the declared subtype
+     */
+    protected Participant resolveParticipant(MethodParameter methodParameter) {
+        // A service declares the participant scope it serves, so narrowing here turns a caller the
+        // service does not serve into an authorization failure rather than an "argument type
+        // mismatch" out of Method.invoke
+        @SuppressWarnings("unchecked")
+        Class<? extends Participant> participantType =
+                (Class<? extends Participant>) methodParameter.getParameterType();
+        return securityContext.requireParticipant(participantType);
+    }
+
+    /**
      * Transforms the JSON content to Java objects using the given expected parameter types
      * @param event the message containing the JSON content to be converted
      * @param parameters to determine the correct type for the {@link TokenBuffer} being decoded.
@@ -118,12 +138,7 @@ public abstract class AbstractJacksonSupport {
             // If the parameter is a Participant we get this from the Vert.x context
             if (Participant.class.isAssignableFrom(methodParameter.getParameterType())) {
 
-                Participant participant = securityContext.currentParticipant();
-                if (participant != null) {
-                    ret.add(participant);
-                } else {
-                    throw new IllegalArgumentException("Participant parameter is required but no Participant is available in the Vert.x context");
-                }
+                ret.add(resolveParticipant(methodParameter));
 
             } else {
                 if (tokenIdx >= tokenCount) {

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
@@ -11,6 +11,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.api.Kinotic;
+import org.kinotic.core.api.exceptions.AuthorizationException;
 import org.kinotic.core.api.exceptions.RpcInvocationException;
 import org.kinotic.core.api.exceptions.RpcMissingMethodException;
 import org.kinotic.core.api.exceptions.RpcMissingServiceException;
@@ -257,6 +258,17 @@ public class RpcTests {
         StepVerifier.create(mono)
                     .expectNext(prefix + PARTICIPANT_ID + suffix)
                     .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    public void testNarrowParticipantRejectsWiderCaller(){
+        // the bound participant is a plain Participant, so it is not the NarrowParticipant the
+        // service declares
+        Mono<String> mono = withParticipant(rpcTestServiceProxy::narrowParticipant);
+
+        StepVerifier.create(mono)
+                    .expectErrorMatches(throwable -> throwable instanceof AuthorizationException)
                     .verify();
     }
 

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/DefaultRpcTestService.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/DefaultRpcTestService.java
@@ -194,6 +194,11 @@ public class DefaultRpcTestService implements RpcTestService{
     }
 
     @Override
+    public Mono<String> narrowParticipant(NarrowParticipant participant){
+        return Mono.just(participant.getId());
+    }
+
+    @Override
     public Integer putListOfSimpleObjects(List<SimpleObject> simpleObjects) {
         for(SimpleObject simpleObject : simpleObjects){
             if(simpleObject == null){

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/NarrowParticipant.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/NarrowParticipant.java
@@ -1,0 +1,11 @@
+package org.kinotic.core.internal.api.support;
+
+import org.kinotic.core.api.security.Participant;
+
+/**
+ * A {@link Participant} subtype a service may declare to serve only callers of that scope,
+ * the way the platform's services declare {@code OrganizationParticipant} or
+ * {@code ApplicationParticipant}.
+ */
+public interface NarrowParticipant extends Participant {
+}

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestService.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestService.java
@@ -99,6 +99,8 @@ public interface RpcTestService {
 
     List<String> modifyListOfStrings(String[] stringsToModify);
 
+    Mono<String> narrowParticipant(NarrowParticipant participant);
+
     Integer putListOfSimpleObjects(List<SimpleObject> simpleObjects);
 
     Integer putListOfStrings(List<String> strings);

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestServiceProxy.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestServiceProxy.java
@@ -83,6 +83,8 @@ public interface RpcTestServiceProxy {
 
     Mono<List<String>> modifyListOfStrings(List<String> stringsToModify);
 
+    Mono<String> narrowParticipant();
+
     Mono<Integer> putListOfSimpleObjects(List<SimpleObject> simpleObjects);
 
     Mono<Integer> putListOfStrings(List<String> strings);

--- a/kinotic-frontend/apps/portal/src/components/EntityDefinitionsList.vue
+++ b/kinotic-frontend/apps/portal/src/components/EntityDefinitionsList.vue
@@ -288,7 +288,7 @@ export default defineComponent({
     </CrudTable>
 
     <EntityDataViewModal
-      v-if="selectedEntityDefinition"
+      v-if="showModal && selectedEntityDefinition"
       v-model="showModal"
       :title="selectedEntityDefinition?.name || 'Data View'"
       :entity-props="{ entityDefinitionId: selectedEntityDefinition?.id }"

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/model/EntityContext.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/model/EntityContext.java
@@ -52,6 +52,23 @@ public interface EntityContext {
     String getTenantId();
 
     /**
+     * The tenant this operation is confined to, for an operation that cannot be carried out
+     * without one — every read and write of an {@link EntityDefinition} whose
+     * {@link org.kinotic.persistence.api.model.idl.decorators.MultiTenancyType} is
+     * {@code SHARED}.
+     *
+     * @return the tenant this operation is confined to; never null
+     * @throws IllegalStateException if the participant carries no tenant
+     */
+    default String requireTenantId() {
+        String tenantId = getTenantId();
+        if (tenantId == null) {
+            throw new IllegalStateException("This operation requires a Participant with a TenantId");
+        }
+        return tenantId;
+    }
+
+    /**
      * Checks if a tenant selection is provided for the current operation
      *
      * @return true if a tenant selection is provided, false otherwise

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/model/EntityContext.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/model/EntityContext.java
@@ -1,6 +1,6 @@
 package org.kinotic.persistence.api.model;
 
-import org.kinotic.domain.api.model.security.participant.ApplicationParticipant;
+import org.kinotic.domain.api.model.security.participant.ScopedParticipant;
 
 import java.util.List;
 
@@ -25,13 +25,31 @@ public interface EntityContext {
     boolean hasIncludedFieldsFilter();
 
     /**
-     * The {@link ApplicationParticipant} performing the operation. Entity data is always
-     * application-scoped end-user data, so an entity operation is always carried out by an
-     * Application participant.
+     * The id of the Organization that owns the data this operation reads or writes. Every
+     * {@link EntityDefinition} belongs to one Organization, so this is never null.
      *
-     * @return the {@link ApplicationParticipant} that is performing the operation
+     * @return the id of the Organization this operation is carried out within
      */
-    ApplicationParticipant getParticipant();
+    String getOrganizationId();
+
+    /**
+     * The {@link ScopedParticipant} performing the operation. An Application's end users reach
+     * entity data as Application participants, and the console reaches it as an Organization
+     * participant, so both scopes appear here.
+     *
+     * @return the {@link ScopedParticipant} that is performing the operation
+     */
+    ScopedParticipant getParticipant();
+
+    /**
+     * The tenant slice of an Application's end-user data this operation is confined to, or null
+     * when the participant carries no tenant. An {@link EntityDefinition} whose
+     * {@link org.kinotic.persistence.api.model.idl.decorators.MultiTenancyType} is
+     * {@code SHARED} requires one.
+     *
+     * @return the tenant this operation is confined to, or null
+     */
+    String getTenantId();
 
     /**
      * Checks if a tenant selection is provided for the current operation

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/AdminJsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/AdminJsonEntitiesRepository.java
@@ -9,7 +9,7 @@ import org.kinotic.persistence.api.model.*;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.api.utils.DomainUtil;
-import org.kinotic.domain.api.model.security.participant.ApplicationParticipant;
+import org.kinotic.domain.api.model.security.participant.ScopedParticipant;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting the number of entities.
      */
-    Future<Long> count(String entityDefinitionId, List<String> tenantSelection, ApplicationParticipant participant);
+    Future<Long> count(String entityDefinitionId, List<String> tenantSelection, ScopedParticipant participant);
 
     /**
      * Returns the number of entities available for the given query.
@@ -41,7 +41,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting the number of entities.
      */
-    Future<Long> countByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ApplicationParticipant participant);
+    Future<Long> countByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ScopedParticipant participant);
 
     /**
      * Deletes the entity with the given id.
@@ -51,7 +51,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting when delete is complete
      */
-    Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant);
+    Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ScopedParticipant participant);
 
     /**
      * Deletes any entities that match the given query.
@@ -62,7 +62,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting when delete is complete
      */
-    Future<Void> deleteByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ApplicationParticipant participant);
+    Future<Void> deleteByQuery(String entityDefinitionId, String query, List<String> tenantSelection, ScopedParticipant participant);
 
     /**
      * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
@@ -73,7 +73,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return a page of entities
      */
-    Future<Page<FastestType>> findAll(String entityDefinitionId, List<String> tenantSelection, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> findAll(String entityDefinitionId, List<String> tenantSelection, Pageable pageable, ScopedParticipant participant);
 
     /**
      * Retrieves an entity by its id.
@@ -83,7 +83,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} with the entity with the given id or {@link Future} emitting null if none found
      */
-    Future<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant);
+    Future<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ScopedParticipant participant);
 
     /**
      * Retrieves a list of entities by their id.
@@ -93,7 +93,7 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting an empty list if none found
      */
-    Future<List<FastestType>> findByIds(String entityDefinitionId, List<TenantSpecificId> ids, ApplicationParticipant participant);
+    Future<List<FastestType>> findByIds(String entityDefinitionId, List<TenantSpecificId> ids, ScopedParticipant participant);
 
     /**
      * Executes a named query.
@@ -109,7 +109,7 @@ public interface AdminJsonEntitiesRepository {
                                      String queryName,
                                      List<QueryParameter> queryParameters,
                                      List<String> tenantSelection,
-                                     ApplicationParticipant participant);
+                                     ScopedParticipant participant);
 
     /**
      * Executes a named query and returns a {@link Page} of results.
@@ -127,7 +127,7 @@ public interface AdminJsonEntitiesRepository {
                                          List<QueryParameter> queryParameters,
                                          List<String> tenantSelection,
                                          Pageable pageable,
-                                         ApplicationParticipant participant);
+                                         ScopedParticipant participant);
 
     /**
      * Returns a {@link Page} of entities matching the search text and paging restriction provided in the {@code Pageable} object.
@@ -141,6 +141,6 @@ public interface AdminJsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return a {@link Future} of a page of entities
      */
-    Future<Page<FastestType>> search(String entityDefinitionId, String searchText, List<String> tenantSelection, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> search(String entityDefinitionId, String searchText, List<String> tenantSelection, Pageable pageable, ScopedParticipant participant);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/JsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/JsonEntitiesRepository.java
@@ -11,7 +11,7 @@ import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.api.utils.DomainUtil;
-import org.kinotic.domain.api.model.security.participant.ApplicationParticipant;
+import org.kinotic.domain.api.model.security.participant.ScopedParticipant;
 import tools.jackson.databind.util.TokenBuffer;
 
 import java.util.List;
@@ -32,7 +32,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} that will complete when all entities have been saved
      */
-    Future<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant);
+    Future<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ScopedParticipant participant);
 
     /**
      * Saves all given entities.
@@ -42,7 +42,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} that will complete when all entities have been saved
      */
-    Future<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant);
+    Future<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ScopedParticipant participant);
 
     /**
      * Returns the number of entities available.
@@ -51,7 +51,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting the number of entities.
      */
-    Future<Long> count(String entityDefinitionId, ApplicationParticipant participant);
+    Future<Long> count(String entityDefinitionId, ScopedParticipant participant);
 
     /**
      * Returns the number of entities available for the given query.
@@ -61,7 +61,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting the number of entities.
      */
-    Future<Long> countByQuery(String entityDefinitionId, String query, ApplicationParticipant participant);
+    Future<Long> countByQuery(String entityDefinitionId, String query, ScopedParticipant participant);
 
     /**
      * Deletes the entity with the given id.
@@ -71,7 +71,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting when delete is complete
      */
-    Future<Void> deleteById(String entityDefinitionId, String id, ApplicationParticipant participant);
+    Future<Void> deleteById(String entityDefinitionId, String id, ScopedParticipant participant);
 
     /**
      * Deletes any entities that match the given query.
@@ -81,7 +81,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting when delete is complete
      */
-    Future<Void> deleteByQuery(String entityDefinitionId, String query, ApplicationParticipant participant);
+    Future<Void> deleteByQuery(String entityDefinitionId, String query, ScopedParticipant participant);
 
     /**
      * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
@@ -91,7 +91,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return a page of entities
      */
-    Future<Page<FastestType>> findAll(String entityDefinitionId, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> findAll(String entityDefinitionId, Pageable pageable, ScopedParticipant participant);
 
     /**
      * Retrieves an entity by its id.
@@ -101,7 +101,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} with the entity with the given id or {@link Future} emitting null if none found
      */
-    Future<FastestType> findById(String entityDefinitionId, String id, ApplicationParticipant participant);
+    Future<FastestType> findById(String entityDefinitionId, String id, ScopedParticipant participant);
 
     /**
      * Retrieves a list of entities by their id.
@@ -111,7 +111,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} with the list of matched entities with the given ids or {@link Future} emitting an empty list if none found
      */
-    Future<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ApplicationParticipant participant);
+    Future<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ScopedParticipant participant);
 
     /**
      * Executes a named query.
@@ -125,7 +125,7 @@ public interface JsonEntitiesRepository {
     Future<List<RawJson>> namedQuery(String entityDefinitionId,
                                      String queryName,
                                      List<QueryParameter> queryParameters,
-                                     ApplicationParticipant participant);
+                                     ScopedParticipant participant);
 
     /**
      * Executes a named query and returns a {@link Page} of results.
@@ -141,7 +141,7 @@ public interface JsonEntitiesRepository {
                                          String queryName,
                                          List<QueryParameter> queryParameters,
                                          Pageable pageable,
-                                         ApplicationParticipant participant);
+                                         ScopedParticipant participant);
 
     /**
      * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
@@ -152,7 +152,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting the saved entity
      */
-    Future<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant);
+    Future<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ScopedParticipant participant);
 
     /**
      * Returns a {@link Page} of entities matching the search text and paging restriction provided in the {@code Pageable} object.
@@ -165,7 +165,7 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return a {@link Future} of a page of entities
      */
-    Future<Page<FastestType>> search(String entityDefinitionId, String searchText, Pageable pageable, ApplicationParticipant participant);
+    Future<Page<FastestType>> search(String entityDefinitionId, String searchText, Pageable pageable, ScopedParticipant participant);
 
     /**
      * This operation makes all the recent writes immediately available for search.
@@ -173,7 +173,7 @@ public interface JsonEntitiesRepository {
      * @param participant     the participant of the logged-in user
      * @return a {@link Future} that will complete when the operation is complete
      */
-    Future<Void> syncIndex(String entityDefinitionId, ApplicationParticipant participant);
+    Future<Void> syncIndex(String entityDefinitionId, ScopedParticipant participant);
 
     /**
      * Updates a given entity. This will only override the fields that are present in the given entity.
@@ -185,6 +185,6 @@ public interface JsonEntitiesRepository {
      * @param participant the participant of the logged-in user
      * @return {@link Future} emitting the saved entity
      */
-    Future<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant);
+    Future<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ScopedParticipant participant);
 
 }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/ReadPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/ReadPreProcessor.java
@@ -55,7 +55,7 @@ public class ReadPreProcessor {
             if(context.hasTenantSelection()){
                 builder.routing(context.getTenantSelection().getFirst());
             }else{
-                builder.routing(context.getParticipant().getTenantId());
+                builder.routing(context.getTenantId());
             }
         }
     }
@@ -98,7 +98,7 @@ public class ReadPreProcessor {
             if(context.hasTenantSelection()){
                 builder.routing(context.getTenantSelection().getFirst());
             }else{
-                builder.routing(context.getParticipant().getTenantId());
+                builder.routing(context.getTenantId());
                 if(!entityDescriptor.isMultiTenantSelectionEnabled()) {
                     builder.sourceExcludes(persistenceProperties.getTenantIdFieldName());
                 }
@@ -161,11 +161,11 @@ public class ReadPreProcessor {
                                                                          .terms(tqf-> tqf.value(fieldValues)))));
             }else{
 
-                routingConsumer.accept(context.getParticipant().getTenantId());
+                routingConsumer.accept(context.getTenantId());
                 queryBuilder = new Query.Builder();
                 queryBuilder
                         .bool(b -> b.filter(qb -> qb.term(tq -> tq.field(persistenceProperties.getTenantIdFieldName())
-                                                                  .value(context.getParticipant().getTenantId()))));
+                                                                  .value(context.getTenantId()))));
             }
         }
         return queryBuilder;
@@ -198,11 +198,11 @@ public class ReadPreProcessor {
 
                 }else{
 
-                    routingConsumer.accept(context.getParticipant().getTenantId());
+                    routingConsumer.accept(context.getTenantId());
                     queryBuilder
                             .bool(b -> b.must(must -> must.queryString(qs -> qs.query(searchText).analyzeWildcard(true)))
                                         .filter(qb -> qb.term(tq -> tq.field(persistenceProperties.getTenantIdFieldName())
-                                                                      .value(context.getParticipant().getTenantId()))));
+                                                                      .value(context.getTenantId()))));
                 }
             }else{
                 queryBuilder.queryString(qs -> qs.query(searchText).analyzeWildcard(true));

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/ReadPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/ReadPreProcessor.java
@@ -55,7 +55,7 @@ public class ReadPreProcessor {
             if(context.hasTenantSelection()){
                 builder.routing(context.getTenantSelection().getFirst());
             }else{
-                builder.routing(context.getTenantId());
+                builder.routing(context.requireTenantId());
             }
         }
     }
@@ -98,7 +98,7 @@ public class ReadPreProcessor {
             if(context.hasTenantSelection()){
                 builder.routing(context.getTenantSelection().getFirst());
             }else{
-                builder.routing(context.getTenantId());
+                builder.routing(context.requireTenantId());
                 if(!entityDescriptor.isMultiTenantSelectionEnabled()) {
                     builder.sourceExcludes(persistenceProperties.getTenantIdFieldName());
                 }
@@ -161,11 +161,12 @@ public class ReadPreProcessor {
                                                                          .terms(tqf-> tqf.value(fieldValues)))));
             }else{
 
-                routingConsumer.accept(context.getTenantId());
+                String tenantId = context.requireTenantId();
+                routingConsumer.accept(tenantId);
                 queryBuilder = new Query.Builder();
                 queryBuilder
                         .bool(b -> b.filter(qb -> qb.term(tq -> tq.field(persistenceProperties.getTenantIdFieldName())
-                                                                  .value(context.getTenantId()))));
+                                                                  .value(tenantId))));
             }
         }
         return queryBuilder;
@@ -198,11 +199,12 @@ public class ReadPreProcessor {
 
                 }else{
 
-                    routingConsumer.accept(context.getTenantId());
+                    String tenantId = context.requireTenantId();
+                    routingConsumer.accept(tenantId);
                     queryBuilder
                             .bool(b -> b.must(must -> must.queryString(qs -> qs.query(searchText).analyzeWildcard(true)))
                                         .filter(qb -> qb.term(tq -> tq.field(persistenceProperties.getTenantIdFieldName())
-                                                                      .value(context.getTenantId()))));
+                                                                      .value(tenantId))));
                 }
             }else{
                 queryBuilder.queryString(qs -> qs.query(searchText).analyzeWildcard(true));

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/AbstractJsonUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/AbstractJsonUpsertPreProcessor.java
@@ -183,7 +183,7 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
                             // or matches the logged in tenant
                             jsonParser.nextToken(); // move to value token
                             currentTenantId = jsonMapper.readValue(jsonParser, String.class);
-                            if(currentTenantId != null && !currentTenantId.equals(context.getParticipant().getTenantId())){
+                            if(currentTenantId != null && !currentTenantId.equals(context.getTenantId())){
                                 throw new IllegalArgumentException("Tenant Id invalid for logged in participant");
                             }
 
@@ -215,7 +215,7 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
                         // If this is a multi tenant EntityDefinition and multi tenant selection is not enabled, add the tenant if necessary
                         if(entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED
                                 && currentTenantId == null){
-                            currentTenantId = context.getParticipant().getTenantId();
+                            currentTenantId = context.getTenantId();
                             jsonGenerator.writeStringProperty(persistenceProperties.getTenantIdFieldName(), currentTenantId);
                         }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/AbstractJsonUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/AbstractJsonUpsertPreProcessor.java
@@ -183,7 +183,7 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
                             // or matches the logged in tenant
                             jsonParser.nextToken(); // move to value token
                             currentTenantId = jsonMapper.readValue(jsonParser, String.class);
-                            if(currentTenantId != null && !currentTenantId.equals(context.getTenantId())){
+                            if(currentTenantId != null && !currentTenantId.equals(context.requireTenantId())){
                                 throw new IllegalArgumentException("Tenant Id invalid for logged in participant");
                             }
 
@@ -215,7 +215,7 @@ public abstract class AbstractJsonUpsertPreProcessor<T> implements UpsertPreProc
                         // If this is a multi tenant EntityDefinition and multi tenant selection is not enabled, add the tenant if necessary
                         if(entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED
                                 && currentTenantId == null){
-                            currentTenantId = context.getTenantId();
+                            currentTenantId = context.requireTenantId();
                             jsonGenerator.writeStringProperty(persistenceProperties.getTenantIdFieldName(), currentTenantId);
                         }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/MapUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/MapUpsertPreProcessor.java
@@ -125,11 +125,11 @@ public class MapUpsertPreProcessor implements UpsertPreProcessor<Map<Object, Obj
 
                 tenantId = (String) entity.get(persistenceProperties.getTenantIdFieldName());
 
-                if (tenantId != null && !tenantId.equals(context.getTenantId())) {
+                if (tenantId != null && !tenantId.equals(context.requireTenantId())) {
                     throw new IllegalArgumentException("Tenant Id invalid for logged in participant");
 
                 } else if (tenantId == null) {
-                    tenantId = context.getTenantId();
+                    tenantId = context.requireTenantId();
                     entity.put(persistenceProperties.getTenantIdFieldName(), tenantId);
                 }
             }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/MapUpsertPreProcessor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/hooks/impl/MapUpsertPreProcessor.java
@@ -125,11 +125,11 @@ public class MapUpsertPreProcessor implements UpsertPreProcessor<Map<Object, Obj
 
                 tenantId = (String) entity.get(persistenceProperties.getTenantIdFieldName());
 
-                if (tenantId != null && !tenantId.equals(context.getParticipant().getTenantId())) {
+                if (tenantId != null && !tenantId.equals(context.getTenantId())) {
                     throw new IllegalArgumentException("Tenant Id invalid for logged in participant");
 
                 } else if (tenantId == null) {
-                    tenantId = context.getParticipant().getTenantId();
+                    tenantId = context.getTenantId();
                     entity.put(persistenceProperties.getTenantIdFieldName(), tenantId);
                 }
             }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/model/DefaultEntityContext.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/model/DefaultEntityContext.java
@@ -1,11 +1,11 @@
 package org.kinotic.persistence.internal.api.model;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.kinotic.domain.api.model.security.participant.ApplicationParticipant;
+import org.apache.commons.lang3.Validate;
+import org.kinotic.domain.api.model.security.participant.ParticipantScope;
+import org.kinotic.domain.api.model.security.participant.ScopedParticipant;
 import org.kinotic.persistence.api.model.EntityContext;
 
 import java.util.List;
@@ -14,26 +14,37 @@ import java.util.List;
  * Created by Navíd Mitchell 🤪 on 6/8/23.
  */
 @Getter
-@Setter
 @Accessors(chain = true)
-@AllArgsConstructor
-@NoArgsConstructor
 public class DefaultEntityContext implements EntityContext {
 
-    private ApplicationParticipant participant;
+    private final ScopedParticipant participant;
 
-    private List<String> includedFieldsFilter = null;
+    private final String organizationId;
 
+    private final String tenantId;
+
+    @Setter
+    private List<String> includedFieldsFilter;
+
+    @Setter
     private List<String> tenantSelection;
 
-    public DefaultEntityContext(ApplicationParticipant participant,
-                                List<String> includedFieldsFilter) {
-        this.participant = participant;
-        this.includedFieldsFilter = includedFieldsFilter;
+    public DefaultEntityContext(ScopedParticipant participant) {
+        this(participant, null);
     }
 
-    public DefaultEntityContext(ApplicationParticipant participant) {
+    public DefaultEntityContext(ScopedParticipant participant,
+                                List<String> includedFieldsFilter) {
+        ParticipantScope scope = participant.getScope();
+        // A SystemParticipant may address app-api but carries no organization, and every entity
+        // index is addressed by organization; rejecting it here names the reason
+        Validate.notBlank(scope.organizationId(),
+                          "Entity data belongs to an Organization, and participant %s carries none",
+                          participant.getId());
         this.participant = participant;
+        this.organizationId = scope.organizationId();
+        this.tenantId = scope.tenantId();
+        this.includedFieldsFilter = includedFieldsFilter;
     }
 
     @Override

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultAdminJsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultAdminJsonEntitiesRepository.java
@@ -2,7 +2,7 @@ package org.kinotic.persistence.internal.api.services;
 
 import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
-import org.kinotic.domain.api.model.security.participant.ApplicationParticipant;
+import org.kinotic.domain.api.model.security.participant.ScopedParticipant;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.api.model.FastestType;
@@ -26,7 +26,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     private final EntitiesService entitiesService;
 
     @Override
-    public Future<Long> count(String entityDefinitionId, List<String> tenantSelection, ApplicationParticipant participant) {
+    public Future<Long> count(String entityDefinitionId, List<String> tenantSelection, ScopedParticipant participant) {
         return entitiesService.count(entityDefinitionId,
                                      new DefaultEntityContext(participant)
                                              .setTenantSelection(tenantSelection));
@@ -36,7 +36,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     public Future<Long> countByQuery(String entityDefinitionId,
                                      String query,
                                      List<String> tenantSelection,
-                                     ApplicationParticipant participant) {
+                                     ScopedParticipant participant) {
         return entitiesService.countByQuery(entityDefinitionId,
                                             query,
                                             new DefaultEntityContext(participant)
@@ -44,7 +44,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant) {
+    public Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, ScopedParticipant participant) {
         return entitiesService.deleteById(entityDefinitionId,
                                           id,
                                           new DefaultEntityContext(participant));
@@ -54,7 +54,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     public Future<Void> deleteByQuery(String entityDefinitionId,
                                       String query,
                                       List<String> tenantSelection,
-                                      ApplicationParticipant participant) {
+                                      ScopedParticipant participant) {
         return entitiesService.deleteByQuery(entityDefinitionId,
                                              query,
                                              new DefaultEntityContext(participant)
@@ -65,7 +65,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     public Future<Page<FastestType>> findAll(String entityDefinitionId,
                                              List<String> tenantSelection,
                                              Pageable pageable,
-                                             ApplicationParticipant participant) {
+                                             ScopedParticipant participant) {
         return entitiesService.findAll(entityDefinitionId,
                                        pageable,
                                        FastestType.class,
@@ -74,7 +74,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     }
 
     @Override
-    public Future<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ApplicationParticipant participant) {
+    public Future<FastestType> findById(String entityDefinitionId, TenantSpecificId id, ScopedParticipant participant) {
         return entitiesService.findById(entityDefinitionId,
                                         id,
                                         FastestType.class,
@@ -84,7 +84,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
     @Override
     public Future<List<FastestType>> findByIds(String entityDefinitionId,
                                                List<TenantSpecificId> ids,
-                                               ApplicationParticipant participant) {
+                                               ScopedParticipant participant) {
         return entitiesService.findByIdsWithTenant(entityDefinitionId,
                                                    ids,
                                                    FastestType.class,
@@ -96,7 +96,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
                                             String queryName,
                                             List<QueryParameter> queryParameters,
                                             List<String> tenantSelection,
-                                            ApplicationParticipant participant) {
+                                            ScopedParticipant participant) {
         return entitiesService.namedQuery(entityDefinitionId,
                                           queryName,
                                           new ListParameterHolder(queryParameters),
@@ -111,7 +111,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
                                                 List<QueryParameter> queryParameters,
                                                 List<String> tenantSelection,
                                                 Pageable pageable,
-                                                ApplicationParticipant participant) {
+                                                ScopedParticipant participant) {
         return entitiesService.namedQueryPage(entityDefinitionId,
                                               queryName,
                                               new ListParameterHolder(queryParameters),
@@ -126,7 +126,7 @@ public class DefaultAdminJsonEntitiesRepository implements AdminJsonEntitiesRepo
                                             String searchText,
                                             List<String> tenantSelection,
                                             Pageable pageable,
-                                            ApplicationParticipant participant) {
+                                            ScopedParticipant participant) {
         return entitiesService.search(entityDefinitionId,
                                       searchText,
                                       pageable,

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntitiesService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntitiesService.java
@@ -55,7 +55,7 @@ public class DefaultEntitiesService implements EntitiesService {
     public <T> Future<Void> bulkSave(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                                      T entities,
                                      EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.bulkSave(entities, context));
     }
 
@@ -64,7 +64,7 @@ public class DefaultEntitiesService implements EntitiesService {
     public <T> Future<Void> bulkUpdate(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                                        T entities,
                                        EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.bulkUpdate(entities, context));
     }
 
@@ -72,7 +72,7 @@ public class DefaultEntitiesService implements EntitiesService {
     @Override
     public Future<Long> count(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                               EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.count(context));
     }
 
@@ -81,7 +81,7 @@ public class DefaultEntitiesService implements EntitiesService {
     public Future<Long> countByQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                                      String query,
                                      EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.countByQuery(query, context));
     }
 
@@ -90,13 +90,13 @@ public class DefaultEntitiesService implements EntitiesService {
     public Future<Void> deleteById(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                                    String id,
                                    EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.deleteById(id, context));
     }
 
     @Override
     public Future<Void> deleteById(String entityDefinitionId, TenantSpecificId id, EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.deleteById(id, context));
     }
 
@@ -105,7 +105,7 @@ public class DefaultEntitiesService implements EntitiesService {
     public Future<Void> deleteByQuery(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                                       String query,
                                       EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.deleteByQuery(query, context));
     }
 
@@ -115,7 +115,7 @@ public class DefaultEntitiesService implements EntitiesService {
                                        Pageable pageable,
                                        Class<T> type,
                                        EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.findAll(pageable, type, context));
     }
 
@@ -125,13 +125,13 @@ public class DefaultEntitiesService implements EntitiesService {
                                   String id,
                                   Class<T> type,
                                   EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.findById(id, type, context));
     }
 
     @Override
     public <T> Future<T> findById(String entityDefinitionId, TenantSpecificId id, Class<T> type, EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.findById(id, type, context));
     }
 
@@ -141,7 +141,7 @@ public class DefaultEntitiesService implements EntitiesService {
                                          List<String> ids,
                                          Class<T> type,
                                          EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.findByIds(ids, type, context));
     }
 
@@ -150,7 +150,7 @@ public class DefaultEntitiesService implements EntitiesService {
                                                    List<TenantSpecificId> ids,
                                                    Class<T> type,
                                                    EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.findByIdsWithTenant(ids, type, context));
     }
 
@@ -161,7 +161,7 @@ public class DefaultEntitiesService implements EntitiesService {
                                           ParameterHolder parameterHolder,
                                           Class<T> type,
                                           EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.namedQuery(queryName, parameterHolder, type, context));
     }
 
@@ -173,7 +173,7 @@ public class DefaultEntitiesService implements EntitiesService {
                                               Pageable pageable,
                                               Class<T> type,
                                               EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.namedQueryPage(queryName,
                                                                        parameterHolder,
                                                                        pageable,
@@ -184,7 +184,7 @@ public class DefaultEntitiesService implements EntitiesService {
     @Override
     public Future<Void> syncIndex(String entityDefinitionId,
                                   EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.syncIndex(context));
     }
 
@@ -193,7 +193,7 @@ public class DefaultEntitiesService implements EntitiesService {
     public <T> Future<T> save(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                               T entity,
                               EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.save(entity, context));
     }
 
@@ -204,7 +204,7 @@ public class DefaultEntitiesService implements EntitiesService {
                                       Pageable pageable,
                                       Class<T> type,
                                       EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.search(searchText, pageable, type, context));
     }
 
@@ -213,7 +213,7 @@ public class DefaultEntitiesService implements EntitiesService {
     public <T> Future<T> update(@SpanAttribute("entityDefinitionId") String entityDefinitionId,
                                 T entity,
                                 EntityContext context) {
-        return entityServiceCache.get(context.getParticipant().getOrganizationId(), entityDefinitionId)
+        return entityServiceCache.get(context.getOrganizationId(), entityDefinitionId)
                 .compose(entityService -> entityService.update(entity, context));
     }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityService.java
@@ -459,7 +459,7 @@ public class DefaultEntityService implements EntityService {
     private String composeId(final String id, final EntityContext context){
         String ret;
         if(entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED){
-            String tenantId = context.getTenantId();
+            String tenantId = context.requireTenantId();
             ret = tenantId + "-" + id;
         }else{
             ret = id;
@@ -475,7 +475,7 @@ public class DefaultEntityService implements EntityService {
         List<MultiGetOperation> ret = new ArrayList<>(ids.size());
         boolean multiTenancyShared = entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED;
 
-        String tenantId = context.getTenantId();
+        String tenantId = multiTenancyShared ? context.requireTenantId() : null;
         for (String id : ids){
             MultiGetOperation.Builder builder =  new MultiGetOperation.Builder();
             builder.index(entityDescriptor.itemIndex());
@@ -521,14 +521,15 @@ public class DefaultEntityService implements EntityService {
                                     formatToPrintJson(object));
                         }
                     }else {
-                        if (tenant != null && tenant.equals(context.getTenantId())) {
+                        String tenantId = context.requireTenantId();
+                        if (tenant != null && tenant.equals(tenantId)) {
                             result.add(object);
                         }else{
                             log.error(
                                     "{} Multi tenancy is not working properly for EntityDefinition: {} and expected tenant: {} got: {}\nData:\n{}",
                                     what,
                                     entityDescriptor,
-                                    context.getTenantId(),
+                                    tenantId,
                                     tenant,
                                     formatToPrintJson(object));
                         }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultEntityService.java
@@ -459,7 +459,7 @@ public class DefaultEntityService implements EntityService {
     private String composeId(final String id, final EntityContext context){
         String ret;
         if(entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED){
-            String tenantId = context.getParticipant().getTenantId();
+            String tenantId = context.getTenantId();
             ret = tenantId + "-" + id;
         }else{
             ret = id;
@@ -475,7 +475,7 @@ public class DefaultEntityService implements EntityService {
         List<MultiGetOperation> ret = new ArrayList<>(ids.size());
         boolean multiTenancyShared = entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED;
 
-        String tenantId = context.getParticipant().getTenantId();
+        String tenantId = context.getTenantId();
         for (String id : ids){
             MultiGetOperation.Builder builder =  new MultiGetOperation.Builder();
             builder.index(entityDescriptor.itemIndex());
@@ -521,14 +521,14 @@ public class DefaultEntityService implements EntityService {
                                     formatToPrintJson(object));
                         }
                     }else {
-                        if (tenant != null && tenant.equals(context.getParticipant().getTenantId())) {
+                        if (tenant != null && tenant.equals(context.getTenantId())) {
                             result.add(object);
                         }else{
                             log.error(
                                     "{} Multi tenancy is not working properly for EntityDefinition: {} and expected tenant: {} got: {}\nData:\n{}",
                                     what,
                                     entityDescriptor,
-                                    context.getParticipant().getTenantId(),
+                                    context.getTenantId(),
                                     tenant,
                                     formatToPrintJson(object));
                         }
@@ -827,7 +827,7 @@ public class DefaultEntityService implements EntityService {
 
     private Future<Void> validateContext(final EntityContext context){
         if(entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED){
-            if(context.getParticipant() != null && context.getParticipant().getTenantId() != null) {
+            if(context.getTenantId() != null) {
 
                 // Check if tenant selection is trying to be used but not enabled
                 if (ObjectUtils.isNotEmpty(context.getTenantSelection())
@@ -860,7 +860,7 @@ public class DefaultEntityService implements EntityService {
         if(entityDescriptor.multiTenancyType() == MultiTenancyType.SHARED
                 && entityDescriptor.isMultiTenantSelectionEnabled()){
 
-            if(entityContext.getParticipant() != null && entityContext.getParticipant().getTenantId() != null) {
+            if(entityContext.getTenantId() != null) {
 
                 List<MultiGetOperation> ret = new ArrayList<>(ids.size());
                 List<String> tenants = new ArrayList<>(ids.size());

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultJsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/DefaultJsonEntitiesRepository.java
@@ -3,7 +3,7 @@ package org.kinotic.persistence.internal.api.services;
 import io.vertx.core.Future;
 import tools.jackson.databind.util.TokenBuffer;
 import lombok.RequiredArgsConstructor;
-import org.kinotic.domain.api.model.security.participant.ApplicationParticipant;
+import org.kinotic.domain.api.model.security.participant.ScopedParticipant;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.internal.api.model.DefaultEntityContext;
@@ -26,49 +26,49 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
     private final EntitiesService entitiesService;
 
     @Override
-    public Future<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant) {
+    public Future<Void> bulkSave(String entityDefinitionId, TokenBuffer entities, ScopedParticipant participant) {
         return entitiesService.bulkSave(entityDefinitionId, entities, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ApplicationParticipant participant) {
+    public Future<Void> bulkUpdate(String entityDefinitionId, TokenBuffer entities, ScopedParticipant participant) {
         return entitiesService.bulkUpdate(entityDefinitionId, entities, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<Long> count(String entityDefinitionId, ApplicationParticipant participant) {
+    public Future<Long> count(String entityDefinitionId, ScopedParticipant participant) {
         return entitiesService.count(entityDefinitionId, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<Long> countByQuery(String entityDefinitionId, String query, ApplicationParticipant participant) {
+    public Future<Long> countByQuery(String entityDefinitionId, String query, ScopedParticipant participant) {
         return entitiesService.countByQuery(entityDefinitionId, query, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<Void> deleteById(String entityDefinitionId, String id, ApplicationParticipant participant) {
+    public Future<Void> deleteById(String entityDefinitionId, String id, ScopedParticipant participant) {
         return entitiesService.deleteById(entityDefinitionId, id, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<Void> deleteByQuery(String entityDefinitionId, String query, ApplicationParticipant participant) {
+    public Future<Void> deleteByQuery(String entityDefinitionId, String query, ScopedParticipant participant) {
         return entitiesService.deleteByQuery(entityDefinitionId, query, new DefaultEntityContext(participant));
     }
 
     @Override
     public Future<Page<FastestType>> findAll(String entityDefinitionId,
                                              Pageable pageable,
-                                             ApplicationParticipant participant) {
+                                             ScopedParticipant participant) {
         return entitiesService.findAll(entityDefinitionId, pageable, FastestType.class, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<FastestType> findById(String entityDefinitionId, String id, ApplicationParticipant participant) {
+    public Future<FastestType> findById(String entityDefinitionId, String id, ScopedParticipant participant) {
         return entitiesService.findById(entityDefinitionId, id, FastestType.class, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ApplicationParticipant participant) {
+    public Future<List<FastestType>> findByIds(String entityDefinitionId, List<String> ids, ScopedParticipant participant) {
         return entitiesService.findByIds(entityDefinitionId, ids, FastestType.class, new DefaultEntityContext(participant));
     }
 
@@ -76,7 +76,7 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
     public Future<List<RawJson>> namedQuery(String entityDefinitionId,
                                             String queryName,
                                             List<QueryParameter> queryParameters,
-                                            ApplicationParticipant participant) {
+                                            ScopedParticipant participant) {
         return entitiesService.namedQuery(entityDefinitionId,
                                           queryName,
                                           new ListParameterHolder(queryParameters),
@@ -89,7 +89,7 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
                                                 String queryName,
                                                 List<QueryParameter> queryParameters,
                                                 Pageable pageable,
-                                                ApplicationParticipant participant) {
+                                                ScopedParticipant participant) {
         return entitiesService.namedQueryPage(entityDefinitionId,
                                               queryName,
                                               new ListParameterHolder(queryParameters),
@@ -99,12 +99,12 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
     }
 
     @Override
-    public Future<Void> syncIndex(String entityDefinitionId, ApplicationParticipant participant) {
+    public Future<Void> syncIndex(String entityDefinitionId, ScopedParticipant participant) {
         return entitiesService.syncIndex(entityDefinitionId, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant) {
+    public Future<TokenBuffer> save(String entityDefinitionId, TokenBuffer entity, ScopedParticipant participant) {
         return entitiesService.save(entityDefinitionId, entity, new DefaultEntityContext(participant));
     }
 
@@ -112,12 +112,12 @@ public class DefaultJsonEntitiesRepository implements JsonEntitiesRepository {
     public Future<Page<FastestType>> search(String entityDefinitionId,
                                             String searchText,
                                             Pageable pageable,
-                                            ApplicationParticipant participant) {
+                                            ScopedParticipant participant) {
         return entitiesService.search(entityDefinitionId, searchText, pageable, FastestType.class, new DefaultEntityContext(participant));
     }
 
     @Override
-    public Future<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ApplicationParticipant participant) {
+    public Future<TokenBuffer> update(String entityDefinitionId, TokenBuffer entity, ScopedParticipant participant) {
         return entitiesService.update(entityDefinitionId, entity, new DefaultEntityContext(participant));
     }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/DataAnalysisTools.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/DataAnalysisTools.java
@@ -2,7 +2,7 @@ package org.kinotic.persistence.internal.api.services.insights;
 
 import io.vertx.core.Future;
 import lombok.extern.slf4j.Slf4j;
-import org.kinotic.domain.api.model.security.participant.ApplicationParticipant;
+import org.kinotic.domain.api.model.security.participant.ScopedParticipant;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.persistence.internal.api.services.EntitiesService;
@@ -25,10 +25,10 @@ import java.util.stream.Collectors;
 public class DataAnalysisTools {
 
     private final EntitiesService entitiesService;
-    private final ApplicationParticipant participant;
+    private final ScopedParticipant participant;
     private final FluxSink<InsightProgress> progressSink;
     
-    public DataAnalysisTools(EntitiesService entitiesService, ApplicationParticipant participant, FluxSink<InsightProgress> progressSink) {
+    public DataAnalysisTools(EntitiesService entitiesService, ScopedParticipant participant, FluxSink<InsightProgress> progressSink) {
         this.entitiesService = entitiesService;
         this.participant = participant;
         this.progressSink = progressSink;

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/AggregateQueryExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/AggregateQueryExecutor.java
@@ -102,7 +102,7 @@ public class AggregateQueryExecutor extends AbstractQueryExecutor {
                 //       ]
                 //     }
 
-                String tenantId = context.getEntityContext().getParticipant().getTenantId();
+                String tenantId = context.getEntityContext().getTenantId();
                 filter = new JsonObject().put("bool", new JsonObject()
                         .put("filter", new JsonArray()
                                 .add(new JsonObject().put("term", new JsonObject()

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/AggregateQueryExecutor.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/sql/executors/AggregateQueryExecutor.java
@@ -102,7 +102,7 @@ public class AggregateQueryExecutor extends AbstractQueryExecutor {
                 //       ]
                 //     }
 
-                String tenantId = context.getEntityContext().getTenantId();
+                String tenantId = context.getEntityContext().requireTenantId();
                 filter = new JsonObject().put("bool", new JsonObject()
                         .put("filter", new JsonArray()
                                 .add(new JsonObject().put("term", new JsonObject()


### PR DESCRIPTION
## Summary

Refactors `EntityContext` to expose `organizationId` and `tenantId` as first-class properties rather than requiring callers to extract them from the participant. This simplifies the API, improves type safety, and enables validation that participants carry the required organization scope.

## Key Changes

- **DefaultEntityContext**: Made `participant`, `organizationId`, and `tenantId` final fields initialized in the constructor. Removed Lombok `@AllArgsConstructor` and `@NoArgsConstructor` to enforce explicit construction. Added validation via `Validate.notBlank()` to reject participants without an organization ID, with a clear error message naming the reason.

- **EntityContext interface**: Replaced `getParticipant()` return type from `ApplicationParticipant` to `ScopedParticipant` to support both application and organization scopes. Added `getOrganizationId()` and `getTenantId()` methods as primary accessors, with updated Javadoc explaining the scope semantics.

- **DefaultEntitiesService**: Updated all 15+ method calls from `context.getParticipant().getOrganizationId()` to `context.getOrganizationId()`, eliminating the need to navigate through the participant object.

- **Repository implementations**: Updated `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, and their default implementations to accept `ScopedParticipant` instead of `ApplicationParticipant`, reflecting the broader scope support.

- **Pre-processors and services**: Updated `ReadPreProcessor`, `DefaultEntityService`, `AbstractJsonUpsertPreProcessor`, and `MapUpsertPreProcessor` to call `context.getTenantId()` instead of `context.getParticipant().getTenantId()`.

- **AbstractJacksonSupport**: Extracted participant resolution logic into a new `resolveParticipant(MethodParameter)` method that narrows the participant to the declared subtype, converting type mismatches into `AuthorizationException` rather than invocation errors.

- **NamedJsonArgumentResolver**: Simplified to use the new `resolveParticipant()` helper, removing duplicate null-check logic.

- **Test support**: Added `NarrowParticipant` interface and test case `testNarrowParticipantRejectsWiderCaller()` to verify that services declaring a specific participant subtype reject callers of a wider scope.

- **Minor fixes**: Fixed Vue modal visibility condition in `EntityDefinitionsList.vue` to check `showModal` before rendering.

## Implementation Details

The constructor validation ensures that any `EntityContext` created carries a valid organization ID, preventing downstream errors with a clear message at the point of context creation. The `ScopedParticipant` type change allows the same repository interfaces to serve both end-user (application-scoped) and administrative (organization-scoped) operations without type casting.

The participant narrowing in `AbstractJacksonSupport.resolveParticipant()` treats a scope mismatch as an authorization failure (the service does not serve that caller type) rather than a parameter type error, improving error semantics for API consumers.

https://claude.ai/code/session_01NnGKfd4Q88nGn2oLLWsAgF