### PR TITLE
Create the developer's kinotic-server service principal from the dev terraform root

### DIFF
--- a/deployment/terraform/azure/COST.md
+++ b/deployment/terraform/azure/COST.md
@@ -31,6 +31,12 @@ Estimated monthly costs for `centralus` (the `location` in `cluster/terraform.tf
 | Entra ID App Registration (Grafana) | Azure AD | Free |
 | Azure Key Vault (platform secrets) | Key Vault Standard | **~$1/mo** |
 | Azure Communication Services | Email | **Per-message** |
+| Front Door Standard profile + endpoint (UI sites) | Azure Front Door | **~$35/mo** base, billed hourly; traffic ~$0.09/GB out, ~$0.01 per 10k requests; custom domains and managed certificates included |
+| Organization storage resource group + private-endpoints subnet | Resource Manager, VNet | Free |
+| Private DNS zone (`privatelink.blob.core.windows.net`) + VNet link | Azure Private DNS | **~$0.50/mo** |
+| Per organization: storage account | Blob Storage (StorageV2, LRS, hot) | **~$0.02/GB/mo**; a published UI is a few MB, so cents |
+| Per organization: private endpoint | Private Link | **~$7.30/mo** each, plus ~$0.01/GB processed |
+| Per site: CNAME + TXT records, Front Door domain and route | Azure DNS, Front Door | Included |
 
 ### Production Only (`beta_mode = false`)
 
@@ -52,7 +58,7 @@ Estimated monthly costs for `centralus` (the `location` in `cluster/terraform.tf
 | Resource | Azure Service | Estimated cost |
 |---|---|---|
 | Azure Container Registry (Basic) | ACR | $5/mo |
-| Azure Front Door / WAF | CDN + WAF | $175+/mo |
+| Front Door WAF policy | Web Application Firewall (needs the Premium tier, ~$330/mo base) | $300+/mo over today's Standard profile |
 
 ---
 
@@ -77,8 +83,11 @@ Includes observability stack (Loki + Alloy + Grafana) and Entra ID auth.
 | Azure Communication Services | Email | 1 | $0.00025/email | $0 |
 | DNS Zone | kinotic.ai | 1 | $0.50 | $1 |
 | State Storage | Blob (LRS) | 1 | $1 | $1 |
+| Front Door Standard (UI sites) | Base fee | 1 | $35 | $35 |
+| Private DNS Zone (blob) | privatelink.blob.core.windows.net | 1 | $0.50 | $1 |
+| Organization storage | Storage account + private endpoint | per org | ~$7.50 | +$7.50 per org |
 
-### Beta Total: ~$573/mo
+### Beta Total: ~$609/mo, plus ~$7.50 per organization
 
 ### Beta Resource Utilization (48 GB across 3 nodes)
 
@@ -128,8 +137,35 @@ AKS Standard tier with uptime SLA.
 | Grafana PVC | managed-csi-premium, 1 GB | 1 | $1 | $1 |
 | DNS Zone | kinotic.ai | 1 | $0.50 | $1 |
 | State Storage | Blob (LRS) | 1 | $1 | $1 |
+| Front Door Standard (UI sites) | Base fee | 1 | $35 | $35 |
+| Private DNS Zone (blob) | privatelink.blob.core.windows.net | 1 | $0.50 | $1 |
+| Organization storage | Storage account + private endpoint | per org | ~$7.50 | +$7.50 per org |
 
-### Production Total: ~$2,025/mo
+### Production Total: ~$2,061/mo, plus ~$7.50 per organization
+
+The per-organization line is the private endpoint; the account itself is cents. At a
+thousand organizations that is ~$7,300/mo, which is where service endpoints or a shared
+account layout would earn a redesign (see the "Deferred" section of the project publishing
+design).
+
+---
+
+## Developer environment (`dev/`)
+
+One per developer, created by `dev/` (see [dev/README.md](dev/README.md)). No VNet, no
+private endpoints, no cluster.
+
+| Line Item | Spec | Count | Unit cost | Total/mo |
+|---|---|---|---|---|
+| Front Door Standard (UI sites) | Base fee, billed hourly | 1 | $35 | $35 |
+| Organization storage accounts | Blob (LRS, hot), a few MB each | per org | cents | ~$0 |
+| Service principal, role assignments, resource group | | | $0 | $0 |
+| DNS records under `apps-<environment>` | In the shared `kinotic.ai` zone | | included | $0 |
+
+### Developer Total: ~$35/mo while it exists
+
+The base fee is billed by the hour, so `terraform destroy` between testing sessions stops
+it, and `terraform apply` brings the environment back in a few minutes.
 
 ---
 

--- a/deployment/terraform/azure/README.md
+++ b/deployment/terraform/azure/README.md
@@ -152,18 +152,15 @@ terraform apply     # creates Static Web App + DNS CNAME (first time only)
 
 A kinotic-server on a developer machine publishes UIs to a real subscription with the `dev`
 root: a resource group the organization storage accounts are created in, a Front Door
-Standard profile and endpoint under `apps-<environment>.<zone>`, and the roles the server
-needs on them. State is local, one environment per developer.
+Standard profile and endpoint under `apps-<environment>.<zone>`, and a service principal
+for the server holding Contributor and Storage Blob Data Contributor on the group, DNS Zone
+Contributor on the zone, and Contributor on the email service. State is local, one
+environment per developer.
 
-The roles go to the identity the server authenticates as. `DefaultAzureCredential` takes the
-service principal named by `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`
-when those are set where the server runs, and the `az login` user otherwise. The root
-defaults to the identity running terraform, so a server that uses a service principal names
-it in `local.auto.tfvars` (gitignored):
-
-```hcl
-server_principal_object_id = "<az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv>"
-```
+The principal's `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID` are written to
+`.env.local` at the repository root (gitignored), replacing those three lines when present
+and leaving the rest of the file alone; the server picks them up through
+`DefaultAzureCredential`. Its secret is also in this root's local state.
 
 ```bash
 cd dev

--- a/deployment/terraform/azure/README.md
+++ b/deployment/terraform/azure/README.md
@@ -32,7 +32,8 @@ deployment/terraform/azure/
 │   ├── main.tf
 │   ├── deploy.sh
 │   └── terraform.tfvars
-├── dev/                       # Storage resource group + Front Door for a kinotic-server on a developer machine
+├── dev/                       # Storage resource group, Front Door and a service principal for a kinotic-server on a developer machine
+│   ├── README.md              # Getting started on your machine
 │   ├── main.tf
 │   └── terraform.tfvars
 ├── modules/                   # Shared modules (aks, firecracker, identity, micro-vm-node, networking)
@@ -169,8 +170,8 @@ terraform apply   # environment = "local" in terraform.tfvars; pick a name of yo
 terraform output -raw application_local_yml > ../../../../kinotic-server/src/main/resources/application-local.yml
 ```
 
-Then run the server with `SPRING_PROFILES_ACTIVE=development,local`. The contributing guide
-on the website (Testing → Publishing UIs against Azure) has the full walkthrough.
+Then run the server with `SPRING_PROFILES_ACTIVE=development,local`. [dev/README.md](dev/README.md)
+has the full walkthrough, from prerequisites to teardown.
 
 ## Deploy Options
 

--- a/deployment/terraform/azure/README.md
+++ b/deployment/terraform/azure/README.md
@@ -151,9 +151,19 @@ terraform apply     # creates Static Web App + DNS CNAME (first time only)
 ## Developer UI Publishing
 
 A kinotic-server on a developer machine publishes UIs to a real subscription with the `dev`
-root: a resource group the organization storage accounts are created in, and a Front Door
-Standard profile and endpoint under `apps-<environment>.<zone>`. State is local, one
-environment per developer.
+root: a resource group the organization storage accounts are created in, a Front Door
+Standard profile and endpoint under `apps-<environment>.<zone>`, and the roles the server
+needs on them. State is local, one environment per developer.
+
+The roles go to the identity the server authenticates as. `DefaultAzureCredential` takes the
+service principal named by `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`
+when those are set where the server runs, and the `az login` user otherwise. The root
+defaults to the identity running terraform, so a server that uses a service principal names
+it in `local.auto.tfvars` (gitignored):
+
+```hcl
+server_principal_object_id = "<az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv>"
+```
 
 ```bash
 cd dev

--- a/deployment/terraform/azure/dev/.gitignore
+++ b/deployment/terraform/azure/dev/.gitignore
@@ -1,0 +1,9 @@
+# Local state: this root is per developer (see main.tf)
+*.tfstate
+*.tfstate.backup
+.terraform.tfstate.lock.info
+.terraform/
+.terraform.lock.hcl
+
+# Local overrides: the server's principal, anything personal
+*.auto.tfvars

--- a/deployment/terraform/azure/dev/README.md
+++ b/deployment/terraform/azure/dev/README.md
@@ -1,0 +1,99 @@
+# Developer UI Publishing
+
+Everything a kinotic-server on your machine needs to publish UIs to a real Azure
+subscription, instead of the Azurite and no-op site provisioner the development profile
+uses. One apply creates:
+
+| Resource | Name | Purpose |
+|---|---|---|
+| Resource group | `rg-kinotic-<environment>` | Holds the Front Door profile and, created by the server at runtime, one storage account per organization |
+| Front Door Standard profile + endpoint | `afd-kinotic-<environment>-sites` | Serves every published UI at `<label>.apps-<environment>.kinotic.ai`; the server adds origin groups, rule sets, domains and routes at runtime |
+| Service principal | `kinotic-<environment>-server` | The identity the server runs as, with Contributor and Storage Blob Data Contributor on the group, DNS Zone Contributor on `kinotic.ai`, and Contributor on the email service |
+| `.env.local` at the repository root | | The principal's `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`, written by the apply |
+
+Site DNS records are written into the shared `kinotic.ai` zone under `apps-<environment>`,
+so the zone itself is not created here. There is no VNet: the server reaches the storage
+accounts over their public endpoints, which the `local` profile's `disablePrivateEndpoint`
+allows for. State is local, in this directory, and gitignored.
+
+## Prerequisites
+
+- `az` and `terraform` (`brew install azure-cli terraform`)
+- On the subscription: rights to create resources and role assignments (Owner, or Contributor
+  plus User Access Administrator), and rights to create app registrations in the tenant
+- Read access to the `stkinotictfstate` storage account, where the global root's outputs
+  (DNS zone, email service) are read from
+
+## Getting started
+
+```bash
+az login
+export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)   # the azurerm provider needs it named
+
+cd deployment/terraform/azure/dev
+```
+
+Pick an environment name of your own in `terraform.tfvars`. It names everything above and
+the `apps-<environment>` sites domain, and a site hostname can be bound to one Front Door
+profile in all of Azure, so two developers sharing one would collide:
+
+```hcl
+environment = "local"   # e.g. your first name
+```
+
+```bash
+terraform init
+terraform apply
+terraform output -raw application_local_yml > ../../../../kinotic-server/src/main/resources/application-local.yml
+```
+
+The last command writes the `local` Spring profile, gitignored, which turns both provisioners
+on and names the resources above. `.env.local` at the repository root now carries the
+principal's credentials; if the file existed, its other lines are untouched.
+
+## Running the server
+
+Start kinotic-server with `.env.local` in its environment and both profiles active:
+
+```bash
+SPRING_PROFILES_ACTIVE=development,local
+```
+
+`DefaultAzureCredential` takes the three `AZURE_*` variables before anything else, so the
+server provisions as the principal whatever `az login` is signed in as.
+
+If your local Elasticsearch predates this, drop the organization index and the migration
+history so the current mapping is created:
+
+```bash
+curl -XDELETE 'localhost:9200/kinotic_organization'
+curl -XDELETE 'localhost:9200/migration_history'
+```
+
+Then sign up a new organization. Its overview in the system console shows the provisioning
+job creating the storage account and preparing Front Door; deploy a project that contains a
+UI and its site appears on the deployment page, `PROVISIONING` for a few minutes while Front
+Door validates the domain and issues the certificate, then `READY` with its URL. An
+organization created before the roles propagated fails with `AuthorizationFailed`;
+**Provision again** on its overview finishes it.
+
+## Tearing down
+
+```bash
+terraform destroy
+```
+
+This removes the resource group with every storage account and Front Door resource the
+server created in it, the service principal, and its role assignments. Two things it does not
+touch: the site CNAME and validation TXT records in the `kinotic.ai` zone, which the server
+removes when a deployment is removed, so remove your deployments first or delete the records
+under `apps-<environment>` by hand; and the three lines in `.env.local`.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `subscription_id is a required provider property` | `ARM_SUBSCRIPTION_ID` is not exported in this shell |
+| `Error acquiring the state lock` with nothing running | A previous run was interrupted; `terraform force-unlock <ID>` with the id from `.terraform.tfstate.lock.info` |
+| Organization storage `FAILED` with `AuthorizationFailed` right after apply | Role assignments take a minute or two to become visible; **Provision again** |
+| The server still authenticates as an old principal | The three `AZURE_*` variables are set elsewhere in its environment, ahead of `.env.local` |

--- a/deployment/terraform/azure/dev/main.tf
+++ b/deployment/terraform/azure/dev/main.tf
@@ -2,10 +2,11 @@
 # What a kinotic-server running on a developer machine needs to publish UIs to a real
 # subscription: the resource group its organizations' storage accounts are created in, and
 # the Front Door Standard profile and endpoint every site is served through, under
-# apps-<environment>.<zone> in the global DNS zone. The server creates the rest at runtime,
-# as it does in the cluster. There is no VNet: the server reaches the accounts over their
-# public endpoints and creates no private endpoints, which is what the `local` profile it
-# runs with turns off. Independent of cluster/: apply and destroy freely.
+# apps-<environment>.<zone> in the global DNS zone, and the roles the server needs on them.
+# The server creates the rest at runtime, as it does in the cluster. There is no VNet: the
+# server reaches the accounts over their public endpoints and creates no private endpoints,
+# which is what the `local` profile it runs with turns off. Independent of cluster/: apply
+# and destroy freely.
 #
 # State is kept locally, next to this file, because the root is per developer: each
 # developer picks an `environment` of their own and owns what it creates.
@@ -50,6 +51,8 @@ locals {
   global       = data.terraform_remote_state.global.outputs
   sites_domain = "apps-${var.environment}.${local.global.dns_zone_name}"
 
+  server_principal_object_id = coalesce(var.server_principal_object_id, data.azurerm_client_config.current.object_id)
+
   common_tags = {
     environment = var.environment
     project     = var.project
@@ -81,6 +84,32 @@ resource "azurerm_cdn_frontdoor_endpoint" "sites" {
   tags                     = local.common_tags
 }
 
+# ── Roles for kinotic-server ──────────────────────────────────────────────────
+# The developer's identity (see server_principal_object_id) gets what the cluster grants the
+# kinotic-server workload identity in keyvault.tf, minus the private endpoint roles it has no
+# VNet to use: Contributor creates the storage accounts, reads their keys and manages the
+# Front Door origin groups, rule sets, domains and routes; Storage Blob Data Contributor
+# is for the blob data plane the storage service reaches with the token, not the key;
+# DNS Zone Contributor writes each site's CNAME and validation TXT.
+
+resource "azurerm_role_assignment" "server_contributor" {
+  scope                = azurerm_resource_group.main.id
+  role_definition_name = "Contributor"
+  principal_id         = local.server_principal_object_id
+}
+
+resource "azurerm_role_assignment" "server_blob_data" {
+  scope                = azurerm_resource_group.main.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = local.server_principal_object_id
+}
+
+resource "azurerm_role_assignment" "server_dns" {
+  scope                = local.global.dns_zone_id
+  role_definition_name = "DNS Zone Contributor"
+  principal_id         = local.server_principal_object_id
+}
+
 # ── Variables ─────────────────────────────────────────────────────────────────
 
 variable "environment" {
@@ -99,6 +128,12 @@ variable "location" {
   description = "Azure region"
   type        = string
   default     = "centralus"
+}
+
+variable "server_principal_object_id" {
+  description = "Object id of the principal kinotic-server authenticates as, which DefaultAzureCredential makes the service principal named by AZURE_CLIENT_ID when that is set where the server runs, and the az login user otherwise. Defaults to the identity running terraform; set it in local.auto.tfvars (gitignored) when the server uses a service principal"
+  type        = string
+  default     = null
 }
 
 # ── Outputs ───────────────────────────────────────────────────────────────────

--- a/deployment/terraform/azure/dev/main.tf
+++ b/deployment/terraform/azure/dev/main.tf
@@ -1,12 +1,12 @@
 # ── Developer UI publishing ───────────────────────────────────────────────────
 # What a kinotic-server running on a developer machine needs to publish UIs to a real
-# subscription: the resource group its organizations' storage accounts are created in, and
-# the Front Door Standard profile and endpoint every site is served through, under
-# apps-<environment>.<zone> in the global DNS zone, and the roles the server needs on them.
-# The server creates the rest at runtime, as it does in the cluster. There is no VNet: the
-# server reaches the accounts over their public endpoints and creates no private endpoints,
-# which is what the `local` profile it runs with turns off. Independent of cluster/: apply
-# and destroy freely.
+# subscription: the resource group its organizations' storage accounts are created in, the
+# Front Door Standard profile and endpoint every site is served through, under
+# apps-<environment>.<zone> in the global DNS zone, and a service principal for the server
+# holding the roles it needs on them and on the email service. The server creates the rest
+# at runtime, as it does in the cluster. There is no VNet: the server reaches the accounts
+# over their public endpoints and creates no private endpoints, which is what the `local`
+# profile it runs with turns off. Independent of cluster/: apply and destroy freely.
 #
 # State is kept locally, next to this file, because the root is per developer: each
 # developer picks an `environment` of their own and owns what it creates.
@@ -18,6 +18,10 @@ terraform {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
     }
   }
 }
@@ -31,6 +35,8 @@ provider "azurerm" {
     }
   }
 }
+
+provider "azuread" {}
 
 # ── Read global state ─────────────────────────────────────────────────────────
 
@@ -50,8 +56,7 @@ locals {
   name_prefix  = "${var.project}-${var.environment}"
   global       = data.terraform_remote_state.global.outputs
   sites_domain = "apps-${var.environment}.${local.global.dns_zone_name}"
-
-  server_principal_object_id = coalesce(var.server_principal_object_id, data.azurerm_client_config.current.object_id)
+  env_local    = "${path.module}/../../../../.env.local"
 
   common_tags = {
     environment = var.environment
@@ -84,30 +89,83 @@ resource "azurerm_cdn_frontdoor_endpoint" "sites" {
   tags                     = local.common_tags
 }
 
+# ── Service principal for kinotic-server ──────────────────────────────────────
+# The server on this machine authenticates as this principal: DefaultAzureCredential takes
+# AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID before anything else, and the
+# root writes those three to .env.local at the repository root. One per developer, holding
+# roles on nothing but what this root creates and the email service.
+
+resource "azuread_application" "server" {
+  display_name = "${local.name_prefix}-server"
+}
+
+resource "azuread_service_principal" "server" {
+  client_id = azuread_application.server.client_id
+}
+
+resource "azuread_application_password" "server" {
+  application_id = azuread_application.server.id
+  display_name   = "${local.name_prefix}-server"
+}
+
+# Keeps the three AZURE_* lines current and everything else in the file as it was: they are
+# replaced when present and appended when not. The secret travels through the environment
+# rather than the command, so it stays out of terraform's output.
+resource "terraform_data" "env_local" {
+  triggers_replace = [azuread_application_password.server.key_id]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -euo pipefail
+      f="${local.env_local}"
+      touch "$f"
+      { grep -v -E '^AZURE_(CLIENT_ID|CLIENT_SECRET|TENANT_ID)=' "$f" || true
+        printf 'AZURE_CLIENT_ID=%s\nAZURE_CLIENT_SECRET=%s\nAZURE_TENANT_ID=%s\n' "$AZURE_CLIENT_ID" "$AZURE_CLIENT_SECRET" "$AZURE_TENANT_ID"
+      } > "$f.tmp" && mv "$f.tmp" "$f"
+    EOT
+    environment = {
+      AZURE_CLIENT_ID     = azuread_application.server.client_id
+      AZURE_CLIENT_SECRET = azuread_application_password.server.value
+      AZURE_TENANT_ID     = data.azurerm_client_config.current.tenant_id
+    }
+  }
+}
+
 # ── Roles for kinotic-server ──────────────────────────────────────────────────
-# The developer's identity (see server_principal_object_id) gets what the cluster grants the
-# kinotic-server workload identity in keyvault.tf, minus the private endpoint roles it has no
-# VNet to use: Contributor creates the storage accounts, reads their keys and manages the
-# Front Door origin groups, rule sets, domains and routes; Storage Blob Data Contributor
-# is for the blob data plane the storage service reaches with the token, not the key;
-# DNS Zone Contributor writes each site's CNAME and validation TXT.
+# What the cluster grants the kinotic-server workload identity in keyvault.tf and email.tf,
+# minus the private endpoint roles it has no VNet to use: Contributor creates the storage
+# accounts, reads their keys and manages the Front Door origin groups, rule sets, domains
+# and routes; Storage Blob Data Contributor is for the blob data plane the storage service
+# reaches with the token, not the key; DNS Zone Contributor writes each site's CNAME and
+# validation TXT; Contributor on the email service sends mail.
 
 resource "azurerm_role_assignment" "server_contributor" {
   scope                = azurerm_resource_group.main.id
   role_definition_name = "Contributor"
-  principal_id         = local.server_principal_object_id
+  principal_id         = azuread_service_principal.server.object_id
+  # a principal created moments ago may not have replicated to the RBAC lookup yet
+  skip_service_principal_aad_check = true
 }
 
 resource "azurerm_role_assignment" "server_blob_data" {
-  scope                = azurerm_resource_group.main.id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = local.server_principal_object_id
+  scope                            = azurerm_resource_group.main.id
+  role_definition_name             = "Storage Blob Data Contributor"
+  principal_id                     = azuread_service_principal.server.object_id
+  skip_service_principal_aad_check = true
 }
 
 resource "azurerm_role_assignment" "server_dns" {
-  scope                = local.global.dns_zone_id
-  role_definition_name = "DNS Zone Contributor"
-  principal_id         = local.server_principal_object_id
+  scope                            = local.global.dns_zone_id
+  role_definition_name             = "DNS Zone Contributor"
+  principal_id                     = azuread_service_principal.server.object_id
+  skip_service_principal_aad_check = true
+}
+
+resource "azurerm_role_assignment" "server_email" {
+  scope                            = local.global.email_communication_service_id
+  role_definition_name             = "Contributor"
+  principal_id                     = azuread_service_principal.server.object_id
+  skip_service_principal_aad_check = true
 }
 
 # ── Variables ─────────────────────────────────────────────────────────────────
@@ -130,17 +188,16 @@ variable "location" {
   default     = "centralus"
 }
 
-variable "server_principal_object_id" {
-  description = "Object id of the principal kinotic-server authenticates as, which DefaultAzureCredential makes the service principal named by AZURE_CLIENT_ID when that is set where the server runs, and the az login user otherwise. Defaults to the identity running terraform; set it in local.auto.tfvars (gitignored) when the server uses a service principal"
-  type        = string
-  default     = null
-}
-
 # ── Outputs ───────────────────────────────────────────────────────────────────
 
 output "sites_domain" {
   description = "The domain every published UI is a label under"
   value       = local.sites_domain
+}
+
+output "server_client_id" {
+  description = "The service principal kinotic-server runs as; its credentials are in .env.local at the repository root"
+  value       = azuread_application.server.client_id
 }
 
 output "application_local_yml" {

--- a/website/content/02.platform/09.contributing.md
+++ b/website/content/02.platform/09.contributing.md
@@ -75,13 +75,27 @@ terraform apply   # environment = "local" in terraform.tfvars; pick a name of yo
 terraform output -raw application_local_yml > ../../../../kinotic-server/src/main/resources/application-local.yml
 ```
 
