### PR TITLE
Name the organization storage container sites, since Azure rejects ui

### DIFF
--- a/deployment/terraform/azure/README.md
+++ b/deployment/terraform/azure/README.md
@@ -159,9 +159,9 @@ Contributor on the zone, and Contributor on the email service. State is local, o
 environment per developer.
 
 The principal's `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID` are written to
-`.env.local` at the repository root (gitignored), replacing those three lines when present
-and leaving the rest of the file alone; the server picks them up through
-`DefaultAzureCredential`. Its secret is also in this root's local state.
+`.env.local` at the repository root (gitignored) as a commented block after a blank line,
+replacing the block a previous apply wrote and leaving the rest of the file alone; the server
+picks them up through `DefaultAzureCredential`. Its secret is also in this root's local state.
 
 ```bash
 cd dev

--- a/deployment/terraform/azure/dev/main.tf
+++ b/deployment/terraform/azure/dev/main.tf
@@ -108,21 +108,44 @@ resource "azuread_application_password" "server" {
   display_name   = "${local.name_prefix}-server"
 }
 
-# Keeps the three AZURE_* lines current and everything else in the file as it was: they are
-# replaced when present and appended when not. The secret travels through the environment
-# rather than the command, so it stays out of terraform's output.
+# Keeps the block below current and everything else in the file as it was: a block a
+# previous run wrote (its comment through AZURE_TENANT_ID) and any stray AZURE_* lines are
+# dropped, trailing blank lines trimmed, and the block appended after one blank line. The
+# secret travels through the environment rather than the command, so it stays out of
+# terraform's output. The script is among the triggers, so editing it rewrites the file on
+# the next apply.
+locals {
+  env_local_script = <<-EOT
+    set -eu
+    f="${local.env_local}"
+    touch "$f"
+    awk '
+      /^# kinotic-server Azure identity/ { skip = 1 }
+      skip && /^AZURE_TENANT_ID=/ { skip = 0; next }
+      skip { next }
+      /^AZURE_(CLIENT_ID|CLIENT_SECRET|TENANT_ID)=/ { next }
+      { lines[++n] = $0; if ($0 !~ /^[[:space:]]*$/) last = n }
+      END { for (i = 1; i <= last; i++) print lines[i] }
+    ' "$f" > "$f.tmp"
+    if [ -s "$f.tmp" ]; then printf '\n' >> "$f.tmp"; fi
+    cat >> "$f.tmp" <<EOF
+    # kinotic-server Azure identity: the ${local.name_prefix}-server service principal, created by
+    # deployment/terraform/azure/dev with the roles the server needs to publish UIs and send email.
+    # DefaultAzureCredential reads these before anything else. Written by terraform apply there;
+    # to write them again: terraform apply -replace=terraform_data.env_local
+    AZURE_CLIENT_ID=$AZURE_CLIENT_ID
+    AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET
+    AZURE_TENANT_ID=$AZURE_TENANT_ID
+    EOF
+    mv "$f.tmp" "$f"
+  EOT
+}
+
 resource "terraform_data" "env_local" {
-  triggers_replace = [azuread_application_password.server.key_id]
+  triggers_replace = [azuread_application_password.server.key_id, local.env_local_script]
 
   provisioner "local-exec" {
-    command = <<-EOT
-      set -euo pipefail
-      f="${local.env_local}"
-      touch "$f"
-      { grep -v -E '^AZURE_(CLIENT_ID|CLIENT_SECRET|TENANT_ID)=' "$f" || true
-        printf 'AZURE_CLIENT_ID=%s\nAZURE_CLIENT_SECRET=%s\nAZURE_TENANT_ID=%s\n' "$AZURE_CLIENT_ID" "$AZURE_CLIENT_SECRET" "$AZURE_TENANT_ID"
-      } > "$f.tmp" && mv "$f.tmp" "$f"
-    EOT
+    command = local.env_local_script
     environment = {
       AZURE_CLIENT_ID     = azuread_application.server.client_id
       AZURE_CLIENT_SECRET = azuread_application_password.server.value

--- a/kinotic-js/workload-runner/test/publish-ui.test.ts
+++ b/kinotic-js/workload-runner/test/publish-ui.test.ts
@@ -11,7 +11,7 @@ const PUBLISH = join(import.meta.dir, '..', 'src', 'publish-ui.ts')
 const ACCOUNT = 'devstoreaccount1'
 const ACCOUNT_KEY = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
 const ENDPOINT = process.env.AZURITE_BLOB_ENDPOINT ?? `http://127.0.0.1:10000/${ACCOUNT}`
