### PR TITLE
Refactor useCrudTablePage to use useTemplateRef

### DIFF
--- a/kinotic-frontend/apps/portal/src/pages/ConnectedAppsPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ConnectedAppsPage.vue
@@ -98,7 +98,7 @@ const toast = useToast()
 const confirm = useConfirm()
 
 // no server-side delegate search; a user has few delegates, so filtering the page suffices
-const { crudTable, tableSearch, dataSource, refreshTable } = useCrudTablePage(
+const { tableSearch, dataSource, refreshTable } = useCrudTablePage(
   filteredPageLoader(
     pageable => Kinotic.delegates.findMyDelegates(pageable),
     toRow,

--- a/kinotic-frontend/apps/portal/src/pages/MachinesPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/MachinesPage.vue
@@ -134,7 +134,7 @@ const toast = useToast()
 const confirm = useConfirm()
 
 // no server-side machine search; an org has few machines, so filtering the page suffices
-const { crudTable, tableSearch, dataSource, refreshTable, run } = useCrudTablePage(
+const { tableSearch, dataSource, refreshTable, run } = useCrudTablePage(
   filteredPageLoader(
     pageable => Kinotic.machines.findMachines(props.applicationId, pageable),
     toRow,

--- a/kinotic-frontend/apps/portal/src/pages/MembersPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/MembersPage.vue
@@ -126,7 +126,7 @@ const toast = useToast()
 const confirm = useConfirm()
 const userState = KinoticStates.getUserState()
 
-const { crudTable, tableSearch, dataSource, refreshTable, run } = useCrudTablePage(load)
+const { tableSearch, dataSource, refreshTable, run } = useCrudTablePage(load)
 
 const formatDate = DatetimeUtil.formatEpochDate
 

--- a/kinotic-frontend/apps/system/src/pages/NodesPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/NodesPage.vue
@@ -182,7 +182,7 @@ async function loadNodes() {
   }
 }
 
-const { crudTable, tableSearch, dataSource, refreshTable, run } = useCrudTablePage(load)
+const { tableSearch, dataSource, refreshTable, run } = useCrudTablePage(load)
 
 async function load(pageable: Pageable, searchText: string | null): Promise<IterablePage<DescriptiveIdentifiable>> {
   const workloads = searchText

--- a/kinotic-frontend/apps/system/src/pages/OrganizationsPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/OrganizationsPage.vue
@@ -54,7 +54,7 @@ const headers: CrudHeader[] = [
   { field: 'created', header: 'Created', sortable: true }
 ]
 
-const { crudTable, tableSearch, dataSource } = useCrudTablePage(load)
+const { tableSearch, dataSource } = useCrudTablePage(load)
 
 async function load(pageable: Pageable, searchText: string | null): Promise<IterablePage<DescriptiveIdentifiable>> {
   const orgs = searchText

--- a/kinotic-frontend/apps/system/src/pages/org/OrgApplicationsTable.vue
+++ b/kinotic-frontend/apps/system/src/pages/org/OrgApplicationsTable.vue
@@ -56,7 +56,7 @@ function fetchPage(pageable: Pageable): Promise<IterablePage<Application>> {
 }
 
 // findApplications has no server-side search, so filtering is client-side over the page
-const { crudTable, tableSearch, dataSource, refreshTable } = useCrudTablePage(
+const { tableSearch, dataSource, refreshTable } = useCrudTablePage(
     filteredPageLoader(
         fetchPage,
         (app: Application) => ({ id: app.id ?? '', name: app.name, description: app.description, updated: app.updated }),

--- a/kinotic-frontend/apps/system/src/pages/org/OrgMembersTable.vue
+++ b/kinotic-frontend/apps/system/src/pages/org/OrgMembersTable.vue
@@ -75,7 +75,7 @@ const headers: CrudHeader[] = [
   { field: 'created', header: 'Created', sortable: false }
 ]
 
-const { crudTable, tableSearch, dataSource, refreshTable } = useCrudTablePage(load)
+const { tableSearch, dataSource, refreshTable } = useCrudTablePage(load)
 
 const formatDate = DatetimeUtil.formatEpochDate
 

--- a/kinotic-frontend/apps/system/src/pages/org/OrgProjectsTable.vue
+++ b/kinotic-frontend/apps/system/src/pages/org/OrgProjectsTable.vue
@@ -55,7 +55,7 @@ function fetchPage(pageable: Pageable): Promise<IterablePage<Project>> {
 }
 
 // findProjects has no server-side search, so filtering is client-side over the page
-const { crudTable, tableSearch, dataSource, refreshTable } = useCrudTablePage(
+const { tableSearch, dataSource, refreshTable } = useCrudTablePage(
     filteredPageLoader(
         fetchPage,
         (project: Project) => ({

--- a/kinotic-frontend/packages/common/src/components/grind/JobRunsTable.vue
+++ b/kinotic-frontend/packages/common/src/components/grind/JobRunsTable.vue
@@ -63,7 +63,7 @@ const headers: CrudHeader[] = [
   { field: 'duration', header: 'Duration', sortable: false, width: '8rem' }
 ]
 
-const { crudTable, tableSearch, dataSource, refreshTable } = useCrudTablePage(load)
+const { tableSearch, dataSource, refreshTable } = useCrudTablePage(load)
 
 async function load(pageable: Pageable, searchText: string | null): Promise<IterablePage<DescriptiveIdentifiable>> {
   const runs = await Kinotic.jobMonitoring.findJobRuns(pageable)

--- a/kinotic-frontend/packages/common/src/components/useCrudTablePage.ts
+++ b/kinotic-frontend/packages/common/src/components/useCrudTablePage.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 import { useToast } from 'primevue/usetoast'
 import {
   FunctionalIterablePage,
@@ -15,13 +15,15 @@ import { showErrorToast } from '../util/helpers'
 export type PageLoader = (pageable: Pageable, searchText: string | null) => Promise<IterablePage<DescriptiveIdentifiable>>
 
 /**
- * The state and behavior every CrudTable management page shares: the table ref and its
- * refresh, the search model, a dataSource delegating to the page's load function, and
- * {@link run} — a mutation wrapped in success/failure toasts, refreshing on success.
+ * The state and behavior every CrudTable management page shares: {@link refreshTable}, the
+ * search model, a dataSource delegating to the page's load function, and {@link run} — a
+ * mutation wrapped in success/failure toasts, refreshing on success.
+ *
+ * The page's CrudTable must carry `ref="crudTable"` for refreshes to reach it.
  */
 export function useCrudTablePage(load: PageLoader) {
   const toast = useToast()
-  const crudTable = ref<InstanceType<typeof CrudTable>>()
+  const crudTable = useTemplateRef<InstanceType<typeof CrudTable>>('crudTable')
   const tableSearch = ref('')
 
   const dataSource = computed<IDataSource<DescriptiveIdentifiable>>(() => ({
@@ -43,7 +45,7 @@ export function useCrudTablePage(load: PageLoader) {
     }
   }
 
-  return { crudTable, tableSearch, dataSource, refreshTable, run }
+  return { tableSearch, dataSource, refreshTable, run }
 }
 
 /**


### PR DESCRIPTION
Replace manual `ref` management with Vue's `useTemplateRef` API in `useCrudTablePage`, eliminating the need for consumers to destructure and manually pass the `crudTable` ref.

## Summary

The `useCrudTablePage` composable previously required consumers to destructure a `crudTable` ref and manually bind it to their CrudTable component. This change adopts Vue's `useTemplateRef` API to automatically capture the template reference by name, simplifying the composable's contract and reducing boilerplate at call sites.

## Changes

- **packages/common/src/components/useCrudTablePage.ts**
  - Import `useTemplateRef` from Vue
  - Replace `const crudTable = ref<InstanceType<typeof CrudTable>>()` with `const crudTable = useTemplateRef<InstanceType<typeof CrudTable>>('crudTable')`
  - Remove `crudTable` from the return object (no longer needed by consumers)
  - Update JSDoc to clarify that the CrudTable component must carry `ref="crudTable"` for the binding to work

- **Consumer updates** (ConnectedAppsPage.vue, MachinesPage.vue, MembersPage.vue, NodesPage.vue, OrganizationsPage.vue, OrgApplicationsTable.vue, OrgMembersTable.vue, OrgProjectsTable.vue, JobRunsTable.vue)
  - Remove `crudTable` from destructuring of `useCrudTablePage()` return value
  - No changes to template bindings (already use `ref="crudTable"`)

## Implementation Details

`useTemplateRef` automatically binds to the template element with the matching ref name, eliminating the manual ref plumbing. The composable now owns the ref lifecycle entirely, and consumers only need to ensure their CrudTable carries `ref="crudTable"` — the binding happens automatically.

https://claude.ai/code/session_01HQnDK547kUx1d1Y8arFdej