-That is a resource group, a Front Door Standard profile with an endpoint, and the
-`apps-<environment>.<zone>` sites domain in the platform's DNS zone. The written file is the
-git-ignored `local` profile: it turns both provisioners on and names those resources. The
-identity `az login` signed in is the one the server provisions with; Contributor on the
-subscription covers the storage accounts, the Front Door resources and the DNS records it
-writes. The `environment` is yours alone: a site hostname can be bound to one Front Door
-profile in all of Azure, so two developers sharing a sites domain would collide.
+That is a resource group, a Front Door Standard profile with an endpoint, the
+`apps-<environment>.<zone>` sites domain in the platform's DNS zone, and the roles the server
+needs on them: Contributor and Storage Blob Data Contributor on the group, DNS Zone
+Contributor on the zone. The written file is the git-ignored `local` profile: it turns both
+provisioners on and names those resources. The `environment` is yours alone: a site hostname
+can be bound to one Front Door profile in all of Azure, so two developers sharing a sites
+domain would collide.
+
+The roles go to the identity the server authenticates as. `DefaultAzureCredential` takes the
+service principal named by `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`
+when those are set where the server runs, and the `az login` user otherwise. The root
+defaults to the identity running terraform, so when the server uses a service principal,
+name it in a git-ignored `local.auto.tfvars` next to `main.tf` before applying:
+
+```hcl
+server_principal_object_id = "<az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv>"
+```
+
+A role assignment takes a minute or two to become visible; an organization provisioned
+before that fails with `AuthorizationFailed` and **Provision again** finishes it once the
+roles have propagated.
 
 Run the server with both profiles:
 