-const CONTAINER = 'ui'
+const CONTAINER = 'sites'
 const SAS_VERSION = '2020-12-06'
 
 function sharedKeyHeaders(method: string, path: string, contentLength: number = 0, extra: Record<string, string> = {}): Record<string, string> {

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/OrganizationStorageProvisioner.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/OrganizationStorageProvisioner.java
@@ -6,13 +6,14 @@ import org.kinotic.domain.api.model.Organization;
 
 /**
  * Provisions the storage an organization's deployments publish to: one account per
- * organization holding the {@code ui} container, recorded on the {@link Organization}.
+ * organization holding the {@code sites} container, recorded on the {@link Organization}.
  * Provisioning runs when the organization is created; a deployment only reads the outcome.
  */
 public interface OrganizationStorageProvisioner {
 
     /** The one container in an organization's account that its deployments publish UIs into. */
-    String UI_CONTAINER = "ui";
+    // container names are 3 to 63 characters, which rules out "ui"; Azurite does not check
+    String UI_CONTAINER = "sites";
 
     /**
      * Leaves the organization with usable storage: returns at once when it is ready, waits

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/UiStoragePaths.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/UiStoragePaths.java
@@ -3,7 +3,7 @@ package org.kinotic.system.api.services;
 import org.apache.commons.lang3.Validate;
 
 /**
- * The layout of published UIs inside an organization's {@code ui} container. Every path is
+ * The layout of published UIs inside an organization's {@code sites} container. Every path is
  * built here, so the environment segment exists in exactly one place.
  *
  * <pre>

--- a/website/content/02.platform/09.contributing.md
+++ b/website/content/02.platform/09.contributing.md
@@ -85,8 +85,9 @@ one Front Door profile in all of Azure, so two developers sharing a sites domain
 collide.
 
 The principal's `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID` are written to
-`.env.local` at the repository root, which git ignores. When the file exists its other lines
-are kept and those three are replaced, or appended if absent. Run the server with that file
+`.env.local` at the repository root, which git ignores, as a commented block after a blank
+line. When the file exists its other lines are kept and the block a previous apply wrote is
+replaced, or appended if absent. Run the server with that file
 in its environment; `DefaultAzureCredential` takes those variables before anything else, so
 the server provisions as the principal whatever `az login` is signed in as. A role
 assignment takes a minute or two to become visible; an organization provisioned before that

--- a/website/content/02.platform/11.reference/03.project-publishing-design.md
+++ b/website/content/02.platform/11.reference/03.project-publishing-design.md
@@ -87,7 +87,8 @@ network access open (Front Door reads from addresses the storage firewall cannot
 every read is authorized by the SAS its rule set carries), a private endpoint in the platform
 VNet registered in `privatelink.blob.core.windows.net` unless
 `kinotic.systemApi.organizationStorage.disablePrivateEndpoint` is set, as it is where the server
-runs outside the VNet, tagged `org=<id>`. It holds one container, `ui`.
+runs outside the VNet, tagged `org=<id>`. It holds one container, `sites` (container names
+are 3 to 63 characters, so not `ui`).
 
 Recorded on `Organization.storage`, an `OrganizationStorage`: `azureSubscriptionId`,
 `azureAccountName`, `azureBlobEndpoint` and `status` (`PROVISIONING`, `READY` or `FAILED`,
@@ -106,9 +107,9 @@ provisioned by a deployment. A mock provisioner under
 at the configured Azurite connection string.
 
 ```
-kin<hash>/ui/prod/orders/ui/admin/index.html          Cache-Control: no-cache; uploaded last: the atomic switch
-kin<hash>/ui/prod/orders/ui/admin/version.json        Cache-Control: no-cache; { "commitSha": "<sha>" }
-kin<hash>/ui/prod/orders/ui/admin/<sha>/assets/…      Cache-Control: public, max-age=31536000, immutable
+kin<hash>/sites/prod/orders/ui/admin/index.html          Cache-Control: no-cache; uploaded last: the atomic switch
+kin<hash>/sites/prod/orders/ui/admin/version.json        Cache-Control: no-cache; { "commitSha": "<sha>" }
+kin<hash>/sites/prod/orders/ui/admin/<sha>/assets/…      Cache-Control: public, max-age=31536000, immutable
 ```
 
 `prod` is one constant in the prefix builder; nothing else knows the environment. The
@@ -132,7 +133,7 @@ Per site, created on first publish: a custom domain `<label>.<sitesDomain>` with
 certificate; DNS in the `kinotic.ai` zone, `CNAME <label>.apps → <profile endpoint host>` and
 `TXT _dnsauth.<label>.apps → <validation token>`; and a route for that domain with pattern
 `/*`, HTTPS only with redirect, the organization's origin group, origin path
-`/ui/prod/<app>/ui/<ui>`, the organization's rule set, caching on and query strings ignored.
+`/sites/prod/<app>/ui/<ui>`, the organization's rule set, caching on and query strings ignored.
 The SAS is signed with the account key (`OrganizationStorageService.issueReadToken`) and
 lasts ten years; each rule is written once, with the organization, and nothing writes it
 again yet, so a rotated account key has no path back into the rule set. Front Door writes are slow, serialized per profile, and answer 409 when one is in
@@ -169,7 +170,7 @@ The publish workload is named `project-ui-publish-<projectId>`, with id
 `DeployTarget.uiPublishWorkloadId` decided in `resolveTarget` like `syncWorkloadId`. It runs
 the same image in the foreground with entrypoint `bun src/publish-ui.ts`, the checkout mounted
 read-only at `/workspace`, env `KINOTIC_UI_COMMIT`, and the secret `KINOTIC_UI_UPLOAD_URL` =
-`<blob endpoint>/ui/prod/<app>/ui?<container SAS, create+write, TTL the run>`. Its allowed
+`<blob endpoint>/sites/prod/<app>/ui?<container SAS, create+write, TTL the run>`. Its allowed
 hosts are the hostname of the organization's `storage.azureBlobEndpoint` only, which the
 platform network resolves to the account's private endpoint; it carries no Kinotic
 credentials and no machine identity, is kept after its run, and is retired by the next run's
@@ -235,7 +236,7 @@ notification of publishes, and service endpoints instead of private endpoints.
   `DeploymentOperationsProxy`, and the portal's deployment page: a microservices table with logs, restart and remove, and the
   machines labelled by the deployment that records them.
 - **Organization storage.** `AzureOrganizationStorageProvisioner` creates the account, the
-  `ui` container, and, unless `disablePrivateEndpoint` is set, the private endpoint with its
+  `sites` container, and, unless `disablePrivateEndpoint` is set, the private endpoint with its
   DNS zone group, recording the outcome on
   `Organization` with a status of `PROVISIONING`, `READY` or `FAILED`. It is the first task
   of the `provision-organization-<id>` job that `DeploymentOperationsService` runs on the


### PR DESCRIPTION
## Summary

The first real organization provisioning got past the storage account and failed creating its container:

```
Status code 400, OutOfRangeInput: The specified resource name length is not within the permissible limits.
```

Azure blob container names are 3 to 63 characters, and the container was named `ui`. Azurite never checked, so development and the tests never saw it. The container is named in one constant, now `sites`, with a note on the constraint:

```java
// kinotic-system-api/.../api/services/OrganizationStorageProvisioner.java
/** The one container in an organization's account that its deployments publish UIs into. */
// container names are 3 to 63 characters, which rules out "ui"; Azurite does not check
String UI_CONTAINER = "sites";
```

Everything that names the container reads the constant: the provisioners, the storage service, the Front Door origin path. The workload-runner's publish test and the design doc's layout follow (`kin<hash>/sites/prod/<app>/ui/<name>/...`).

An organization that failed on this resumes at the account it already created: **Provision again** creates the `sites` container and continues.

Also carried: the `.env.local` write from the dev terraform root now lands as a commented block after a blank line, replacing the block a previous apply wrote, instead of bare lines appended at the end. The script is among the resource's triggers, so the next `terraform apply` rewrites the file with the same values.

## Verification

- `:kinotic-system-api:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZo7VFb5umbA2xP2MwmSGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZo7VFb5umbA2xP2MwmSGW)_