### PR TITLE
Show and highlight the sidebar on the job run page

### DIFF
--- a/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
+++ b/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
@@ -8,22 +8,8 @@ import { isDark as darkMode } from '@kinotic-ai/frontend-common'
 const sidebarRef = ref<InstanceType<typeof SideBar> | null>(null)
 const route = useRoute()
 
-const hideSidebar = computed(() => route.meta.hideSidebar === true)
-
 const isSidebarCollapsed = computed(() => {
     return sidebarRef.value?.collapsed ?? false
-})
-
-const contentPaddingLeft = computed(() => {
-    let ret: string
-    if (hideSidebar.value) {
-        ret = 'pl-0'
-    } else if (isSidebarCollapsed.value) {
-        ret = 'pl-[64px]'
-    } else {
-        ret = 'pl-[256px]'
-    }
-    return ret
 })
 
 const isDark = computed(() => darkMode.value)
@@ -37,8 +23,13 @@ const isFullWidth = computed(() => route.meta.fullWidth === true)
         <div class="fixed top-0 left-0 right-0 z-50 h-[64px]">
             <Header />
         </div>
-        <SideBar v-if="!hideSidebar" ref="sidebarRef" />
-        <div :class="['pt-[64px] h-full transition-all duration-300', contentPaddingLeft]">
+        <SideBar ref="sidebarRef" />
+        <div
+            :class="[
+                'pt-[64px] h-full transition-all duration-300',
+                isSidebarCollapsed ? 'pl-[64px]' : 'pl-[256px]'
+            ]"
+        >
             <div :class="['h-[calc(100vh-64px)] overflow-y-auto px-8 py-6 transition-colors', isDark ? 'bg-surface-900 text-surface-0' : 'bg-surface-0 text-surface-950']">
                 <router-view v-if="isFullWidth" />
                 <!-- h-full (not min-h-full) gives the page a definite height to divide up, so a

--- a/kinotic-frontend/apps/portal/src/pages/routes.ts
+++ b/kinotic-frontend/apps/portal/src/pages/routes.ts
@@ -66,13 +66,10 @@ const pageRoutes: RouteRecordRaw[] = [
         component: () => import('@/pages/JobsPage.vue'),
       },
       {
-        // Drill-down view: the sidebar gives way to the run itself, and the page
-        // header's "All jobs" action is the way back out
         name: 'job-run',
         path: ':jobRunId',
         component: () => import('@/pages/JobRunPage.vue'),
         props: true,
-        meta: { hideSidebar: true } as RouteMeta,
       },
     ]
   },

--- a/kinotic-frontend/apps/system/src/layouts/ConsoleLayout.vue
+++ b/kinotic-frontend/apps/system/src/layouts/ConsoleLayout.vue
@@ -1,31 +1,14 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useRoute } from 'vue-router'
 import { SideBar } from '@kinotic-ai/frontend-common'
 import { isDark as darkMode } from '@kinotic-ai/frontend-common'
 
 import Header from './Header.vue'
 
-const route = useRoute()
-
 const sidebarRef = ref<InstanceType<typeof SideBar> | null>(null)
-
-const hideSidebar = computed(() => route.meta.hideSidebar === true)
 
 const isSidebarCollapsed = computed(() => {
     return sidebarRef.value?.collapsed ?? false
-})
-
-const contentPaddingLeft = computed(() => {
-    let ret: string
-    if (hideSidebar.value) {
-        ret = 'pl-0'
-    } else if (isSidebarCollapsed.value) {
-        ret = 'pl-[64px]'
-    } else {
-        ret = 'pl-[256px]'
-    }
-    return ret
 })
 
 const isDark = computed(() => darkMode.value)
@@ -36,8 +19,13 @@ const isDark = computed(() => darkMode.value)
         <div class="fixed top-0 left-0 right-0 z-50 h-[64px]">
             <Header />
         </div>
-        <SideBar v-if="!hideSidebar" ref="sidebarRef" />
-        <div :class="['pt-[64px] h-full transition-all duration-300', contentPaddingLeft]">
+        <SideBar ref="sidebarRef" />
+        <div
+            :class="[
+                'pt-[64px] h-full transition-all duration-300',
+                isSidebarCollapsed ? 'pl-[64px]' : 'pl-[256px]'
+            ]"
+        >
             <div :class="['h-[calc(100vh-64px)] overflow-y-auto px-8 py-6 transition-colors', isDark ? 'bg-surface-900 text-surface-0' : 'bg-surface-0 text-surface-950']">
                 <!-- flex + flex-1 (rather than min-h-full on the page root) so short pages still
                      stretch to the bottom of the viewport inside this auto-height wrapper. -->