--- a/website/content/02.platform/09.contributing.md
+++ b/website/content/02.platform/09.contributing.md
@@ -76,26 +76,22 @@ terraform output -raw application_local_yml > ../../../../kinotic-server/src/mai
 ```
 
 That is a resource group, a Front Door Standard profile with an endpoint, the
-`apps-<environment>.<zone>` sites domain in the platform's DNS zone, and the roles the server
-needs on them: Contributor and Storage Blob Data Contributor on the group, DNS Zone
-Contributor on the zone. The written file is the git-ignored `local` profile: it turns both
-provisioners on and names those resources. The `environment` is yours alone: a site hostname
-can be bound to one Front Door profile in all of Azure, so two developers sharing a sites
-domain would collide.
+`apps-<environment>.<zone>` sites domain in the platform's DNS zone, and a service principal
+for the server with the roles it needs: Contributor and Storage Blob Data Contributor on the
+group, DNS Zone Contributor on the zone, and Contributor on the email service, so it sends
+mail too. The written file is the git-ignored `local` profile: it turns both provisioners on
+and names those resources. The `environment` is yours alone: a site hostname can be bound to
+one Front Door profile in all of Azure, so two developers sharing a sites domain would
+collide.
 
-The roles go to the identity the server authenticates as. `DefaultAzureCredential` takes the
-service principal named by `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`
-when those are set where the server runs, and the `az login` user otherwise. The root
-defaults to the identity running terraform, so when the server uses a service principal,
-name it in a git-ignored `local.auto.tfvars` next to `main.tf` before applying:
-
-```hcl
-server_principal_object_id = "<az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv>"
-```
-
-A role assignment takes a minute or two to become visible; an organization provisioned
-before that fails with `AuthorizationFailed` and **Provision again** finishes it once the
-roles have propagated.
+The principal's `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID` are written to
+`.env.local` at the repository root, which git ignores. When the file exists its other lines
+are kept and those three are replaced, or appended if absent. Run the server with that file
+in its environment; `DefaultAzureCredential` takes those variables before anything else, so
+the server provisions as the principal whatever `az login` is signed in as. A role
+assignment takes a minute or two to become visible; an organization provisioned before that
+fails with `AuthorizationFailed`, and **Provision again** finishes it once the roles have
+propagated.
 
 Run the server with both profiles:
 


### PR DESCRIPTION
## Summary

The `dev` terraform root from #512 created the resource group and Front Door profile but granted nothing on them, so the first organization provisioned from a developer machine failed with `AuthorizationFailed` on `Microsoft.Storage/storageAccounts/read`. The server on a developer machine runs as whatever `DefaultAzureCredential` finds first, which is the `AZURE_CLIENT_ID` service principal when those variables are set, and that principal had no rights on the new group.

The root now owns the server's identity end to end. Each developer gets a service principal scoped to what their root creates, plus the email service so mail sends too:

```hcl
# deployment/terraform/azure/dev/main.tf
resource "azuread_application" "server"          { display_name = "${local.name_prefix}-server" }
resource "azuread_service_principal" "server"    { client_id = azuread_application.server.client_id }
resource "azuread_application_password" "server" { application_id = azuread_application.server.id }

