### PR TITLE
Sort the Jobs and Worker nodes tables newest first

### DIFF
--- a/kinotic-frontend/apps/system/src/pages/NodesPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/NodesPage.vue
@@ -63,6 +63,7 @@
       :headers="headers"
       :data-source="dataSource"
       :search="tableSearch"
+      :default-sort="DEFAULT_SORT"
       :is-show-add-new="false"
       :disable-modifications="true"
       :row-actions="rowActions"
@@ -136,6 +137,8 @@ interface WorkloadRow extends DescriptiveIdentifiable {
   created: number | null
   autoRemove: boolean
 }
+
+const DEFAULT_SORT = [new Order('created', Direction.DESC)]
 
 const headers: CrudHeader[] = [
   { field: 'name', header: 'Name', sortable: true },

--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -12,6 +12,7 @@ import ConfirmDialog from "primevue/confirmdialog";
 import Card from "primevue/card";
 import Menu from "primevue/menu";
 import type { MenuItem } from "primevue/menuitem";
+import type { DataTableSortMeta } from "primevue/datatable";
 import Paginator, { type PageState } from "primevue/paginator";
 import SelectButton from "primevue/selectbutton";
 import Skeleton from "primevue/skeleton";
@@ -57,6 +58,9 @@ const props = withDefaults(defineProps<{
   enableRowHover?: boolean
   defaultPageSize?: number
   transparentDarkCards?: boolean
+  // The sort the table opens with, applied by the data source. The user replaces it by
+  // clicking a column header.
+  defaultSort?: Order[]
   // Fills the first load with placeholder rows. Worth it only where the fetch is slow
   // enough to be worth previewing — against a fast one the placeholder is a flash.
   showLoadingSkeleton?: boolean
@@ -117,9 +121,16 @@ const options = ref({
   page: 0,
   rows: 10,
   first: 0,
-  sortField: "",
-  sortOrder: 1 as 1 | -1,
 });
+
+// The DataTable is lazy, so it does not reorder the rows it was given. This is the order it
+// displays and the order find() asks the data source for, seeded from defaultSort.
+const sortMeta = ref<DataTableSortMeta[]>(
+  (props.defaultSort ?? []).map((order) => ({
+    field: order.property,
+    order: order.direction === Direction.DESC ? -1 : 1,
+  }))
+);
 
 const viewOptions = [
   { icon: "pi pi-bars", value: "burger" },
@@ -264,9 +275,7 @@ onMounted(() => {
   if (urlSearch) {
     searchText.value = urlSearch;
   }
-  options.value.page = 0;
-  options.value.first = 0;
-  find();
+  reloadFirstPage();
 });
 
 watch(
@@ -279,9 +288,7 @@ watch(
       return;
     }
     searchText.value = newVal;
-    options.value.page = 0;
-    options.value.first = 0;
-    find();
+    reloadFirstPage();
   },
   { immediate: true }
 );
@@ -308,12 +315,15 @@ watch(searchText, (newVal) => {
   emitSearchUpdate(newVal as string);
 
   if (searchDebounceTimer.value) clearTimeout(searchDebounceTimer.value);
-  searchDebounceTimer.value = setTimeout(() => {
-    options.value.page = 0;
-    options.value.first = 0;
-    find();
-  }, 400);
+  searchDebounceTimer.value = setTimeout(reloadFirstPage, 400);
 });
+
+/** Refetches from the first page, which every change to what the query selects starts over at. */
+function reloadFirstPage() {
+  options.value.page = 0;
+  options.value.first = 0;
+  find();
+}
 
 function onPaginatorPage(event: PageState) {
   options.value.page = event.page;
@@ -328,11 +338,7 @@ onBeforeUnmount(() => {
 
 function onSearchChange() {
   if (searchDebounceTimer.value) clearTimeout(searchDebounceTimer.value);
-  searchDebounceTimer.value = setTimeout(() => {
-    options.value.page = 0;
-    options.value.first = 0;
-    find();
-  }, 400);
+  searchDebounceTimer.value = setTimeout(reloadFirstPage, 400);
 }
 
 function handleCardClick(item: Identifiable<string>, index: number) {
@@ -344,15 +350,9 @@ function find() {
     loading.value = true;
   }
 
-  const orders: Order[] = [];
-  if (options.value.sortField) {
-    orders.push(
-      new Order(
-        options.value.sortField,
-        options.value.sortOrder === -1 ? Direction.DESC : Direction.ASC
-      )
-    );
-  }
+  const orders: Order[] = sortMeta.value.map(
+    (meta) => new Order(String(meta.field), meta.order === -1 ? Direction.DESC : Direction.ASC)
+  );
 
   const pageable = Pageable.create(options.value.page, options.value.rows, {
     orders,
@@ -549,7 +549,10 @@ defineExpose({ find, displayAlert });
             scrollable
             scrollHeight="flex"
             @row-click="onRowClick"
+            lazy
             sortMode="multiple"
+            v-model:multiSortMeta="sortMeta"
+            @sort="reloadFirstPage"
             :rowClass="getRowClass"
           >
             <Column

--- a/kinotic-frontend/packages/common/src/components/grind/JobRunsTable.vue
+++ b/kinotic-frontend/packages/common/src/components/grind/JobRunsTable.vue
@@ -4,6 +4,7 @@
     :headers="headers"
     :data-source="dataSource"
     :search="tableSearch"
+    :default-sort="DEFAULT_SORT"
     :is-show-add-new="false"
     :disable-modifications="true"
     empty-state-text="No job runs"
@@ -31,7 +32,8 @@
 
 <script setup lang="ts">
 import Tag from 'primevue/tag'
-import { Kinotic, FunctionalIterablePage, type IterablePage, type Page, type Pageable } from '@kinotic-ai/core'
+import { Direction, Kinotic, FunctionalIterablePage, Order,
+         type IterablePage, type Page, type Pageable } from '@kinotic-ai/core'
 import type { JobRun } from '@kinotic-ai/management-api'
 import CrudTable from '../CrudTable.vue'
 import { useCrudTablePage } from '../useCrudTablePage'
@@ -41,7 +43,7 @@ import DatetimeUtil from '../../util/DatetimeUtil'
 import { executionStatusSeverity } from './jobRunDisplay'
 
 /**
- * The job runs the caller may view, newest knowledge first as the facade returns them.
+ * The job runs the caller may view, most recently started first.
  * Emits open with the run id when a row is clicked; refresh() reloads the table.
  */
 const emit = defineEmits<{
@@ -50,6 +52,8 @@ const emit = defineEmits<{
 
 const formatEpochDateTime = DatetimeUtil.formatEpochDateTime
 const formatDuration = DatetimeUtil.formatDuration
+
+const DEFAULT_SORT = [new Order('started', Direction.DESC)]
 
 const headers: CrudHeader[] = [
   { field: 'name', header: 'Name', sortable: true },


### PR DESCRIPTION
Sorting in `CrudTable` never reached the server. The sort state was declared but nothing ever assigned it, and without `lazy` the PrimeVue DataTable reordered only the page already on screen:

```ts
// CrudTable.vue — before
const options = ref({ page: 0, rows: 10, first: 0, sortField: "", sortOrder: 1 });

const orders = [];
if (options.value.sortField) {          // nothing ever set it, and there was no @sort handler
  orders.push(new Order(options.value.sortField, ...));
}
```

So a header click looked like it sorted, but only shuffled the ten rows the browser happened to hold — the rest of the collection was unaffected, and the first page was never ordered at all.

## What changed

The DataTable now binds its sort model and runs `lazy`, which is what stops it sorting locally so the data source is the only thing that orders rows. The bindings added to it are `lazy`, `v-model:multiSortMeta="sortMeta"` and `@sort="reloadFirstPage"`.

`find()` then builds the pageable's orders from that model:

```ts
// CrudTable.vue — after
const sortMeta = ref(
  (props.defaultSort ?? []).map((order) => ({
    field: order.property,
    order: order.direction === Direction.DESC ? -1 : 1,
  }))
);

const orders = sortMeta.value.map(
  (meta) => new Order(String(meta.field), meta.order === -1 ? Direction.DESC : Direction.ASC)
);
```

A new `defaultSort` prop takes an array of `Order` — the same `@kinotic-ai/core` type the pageable carries, already used on `NodesPage` for the node cards — and seeds the order a table opens with:

```ts
// JobRunsTable.vue
const DEFAULT_SORT = [new Order('started', Direction.DESC)]

// NodesPage.vue
const DEFAULT_SORT = [new Order('created', Direction.DESC)]
```

Both columns are `DATE` in the index (`V1__init.sql`), so Elasticsearch orders them. Every other `CrudTable` is unaffected: `defaultSort` is optional, and an absent one means no orders in the pageable, exactly as before.

Also folded the four copies of `page = 0; first = 0; find()` into one `reloadFirstPage()`, which the new `@sort` handler needs anyway.

## Verified

Driven in Chromium against a stub data source that echoes the pageable it receives:

```
default     {"orders":["created:DESC"],"pageNumber":0} | job-59 COMPLETED
name asc    {"orders":["name:ASC"],"pageNumber":0}     | job-00 PENDING
name desc   {"orders":["name:DESC"],"pageNumber":0}    | job-59 COMPLETED
created     {"orders":["created:ASC"],"pageNumber":0}  | job-00 PENDING
page 2      {"orders":["created:ASC"],"pageNumber":1}  | job-10 FAILED
```

The sort survives paging, and a header click reaches the server rather than reordering the visible page. `vue-tsc` and `vite build` pass for both apps.

Column filtering was explored on this branch and backed out — it needs server-side narrowing, which needs `search` on the services behind these tables. That is being picked up separately.

https://claude.ai/code/session_01NfpLQXhDUaJZzypGjWnwa4