--- a/kinotic-frontend/apps/system/src/router.ts
+++ b/kinotic-frontend/apps/system/src/router.ts
@@ -50,13 +50,13 @@ const routes: RouteRecordRaw[] = [
                 meta: { sidebar: consoleSidebarItem('Jobs', 'pi-list-check', 40) }
             },
             {
-                // Drill-down view: the sidebar gives way to the run itself, and the page
-                // header's "All jobs" action is the way back out
+                // Drilling into a run keeps the console sidebar without being an item in it;
+                // without this the route matches no group and renders an empty sidebar
                 name: 'job-run',
                 path: 'jobs/:jobRunId',
                 component: () => import('./pages/JobRunPage.vue'),
                 props: true,
-                meta: { hideSidebar: true }
+                meta: { sidebarGroup: 'console' }
             },
             {
                 name: 'organization-detail',

--- a/kinotic-frontend/packages/common/src/components/SideBar.vue
+++ b/kinotic-frontend/packages/common/src/components/SideBar.vue
@@ -108,8 +108,28 @@ function resolvePath(path: string): string {
   })
 }
 
+/**
+ * The item the current route falls under: the longest item path the route sits inside.
+ * A detail route keeps its section highlighted (/jobs/<id> lights up Jobs) while a
+ * deeper item still wins over the shallower one it nests under.
+ */
+const activePath = computed((): string | null => {
+  let ret: string | null = null
+  for (const item of sidebarItems.value) {
+    if (containsRoute(item.path) && (ret === null || item.path.length > ret.length)) {
+      ret = item.path
+    }
+  }
+  return ret
+})
+
+// Compares whole segments so /jobs does not swallow a sibling like /jobs-archive
+function containsRoute(itemPath: string): boolean {
+  return route.path === itemPath || route.path.startsWith(itemPath + '/')
+}
+
 function isActive(path: string): boolean {
-  return route.path === path
+  return activePath.value === path
 }
 
 defineExpose({ collapsed })


### PR DESCRIPTION
Follow-up to #504, which went in the wrong direction: it hid the left nav on the job run page. The intent was the opposite — the page should show the nav with its real entries, with the section it belongs to highlighted.

## 1. Why the system console drew an empty shell

`generateSidebarItems()` found no group for `job-run`, then fell through to the `showInMainNav` fallback — and the system console registers zero such routes, so the list came back empty:

```ts
// packages/common/src/components/SideBar.vue:79 — matched was undefined, so group was null
const matched = route.matched.find(
    r => r.meta?.sidebarGroup || (r.meta?.sidebar as SidebarItemMeta | undefined)?.group)
```

Fixed by declaring the group the route belongs to:

```ts
// apps/system/src/router.ts:52
{
    name: 'job-run',
    path: 'jobs/:jobRunId',
    component: () => import('./pages/JobRunPage.vue'),
    props: true,
    meta: { sidebarGroup: 'console' }   // was: meta: { hideSidebar: true }
},
```

That is the idiom `SidebarItemMeta` documents for exactly this case:

```ts
// packages/common/src/types/SidebarItemMeta.ts:5
 * Routes that should display a group's sidebar without being an item themselves
 * (detail/editor children) declare {@code meta.sidebarGroup} instead.
```

The portal needed no equivalent addition — its `job-run` is a child of `/jobs`, which already supplies `group: 'organization'`. Dropping the flag restores what it rendered before #504. `ConsoleLayout.vue` and `LayoutForPage.vue` return to their pre-#504 form; no `hideSidebar` references remain in the tree.

## 2. Nothing was highlighted on a detail route

With the nav restored, no item lit up on `/jobs/<id>` — the active test was an exact path match:

```ts
// before
function isActive(path: string): boolean {
  return route.path === path      // '/jobs/6d2c…' !== '/jobs'
}
```

A plain prefix match would fix that but break nesting, lighting up both Overview (`/application/<id>`) and Members (`/application/<id>/members`). The active item is now the *longest* item path the route sits inside, so the deeper item still wins:

```ts
// after
const activePath = computed((): string | null => {
  let ret: string | null = null
  for (const item of sidebarItems.value) {
    if (containsRoute(item.path) && (ret === null || item.path.length > ret.length)) {
      ret = item.path
    }
  }
  return ret
})

// Compares whole segments so /jobs does not swallow a sibling like /jobs-archive
function containsRoute(itemPath: string): boolean {
  return route.path === itemPath || route.path.startsWith(itemPath + '/')
}

function isActive(path: string): boolean {
  return activePath.value === path
}
```

## Verification

Resolved both real routers and replayed `generateSidebarItems()` against each path:

```
system   /jobs/6d2c305d-…    grp: console        → Dashboard, Organizations, Worker nodes, Jobs
portal   /jobs/6d2c305d-…    grp: organization   → Applications, Jobs, Members, Roles & permissions, …
```

Then compared old vs new highlighting across all 27 nav-bearing routes in both apps. Every previously-correct highlight is preserved, both job run pages are fixed, and no route lights up two items:

```
FIXED  /jobs/6d2c305d-…                          old:[-]        new:[Jobs]        (both apps)
same   /application/app1                         old:[Overview] new:[Overview]
same   /application/app1/members                 old:[Members]  new:[Members]     ← nesting holds
same   /application/app1/project/p1/deployment   old:[Deployment] new:[Deployment]
…
NO REGRESSIONS
```

`pnpm -r build` (vue-tsc + vite) passes for both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY6ZgmFbvWVKEzKXJJxQXk