### PR TITLE
Start the table scrollbar below the header row

### DIFF
--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -633,6 +633,52 @@ defineExpose({ find, displayAlert });
 </template>
 
 <style>
+/* PrimeVue scrolls .p-datatable-table-container with the header sticky inside it, so its
+   scrollbar spans the header as well as the rows. Splitting the head and body into sibling
+   scroll boxes hands the scrollbar to the rows alone, starting it below the header. Both
+   boxes reserve a gutter so their columns keep matching widths; the header's stays empty. */
+.crud-table__datatable .p-datatable-table-container {
+  overflow: hidden !important;
+}
+
+.crud-table__datatable .p-datatable-table {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* overflow-x is hidden rather than left visible: the spec would promote it to auto next to a
+   scrolling y axis, giving the head and body independent horizontal scroll that desyncs them. */
+.crud-table__datatable .p-datatable-thead,
+.crud-table__datatable .p-datatable-tbody {
+  display: block;
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+
+.crud-table__datatable .p-datatable-thead {
+  flex: none;
+  scrollbar-color: transparent transparent;
+}
+
+.crud-table__datatable .p-datatable-thead::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+
+.crud-table__datatable .p-datatable-tbody {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Each row lays itself out as its own fixed table, reproducing the widths the single table
+   computed: the explicit column widths, with the remainder split evenly. */
+.crud-table__datatable .p-datatable-thead > tr,
+.crud-table__datatable .p-datatable-tbody > tr {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
 /* While loading, an indeterminate line overlays the header row's bottom divider. */
 .crud-table__datatable--loading .p-datatable-thead {
   position: relative;


### PR DESCRIPTION
The vertical scrollbar in every `CrudTable` ran the full height of the table, alongside the header row rather than only the rows it scrolls.

## Cause

PrimeVue scrolls the container and makes the header sticky *inside* it:

```js
// primevue/datatable/style/index.mjs:146
var inlineStyles = {
  tableContainer: { overflow: 'auto' },   // the scrollport — header and rows both live here
  thead: { position: 'sticky' },
```

Measured on the rendered table, the header's top and the scrollport's top are the same edge, so a native scrollbar — which always spans its scrollport — necessarily covers the header band:

```
containerTop: 149   headerTop: 149   headerBottom: 198   overflowY: "auto"   theadPosition: "sticky"
```

## Fix

The head and body become sibling scroll boxes, so the scrollbar belongs to the rows alone and starts at the header's bottom edge (`packages/common/src/components/CrudTable.vue`):

```css
.crud-table__datatable .p-datatable-table-container { overflow: hidden !important; }

.crud-table__datatable .p-datatable-table { display: flex; flex-direction: column; min-height: 0; }

.crud-table__datatable .p-datatable-thead,
.crud-table__datatable .p-datatable-tbody { display: block; overflow-x: hidden; overflow-y: scroll; }

.crud-table__datatable .p-datatable-thead > tr,
.crud-table__datatable .p-datatable-tbody > tr { display: table; width: 100%; table-layout: fixed; }
```

Three details carry the correctness:

- **Both boxes use `overflow-y: scroll`**, so they reserve the same gutter and their columns cannot drift apart. The header's gutter is left empty (`scrollbar-color: transparent transparent`).
- **`table-layout: fixed` per row** reproduces exactly what the single table computed — explicit column widths honoured, the rest split evenly.
- **`overflow-x: hidden` is explicit.** Left `visible`, the spec promotes it to `auto` next to a scrolling y axis, which would give head and body independent horizontal scroll and desync them.

## Verification

Rendered the real component against a fake data source and measured the DOM before and after:

```
BEFORE  bodyScrolls: false                       (the container scrolled — header included)
AFTER   bodyScrolls: true   containerScrolls: false
        bodyTop: 198 == headerBottom: 198        (scroll region starts below the header)
        th [294,294,294,294,128] == td [294,294,294,294,128]   aligned: true
```

At 1400 / 900 / 700px wide, after scrolling the body:

```
1400px -> aligned: true, headerStayedPut: true, bodyScrolled: true, horizontalOverflow: false
 900px -> aligned: true, headerStayedPut: true, bodyScrolled: true, horizontalOverflow: false
 700px -> aligned: true, headerStayedPut: true, bodyScrolled: true, horizontalOverflow: false
```

One limit worth stating plainly: the test browser uses overlay scrollbars, so the measured gutter was 0 on both boxes (equal, but not a non-zero comparison). Gutter equality on classic-scrollbar platforms holds by construction — both boxes declare `overflow-y: scroll`, so both reserve the same width — rather than by measurement here.

`pnpm -r build` (vue-tsc + vite) passes for both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY6ZgmFbvWVKEzKXJJxQXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6ZgmFbvWVKEzKXJJxQXk)_