### PR TITLE
Revert "Start the table scrollbar below the header row"

### DIFF
--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -633,52 +633,6 @@ defineExpose({ find, displayAlert });
 </template>
 
 <style>
-/* PrimeVue scrolls .p-datatable-table-container with the header sticky inside it, so its
-   scrollbar spans the header as well as the rows. Splitting the head and body into sibling
-   scroll boxes hands the scrollbar to the rows alone, starting it below the header. Both
-   boxes reserve a gutter so their columns keep matching widths; the header's stays empty. */
-.crud-table__datatable .p-datatable-table-container {
-  overflow: hidden !important;
-}
-
-.crud-table__datatable .p-datatable-table {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-/* overflow-x is hidden rather than left visible: the spec would promote it to auto next to a
-   scrolling y axis, giving the head and body independent horizontal scroll that desyncs them. */
-.crud-table__datatable .p-datatable-thead,
-.crud-table__datatable .p-datatable-tbody {
-  display: block;
-  overflow-x: hidden;
-  overflow-y: scroll;
-}
-
-.crud-table__datatable .p-datatable-thead {
-  flex: none;
-  scrollbar-color: transparent transparent;
-}
-
-.crud-table__datatable .p-datatable-thead::-webkit-scrollbar-thumb {
-  background: transparent;
-}
-
-.crud-table__datatable .p-datatable-tbody {
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
-/* Each row lays itself out as its own fixed table, reproducing the widths the single table
-   computed: the explicit column widths, with the remainder split evenly. */
-.crud-table__datatable .p-datatable-thead > tr,
-.crud-table__datatable .p-datatable-tbody > tr {
-  display: table;
-  width: 100%;
-  table-layout: fixed;
-}
-
 /* While loading, an indeterminate line overlays the header row's bottom divider. */
 .crud-table__datatable--loading .p-datatable-thead {
   position: relative;


### PR DESCRIPTION
Reverts #507. Splitting the head and body into sibling scroll boxes made the tables look worse than the overlapping scrollbar it set out to fix.

`CrudTable` goes back to the single scrolling container with the sticky header that PrimeVue renders by default:

```css
/* removed */
.crud-table__datatable .p-datatable-table-container { overflow: hidden !important; }
.crud-table__datatable .p-datatable-table { display: flex; flex-direction: column; min-height: 0; }
.crud-table__datatable .p-datatable-thead,
.crud-table__datatable .p-datatable-tbody { display: block; overflow-x: hidden; overflow-y: scroll; }
.crud-table__datatable .p-datatable-thead > tr,
.crud-table__datatable .p-datatable-tbody > tr { display: table; width: 100%; table-layout: fixed; }
```

The scrollbar once again spans the header as well as the rows — the original complaint stands, unfixed.

## Verification

`CrudTable.vue` was restored from `ad478c6`, the commit #507 branched from. Nothing else has touched the file since:

```
$ git log --oneline ad478c6..origin/develop -- .../CrudTable.vue
bf2c153 Start the table scrollbar below the header row (#507)

$ git diff ad478c6 -- .../CrudTable.vue
(no output — exact match)
```

So the diff is the 46 added lines removed and nothing else. `pnpm -r build` (vue-tsc + vite) passes for both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY6ZgmFbvWVKEzKXJJxQXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY6ZgmFbvWVKEzKXJJxQXk)_