### PR TITLE
Name OrganizationStorage's fields for what they are and stop storing a host

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/model/OrganizationStorage.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/model/OrganizationStorage.java
@@ -6,9 +6,10 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
- * An organization's storage: the one account everything its deployments publish goes to,
- * and where that account is in its lifecycle. Held by {@link Organization} once its
- * provisioning job has started; the account's details fill in as provisioning progresses.
+ * An organization's storage: the one Azure storage account everything its deployments publish
+ * goes to, and where that account is in its lifecycle. Held by {@link Organization} once its
+ * provisioning job has started; the account's details fill in as provisioning progresses. In
+ * development an Azurite stands in for the account and fills the same fields.
  */
 @Getter
 @Setter
@@ -17,27 +18,21 @@ import lombok.experimental.Accessors;
 public class OrganizationStorage {
 
     /**
-     * The Azure subscription holding the account, or {@code null} when it is not hosted in
-     * Azure.
+     * The Azure subscription holding the account, or {@code null} when an Azurite stands in
+     * for it.
      */
-    private String subscriptionId;
+    private String azureSubscriptionId;
 
     /**
-     * The name of the account.
+     * The name of the storage account.
      */
-    private String accountName;
+    private String azureAccountName;
 
     /**
-     * The blob service endpoint of the account, or {@code null} until it exists.
+     * The blob service endpoint of the account, {@code https://<account>.blob.core.windows.net/},
+     * or {@code null} until it exists. Its hostname is where workloads reach the account.
      */
-    private String blobEndpoint;
-
-    /**
-     * The one host a publish workload may reach, where the account answers the platform: its
-     * private endpoint's address inside the platform network, or its public host where no
-     * private endpoint exists. {@code null} until the account exists.
-     */
-    private String publishHost;
+    private String azureBlobEndpoint;
 
     /**
      * Where the storage is in its lifecycle.

--- a/kinotic-frontend/apps/system/src/pages/org/OrgOverview.vue
+++ b/kinotic-frontend/apps/system/src/pages/org/OrgOverview.vue
@@ -46,9 +46,9 @@
           <dd class="break-words">{{ organization.storage.status.message }}</dd>
         </template>
         <dt class="text-muted-color">Account</dt>
-        <dd class="font-mono">{{ organization?.storage?.accountName || '—' }}</dd>
+        <dd class="font-mono">{{ organization?.storage?.azureAccountName || '—' }}</dd>
         <dt class="text-muted-color">Endpoint</dt>
-        <dd class="font-mono break-all">{{ organization?.storage?.blobEndpoint || '—' }}</dd>
+        <dd class="font-mono break-all">{{ organization?.storage?.azureBlobEndpoint || '—' }}</dd>
         <dt class="text-muted-color">Last run</dt>
         <dd>
           <router-link v-if="organization?.provisioningJobRunId" class="font-mono text-primary"

--- a/kinotic-js/workspace/packages/management-api/src/api/model/OrganizationStorage.ts
+++ b/kinotic-js/workspace/packages/management-api/src/api/model/OrganizationStorage.ts
@@ -1,29 +1,25 @@
 import type { DeploymentStatus } from '@/api/model/DeploymentStatus'
 
 /**
- * An organization's storage: the one account everything its deployments publish goes to,
- * and where that account is in its lifecycle. The account's details fill in as provisioning
- * progresses.
+ * An organization's storage: the one Azure storage account everything its deployments publish
+ * goes to, and where that account is in its lifecycle. The account's details fill in as
+ * provisioning progresses. In development an Azurite stands in for the account and fills the
+ * same fields.
  */
 export interface OrganizationStorage {
     /**
-     * The Azure subscription holding the account, or null when it is not hosted in Azure.
+     * The Azure subscription holding the account, or null when an Azurite stands in for it.
      */
-    subscriptionId: string | null
+    azureSubscriptionId: string | null
     /**
-     * The name of the account.
+     * The name of the storage account.
      */
-    accountName: string | null
+    azureAccountName: string | null
     /**
-     * The blob service endpoint of the account, or null until it exists.
+     * The blob service endpoint of the account, https://<account>.blob.core.windows.net/, or
+     * null until it exists. Its hostname is where workloads reach the account.
      */
-    blobEndpoint: string | null
-    /**
-     * The one host a publish workload may reach, where the account answers the platform: its
-     * private endpoint's address inside the platform network, or its public host where no
-     * private endpoint exists. Null until the account exists.
-     */
-    publishHost: string | null
+    azureBlobEndpoint: string | null
     /**
      * Where the storage is in its lifecycle.
      */

--- a/kinotic-migration/src/main/resources/migrations/V1__init.sql
+++ b/kinotic-migration/src/main/resources/migrations/V1__init.sql
@@ -242,7 +242,7 @@ CREATE TABLE IF NOT EXISTS kinotic_organization (
     description TEXT,
     ssoConfigId KEYWORD NOT INDEXED,
     createdBy KEYWORD,
-    storage OBJECT (subscriptionId KEYWORD, accountName KEYWORD, blobEndpoint KEYWORD, publishHost KEYWORD,
+    storage OBJECT (azureSubscriptionId KEYWORD, azureAccountName KEYWORD, azureBlobEndpoint KEYWORD,
                     status OBJECT (type KEYWORD, message TEXT)),
     provisioningJobRunId KEYWORD,
     created DATE,

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageProvisioner.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageProvisioner.java
@@ -31,7 +31,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
 import java.util.Date;
 
 /**
@@ -127,10 +126,10 @@ public class AzureOrganizationStorageProvisioner implements OrganizationStorageP
     private Future<Organization> provision(Organization organization) {
         String organizationId = organization.getId();
         OrganizationStorage storage = organization.getStorage() != null ? organization.getStorage() : new OrganizationStorage();
-        String subscriptionId = storage.getSubscriptionId() != null ? storage.getSubscriptionId() : chooseSubscription(organizationId);
+        String subscriptionId = storage.getAzureSubscriptionId() != null ? storage.getAzureSubscriptionId() : chooseSubscription(organizationId);
         String accountName = accountName(organizationId);
-        storage.setSubscriptionId(subscriptionId)
-               .setAccountName(accountName)
+        storage.setAzureSubscriptionId(subscriptionId)
+               .setAzureAccountName(accountName)
                .setStatus(new DeploymentStatus(DeploymentStatusType.PROVISIONING));
         organization.setStorage(storage).setUpdated(new Date());
         AzureProfile profile = new AzureProfile(null, subscriptionId, AzureEnvironment.AZURE);
@@ -141,10 +140,9 @@ public class AzureOrganizationStorageProvisioner implements OrganizationStorageP
         return organizationService.saveSync(organization)
                 .compose(saved -> AzureUtil.toFuture(ensureAccount(storageManager, accountName, organizationId), vertx))
                 .compose(account -> AzureUtil.toFuture(ensureContainer(storageManager, accountName), vertx)
-                        .compose(container -> publishHost(network, account))
-                        .map(publishHost -> {
-                            storage.setBlobEndpoint(account.endPoints().primary().blob())
-                                   .setPublishHost(publishHost)
+                        .compose(container -> ensurePrivateEndpoint(network, account))
+                        .map(v -> {
+                            storage.setAzureBlobEndpoint(account.endPoints().primary().blob())
                                    .setStatus(new DeploymentStatus(DeploymentStatusType.READY));
                             return organization.setUpdated(new Date());
                         }))
@@ -190,41 +188,31 @@ public class AzureOrganizationStorageProvisioner implements OrganizationStorageP
     }
 
     /**
-     * The one host publish workloads reach the account on: its private endpoint's address, or
-     * its public blob host when private endpoints are disabled.
-     */
-    private Future<String> publishHost(NetworkManager network, StorageAccount account) {
-        Future<String> ret;
-        if (properties().isDisablePrivateEndpoint()) {
-            ret = Future.succeededFuture(URI.create(account.endPoints().primary().blob()).getHost());
-        } else {
-            ret = AzureUtil.toFuture(ensurePrivateEndpoint(network, account), vertx);
-        }
-        return ret;
-    }
-
-    /**
      * Places the account's blob private endpoint in the platform subnet and registers it in the
      * private DNS zone through a zone group, so the platform resolves the account's public name
-     * to the private address. Emits that address.
+     * to the private address. Creates nothing when private endpoints are disabled.
      */
-    private Mono<String> ensurePrivateEndpoint(NetworkManager network, StorageAccount account) {
-        String endpointName = "pe-" + account.name();
-        return AzureUtil.emptyIfNotFound(network.privateEndpoints().getByResourceGroupAsync(properties().getResourceGroup(), endpointName))
-                        .switchIfEmpty(Mono.defer(() -> network.privateEndpoints()
-                                .define(endpointName)
-                                .withRegion(properties().getLocation())
-                                .withExistingResourceGroup(properties().getResourceGroup())
-                                .withSubnetId(properties().getPrivateEndpointSubnetId())
-                                .definePrivateLinkServiceConnection("blob")
-                                    .withResourceId(account.id())
-                                    .withSubResource(PrivateLinkSubResourceName.STORAGE_BLOB)
-                                    .attach()
-                                .createAsync()))
-                        .flatMap(endpoint -> ensureDnsZoneGroup(endpoint).thenReturn(endpoint))
-                        .flatMap(endpoint -> network.networkInterfaces()
-                                                    .getByIdAsync(endpoint.networkInterfaces().getFirst().id())
-                                                    .map(nic -> nic.primaryPrivateIP()));
+    private Future<Void> ensurePrivateEndpoint(NetworkManager network, StorageAccount account) {
+        Future<Void> ret;
+        if (properties().isDisablePrivateEndpoint()) {
+            ret = Future.succeededFuture();
+        } else {
+            String endpointName = "pe-" + account.name();
+            Mono<PrivateEndpoint> endpoint = AzureUtil.emptyIfNotFound(network.privateEndpoints().getByResourceGroupAsync(properties().getResourceGroup(), endpointName))
+                    .switchIfEmpty(Mono.defer(() -> network.privateEndpoints()
+                            .define(endpointName)
+                            .withRegion(properties().getLocation())
+                            .withExistingResourceGroup(properties().getResourceGroup())
+                            .withSubnetId(properties().getPrivateEndpointSubnetId())
+                            .definePrivateLinkServiceConnection("blob")
+                                .withResourceId(account.id())
+                                .withSubResource(PrivateLinkSubResourceName.STORAGE_BLOB)
+                                .attach()
+                            .createAsync()))
+                    .flatMap(created -> ensureDnsZoneGroup(created).thenReturn(created));
+            ret = AzureUtil.toFuture(endpoint, vertx).mapEmpty();
+        }
+        return ret;
     }
 
     // An endpoint carries at most one zone group, so any existing one is the registration

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageService.java
@@ -89,9 +89,9 @@ public class AzureOrganizationStorageService implements OrganizationStorageServi
         } else {
             OrganizationStorage storage = requireStorage(organization);
             ret = AzureUtil.toFuture(accountKey(organization).map(key -> new BlobContainerClientBuilder()
-                    .endpoint(storage.getBlobEndpoint())
+                    .endpoint(storage.getAzureBlobEndpoint())
                     .containerName(OrganizationStorageProvisioner.UI_CONTAINER)
-                    .credential(new StorageSharedKeyCredential(storage.getAccountName(), key))
+                    .credential(new StorageSharedKeyCredential(storage.getAzureAccountName(), key))
                     .buildAsyncClient()
                     .generateSas(values)), vertx);
         }
@@ -102,12 +102,12 @@ public class AzureOrganizationStorageService implements OrganizationStorageServi
     // Contributor on the resource group every organization account is created in
     private Mono<String> accountKey(Organization organization) {
         OrganizationStorage storage = requireStorage(organization);
-        Validate.notBlank(storage.getSubscriptionId(), "Organization %s has no storage subscription recorded", organization.getId());
-        Validate.notBlank(storage.getAccountName(), "Organization %s has no storage account recorded", organization.getId());
-        AzureProfile profile = new AzureProfile(null, storage.getSubscriptionId(), AzureEnvironment.AZURE);
+        Validate.notBlank(storage.getAzureSubscriptionId(), "Organization %s has no storage subscription recorded", organization.getId());
+        Validate.notBlank(storage.getAzureAccountName(), "Organization %s has no storage account recorded", organization.getId());
+        AzureProfile profile = new AzureProfile(null, storage.getAzureSubscriptionId(), AzureEnvironment.AZURE);
         return StorageManager.authenticate(credential, profile)
                              .storageAccounts()
-                             .getByResourceGroupAsync(properties().getResourceGroup(), storage.getAccountName())
+                             .getByResourceGroupAsync(properties().getResourceGroup(), storage.getAzureAccountName())
                              .flatMap(StorageAccount::getKeysAsync)
                              .map(keys -> keys.getFirst().value());
     }
@@ -146,7 +146,7 @@ public class AzureOrganizationStorageService implements OrganizationStorageServi
 
     private BlobServiceAsyncClient service(Organization organization) {
         OrganizationStorage storage = requireStorage(organization);
-        return clientsByEndpoint.computeIfAbsent(storage.getBlobEndpoint(), endpoint -> {
+        return clientsByEndpoint.computeIfAbsent(storage.getAzureBlobEndpoint(), endpoint -> {
             BlobServiceClientBuilder builder = new BlobServiceClientBuilder();
             if (azurite()) {
                 builder.connectionString(properties().getAzuriteConnectionString());
@@ -159,7 +159,7 @@ public class AzureOrganizationStorageService implements OrganizationStorageServi
 
     private static OrganizationStorage requireStorage(Organization organization) {
         Validate.notNull(organization, "organization is required");
-        Validate.isTrue(organization.getStorage() != null && organization.getStorage().getBlobEndpoint() != null,
+        Validate.isTrue(organization.getStorage() != null && organization.getStorage().getAzureBlobEndpoint() != null,
                         "Organization %s has no storage endpoint recorded", organization.getId());
         return organization.getStorage();
     }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/FrontDoorUiDeploymentProvisioner.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/FrontDoorUiDeploymentProvisioner.java
@@ -216,7 +216,7 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
     /** The organization's origin group and its one origin, the storage account's blob endpoint. Emits the group's id. */
     private Future<String> ensureOriginGroup(Organization organization) {
         String groupName = originGroupName(organization);
-        String host = URI.create(organization.getStorage().getBlobEndpoint()).getHost();
+        String host = URI.create(organization.getStorage().getAzureBlobEndpoint()).getHost();
         return getOrCreate(cdn.getAfdOriginGroups().getAsync(resourceGroup, profileName, groupName),
                            () -> cdn.getAfdOriginGroups().createAsync(resourceGroup, profileName, groupName, new AfdOriginGroupInner()
                                    .withLoadBalancingSettings(new LoadBalancingSettingsParameters()
@@ -501,7 +501,7 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
 
     private static void requireStorage(Organization organization) {
         Validate.notNull(organization, "organization is required");
-        Validate.isTrue(organization.getStorage() != null && organization.getStorage().getBlobEndpoint() != null,
+        Validate.isTrue(organization.getStorage() != null && organization.getStorage().getAzureBlobEndpoint() != null,
                         "Organization %s has no storage endpoint recorded", organization.getId());
     }
 

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/MockOrganizationStorageProvisioner.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/MockOrganizationStorageProvisioner.java
@@ -17,7 +17,6 @@ import org.kinotic.system.api.services.OrganizationStorageProvisioner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-import java.net.URI;
 import java.util.Date;
 
 /**
@@ -54,11 +53,9 @@ public class MockOrganizationStorageProvisioner implements OrganizationStoragePr
                     } else {
                         ret = AzureUtil.toFuture(blobService.createBlobContainerIfNotExists(UI_CONTAINER), vertx)
                                        .compose(container -> {
-                                           URI endpoint = URI.create(blobService.getAccountUrl());
                                            organization.setStorage(new OrganizationStorage()
-                                                               .setAccountName(blobService.getAccountName())
-                                                               .setBlobEndpoint(blobService.getAccountUrl())
-                                                               .setPublishHost(endpoint.getHost())
+                                                               .setAzureAccountName(blobService.getAccountName())
+                                                               .setAzureBlobEndpoint(blobService.getAccountUrl())
                                                                .setStatus(new DeploymentStatus(DeploymentStatusType.READY)))
                                                        .setUpdated(new Date());
                                            log.debug("MockOrganizationStorageProvisioner pointed organization {} at {}",

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
@@ -54,6 +54,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -599,7 +600,7 @@ public class ProjectDeployJobDefinitionFactory {
     /**
      * The publish workload carries the built UIs to the organization's storage and nothing
      * else: no Kinotic credentials, no machine identity, a read-only checkout, and an egress
-     * policy naming the storage's publish host alone. Kept after its run, like the sync
+     * policy naming the storage account's host alone. Kept after its run, like the sync
      * workload, so its logs stay inspectable until the next run retires it.
      */
     private Workload publishWorkload(Project project,
@@ -623,7 +624,7 @@ public class ProjectDeployJobDefinitionFactory {
         workload.getVolumeMounts().add(new VolumeMount().setHostPath(target.hostDir())
                                                         .setGuestPath("/workspace")
                                                         .setReadOnly(true));
-        workload.getNetwork().setAllowedHosts(List.of(organization.getStorage().getPublishHost()));
+        workload.getNetwork().setAllowedHosts(List.of(URI.create(organization.getStorage().getAzureBlobEndpoint()).getHost()));
         return workload;
     }
 

--- a/website/content/02.platform/11.reference/03.project-publishing-design.md
+++ b/website/content/02.platform/11.reference/03.project-publishing-design.md
@@ -89,10 +89,9 @@ VNet registered in `privatelink.blob.core.windows.net` unless
 `kinotic.systemApi.organizationStorage.disablePrivateEndpoint` is set, as it is where the server
 runs outside the VNet, tagged `org=<id>`. It holds one container, `ui`.
 
-Recorded on `Organization.storage`, an `OrganizationStorage`: `subscriptionId`, `accountName`,
-`blobEndpoint`, `publishHost` (the private endpoint's address, or the account's public host
-without one) and `status` (`PROVISIONING`, `READY` or `FAILED`, with a
-message). Provisioning is a grind job, `provision-organization-<id>`, with a **Provision
+Recorded on `Organization.storage`, an `OrganizationStorage`: `azureSubscriptionId`,
+`azureAccountName`, `azureBlobEndpoint` and `status` (`PROVISIONING`, `READY` or `FAILED`,
+with a message). Provisioning is a grind job, `provision-organization-<id>`, with a **Provision
 storage** task and a **Prepare Front Door** task, both idempotent, owned by the organization
 and recorded on it as `provisioningJobRunId`. `OrganizationService.provision` runs every
 `OrganizationProvisioner` (a domain hook) on the organization: the signup flow calls it once
@@ -171,7 +170,8 @@ The publish workload is named `project-ui-publish-<projectId>`, with id
 the same image in the foreground with entrypoint `bun src/publish-ui.ts`, the checkout mounted
 read-only at `/workspace`, env `KINOTIC_UI_COMMIT`, and the secret `KINOTIC_UI_UPLOAD_URL` =
 `<blob endpoint>/ui/prod/<app>/ui?<container SAS, create+write, TTL the run>`. Its allowed
-hosts are the organization's `storage.publishHost` only; it carries no Kinotic
+hosts are the hostname of the organization's `storage.azureBlobEndpoint` only, which the
+platform network resolves to the account's private endpoint; it carries no Kinotic
 credentials and no machine identity, is kept after its run, and is retired by the next run's
 `resolveTarget`. Its exit check is the one `syncSource` uses, extracted to one method with two
 consumers. `publish-ui.ts` uploads, per UI, everything in `dist` except `index.html` under
@@ -263,7 +263,7 @@ notification of publishes, and service endpoints instead of private endpoints.
 - **The publish task.** The deploy job's fifth task, **Publish UIs**, runs
   `project-ui-publish-<projectId>` under `DeployTarget.uiPublishWorkloadId` with
   `publish-ui.ts`, the checkout read-only, `KINOTIC_UI_COMMIT`, the secret
-  `KINOTIC_UI_UPLOAD_URL` (a one-hour container SAS) and the storage's publish host as its
+  `KINOTIC_UI_UPLOAD_URL` (a one-hour container SAS) and the storage account's hostname as its
   only egress, then finalizes: mints labels with numeric suffixes on collision, provisions new
   sites, adopts returning ones, orphans vanished ones, keeps the current and previous commit
   directories and deletes the rest. The exit check is shared with the sync task, and the


### PR DESCRIPTION
## Summary

Follow-up to #512. `OrganizationStorage` holds an Azure storage account, so its fields say so, and the address the publish workload's egress allowlist names is no longer stored: it is derived from the blob endpoint where it is needed.

```java
// kinotic-domain/.../api/model/OrganizationStorage.java
private String azureSubscriptionId;   // null when an Azurite stands in
private String azureAccountName;
private String azureBlobEndpoint;     // https://<account>.blob.core.windows.net/
private DeploymentStatus status;
```

```java
// ProjectDeployJobDefinitionFactory.publishWorkload
workload.getNetwork().setAllowedHosts(List.of(URI.create(organization.getStorage().getAzureBlobEndpoint()).getHost()));
```

The hostname is per account and the platform's private DNS zone resolves it to the account's private endpoint inside the VNet, a developer machine resolves it publicly, and with Azurite it is `127.0.0.1`. So the private endpoint's address, which #512 stored as `allowedHost` and before that as `privateEndpointIp`, was never needed. `AzureOrganizationStorageProvisioner` still creates `pe-<account>` and its DNS zone group unless `disablePrivateEndpoint` is on; the NIC lookup that read the address back is deleted:

```java
private Future<Void> ensurePrivateEndpoint(NetworkManager network, StorageAccount account) {
    if (properties().isDisablePrivateEndpoint()) {
        ret = Future.succeededFuture();
    } else {
        ... create the endpoint, ensure its zone group ...
        ret = AzureUtil.toFuture(endpoint, vertx).mapEmpty();
    }
```

Renamed at every read: `AzureOrganizationStorageService`, `FrontDoorUiDeploymentProvisioner`, the Azurite mock, the TS model, `V1__init.sql`, the system console's organization overview, and the design doc.

## Depends on

- **Cloud Hypervisor egress by hostname**, in flight separately. Until it lands, a cluster publish workload's allowlist entry is a hostname the node's firewall rejects, so the two should merge together.

## Publishing

`@kinotic-ai/management-api` 5.0.0-beta.28 is still unpublished, so the renamed TS fields ship under the version #512 already set; nothing else moves.

The `kinotic_organization` mapping changed (`storage` columns renamed), so a local Elasticsearch needs that index and `migration_history` dropped for V1 to re-apply.

## Verification

- `:kinotic-domain:compileJava` and `:kinotic-system-api:test` pass
- `@kinotic-ai/management-api` type-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZo7VFb5umbA2xP2MwmSGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZo7VFb5umbA2xP2MwmSGW)_