### PR TITLE
Hide sidebar on job run detail pages

### DIFF
--- a/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
+++ b/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
@@ -8,8 +8,22 @@ import { isDark as darkMode } from '@kinotic-ai/frontend-common'
 const sidebarRef = ref<InstanceType<typeof SideBar> | null>(null)
 const route = useRoute()
 
+const hideSidebar = computed(() => route.meta.hideSidebar === true)
+
 const isSidebarCollapsed = computed(() => {
     return sidebarRef.value?.collapsed ?? false
+})
+
+const contentPaddingLeft = computed(() => {
+    let ret: string
+    if (hideSidebar.value) {
+        ret = 'pl-0'
+    } else if (isSidebarCollapsed.value) {
+        ret = 'pl-[64px]'
+    } else {
+        ret = 'pl-[256px]'
+    }
+    return ret
 })
 
 const isDark = computed(() => darkMode.value)
@@ -23,13 +37,8 @@ const isFullWidth = computed(() => route.meta.fullWidth === true)
         <div class="fixed top-0 left-0 right-0 z-50 h-[64px]">
             <Header />
         </div>
-        <SideBar ref="sidebarRef" />
-        <div
-            :class="[
-                'pt-[64px] h-full transition-all duration-300',
-                isSidebarCollapsed ? 'pl-[64px]' : 'pl-[256px]'
-            ]"
-        >
+        <SideBar v-if="!hideSidebar" ref="sidebarRef" />
+        <div :class="['pt-[64px] h-full transition-all duration-300', contentPaddingLeft]">
             <div :class="['h-[calc(100vh-64px)] overflow-y-auto px-8 py-6 transition-colors', isDark ? 'bg-surface-900 text-surface-0' : 'bg-surface-0 text-surface-950']">
                 <router-view v-if="isFullWidth" />
                 <!-- h-full (not min-h-full) gives the page a definite height to divide up, so a

--- a/kinotic-frontend/apps/portal/src/pages/routes.ts
+++ b/kinotic-frontend/apps/portal/src/pages/routes.ts
@@ -66,10 +66,13 @@ const pageRoutes: RouteRecordRaw[] = [
         component: () => import('@/pages/JobsPage.vue'),
       },
       {
+        // Drill-down view: the sidebar gives way to the run itself, and the page
+        // header's "All jobs" action is the way back out
         name: 'job-run',
         path: ':jobRunId',
         component: () => import('@/pages/JobRunPage.vue'),
         props: true,
+        meta: { hideSidebar: true } as RouteMeta,
       },
     ]
   },

--- a/kinotic-frontend/apps/system/src/layouts/ConsoleLayout.vue
+++ b/kinotic-frontend/apps/system/src/layouts/ConsoleLayout.vue
@@ -1,14 +1,31 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { SideBar } from '@kinotic-ai/frontend-common'
 import { isDark as darkMode } from '@kinotic-ai/frontend-common'
 
 import Header from './Header.vue'
 
+const route = useRoute()
+
 const sidebarRef = ref<InstanceType<typeof SideBar> | null>(null)
+
+const hideSidebar = computed(() => route.meta.hideSidebar === true)
 
 const isSidebarCollapsed = computed(() => {
     return sidebarRef.value?.collapsed ?? false
+})
+
+const contentPaddingLeft = computed(() => {
+    let ret: string
+    if (hideSidebar.value) {
+        ret = 'pl-0'
+    } else if (isSidebarCollapsed.value) {
+        ret = 'pl-[64px]'
+    } else {
+        ret = 'pl-[256px]'
+    }
+    return ret
 })
 
 const isDark = computed(() => darkMode.value)
@@ -19,13 +36,8 @@ const isDark = computed(() => darkMode.value)
         <div class="fixed top-0 left-0 right-0 z-50 h-[64px]">
             <Header />
         </div>
-        <SideBar ref="sidebarRef" />
-        <div
-            :class="[
-                'pt-[64px] h-full transition-all duration-300',
-                isSidebarCollapsed ? 'pl-[64px]' : 'pl-[256px]'
-            ]"
-        >
+        <SideBar v-if="!hideSidebar" ref="sidebarRef" />
+        <div :class="['pt-[64px] h-full transition-all duration-300', contentPaddingLeft]">
             <div :class="['h-[calc(100vh-64px)] overflow-y-auto px-8 py-6 transition-colors', isDark ? 'bg-surface-900 text-surface-0' : 'bg-surface-0 text-surface-950']">
                 <!-- flex + flex-1 (rather than min-h-full on the page root) so short pages still
                      stretch to the bottom of the viewport inside this auto-height wrapper. -->

--- a/kinotic-frontend/apps/system/src/router.ts
+++ b/kinotic-frontend/apps/system/src/router.ts
@@ -50,10 +50,13 @@ const routes: RouteRecordRaw[] = [
                 meta: { sidebar: consoleSidebarItem('Jobs', 'pi-list-check', 40) }
             },
             {
+                // Drill-down view: the sidebar gives way to the run itself, and the page
+                // header's "All jobs" action is the way back out
                 name: 'job-run',
                 path: 'jobs/:jobRunId',
                 component: () => import('./pages/JobRunPage.vue'),
-                props: true
+                props: true,
+                meta: { hideSidebar: true }
             },
             {
                 name: 'organization-detail',


### PR DESCRIPTION
## Summary
Adds support for hiding the sidebar on specific routes via route metadata, and applies this to job run detail pages in both the system and portal apps. This gives the job run view more screen real estate by removing the sidebar navigation.

## Changes
- **ConsoleLayout.vue** and **LayoutForPage.vue**: 
  - Added `hideSidebar` computed property that checks `route.meta.hideSidebar`
  - Extracted sidebar padding logic into `contentPaddingLeft` computed property to handle three states: hidden sidebar (no padding), collapsed sidebar (64px), and expanded sidebar (256px)
  - Conditionally render `<SideBar>` with `v-if="!hideSidebar"`
  - Simplified template by using the new `contentPaddingLeft` computed property

- **router.ts** (system app) and **routes.ts** (portal app):
  - Added `meta: { hideSidebar: true }` to the `job-run` route in both applications
  - Added clarifying comments explaining the drill-down UX pattern

## Implementation Details
The `contentPaddingLeft` computed property follows the codebase convention of a single return statement with guard logic, returning the appropriate Tailwind padding class based on sidebar visibility and collapse state. This ensures the content area adjusts properly regardless of sidebar state.

https://claude.ai/code/session_01WY6ZgmFbvWVKEzKXJJxQXk