# Contributor + Storage Blob Data Contributor on the group, DNS Zone Contributor on the zone,
# Contributor on the communication service: what the cluster grants the workload identity in
# keyvault.tf and email.tf, minus the private endpoint roles there is no VNet for
```

Its `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID` are written to `.env.local` at the repository root (gitignored). The file's other lines are kept; those three are replaced when present and appended otherwise, and the write repeats when the secret rotates:

```bash
{ grep -v -E '^AZURE_(CLIENT_ID|CLIENT_SECRET|TENANT_ID)=' "$f" || true
  printf 'AZURE_CLIENT_ID=%s\nAZURE_CLIENT_SECRET=%s\nAZURE_TENANT_ID=%s\n' "$AZURE_CLIENT_ID" "$AZURE_CLIENT_SECRET" "$AZURE_TENANT_ID"
} > "$f.tmp" && mv "$f.tmp" "$f"
```

The secret goes through the provisioner's environment rather than its command line, so it stays out of terraform's output. It is in the root's local state, which the root's new `.gitignore` covers along with `*.auto.tfvars`, mirroring the cluster root's.

The role assignments use `skip_service_principal_aad_check`, since a principal created in the same apply may not have replicated to the RBAC lookup yet.

## Docs

- `dev/README.md`: a developer's getting-started guide, from prerequisites through running the server to teardown and troubleshooting. The terraform README and the contributing guide point at it.
- `COST.md`: Front Door Standard (~$35/mo) and organization storage (~$7.50 per organization for the private endpoint; the account is cents) move from "future" into the always-created inventory and the beta and production totals, and a developer environment section puts one `dev/` root at ~$35/mo while it exists.

## Setup change

```bash
cd deployment/terraform/azure/dev
terraform init -upgrade      # adds the azuread provider
·t·erraform a·pply
```

Then run the server with `.env.local` in its environment instead of a hand-made principal. `terraform output server_client_id` names the principal for reference.

## Verification

- Terraform is not installed in this environment, so the root has not been through `terraform validate`; it follows the global root's `azuread_application` / `azuread_service_principal` / `azuread_application_password` shape and its `terraform_data` + `local-exec` provisioner conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZo7VFb5umbA2xP2MwmSGW