### PR TITLE
Fix the asset rewrite destination and test provisioning against Azure from a unit test

### DIFF
--- a/deployment/terraform/azure/dev/README.md
+++ b/deployment/terraform/azure/dev/README.md
@@ -51,6 +51,20 @@ The last command writes the `local` Spring profile, gitignored, which turns both
 on and names the resources above. `.env.local` at the repository root now carries the
 principal's credentials; if the file existed, its other lines are untouched.
 
+## Checking the setup
+
+Provision a fixed organization and one site from a test, before starting the server. It
+reads `application-local.yml`, takes the principal from `.env.local`, and reads back from Azure
+what each step created, so whatever Azure rejects fails naming the call:
+
+```bash
+cd ../../../..
+./gradlew :kinotic-system-api:test --tests '*AzureProvisioningIntegrationTest*'
+```
+
+It creates the storage account of `kinotic-azure-it` in the resource group and the site
+`azure-it.apps-<environment>.kinotic.ai`, and leaves them, so a second run is quick.
+
 ## Running the server
 
 Start kinotic-server with `.env.local` in its environment and both profiles active:

--- a/kinotic-system-api/build.gradle
+++ b/kinotic-system-api/build.gradle
@@ -31,3 +31,15 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'tools.jackson.core:jackson-databind'
 }
+
+// A developer's .env.local (written by deployment/terraform/azure/dev) carries the service
+// principal AzureProvisioningIntegrationTest runs as; without it the test skips itself
+tasks.named('test') {
+    def envLocal = rootProject.file('.env.local')
+    if (envLocal.exists()) {
+        envLocal.readLines().findAll { it ==~ /^[A-Z_][A-Z0-9_]*=.*/ }.each { line ->
+            def (key, value) = line.split('=', 2)
+            environment key, value
+        }
+    }
+}

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/FrontDoorUiDeploymentProvisioner.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/FrontDoorUiDeploymentProvisioner.java
@@ -68,7 +68,7 @@ import java.util.function.Supplier;
  * {@code <label>.<sitesDomain>}. What an organization's sites share is created with the
  * organization, once its storage is ready: an origin group on the storage account and a rule
  * set that routes requests naming a file to that file and everything else to
- * {@code index.html}, each with a read-only SAS on the {@code ui} container. Every site gets a custom domain with a managed
+ * {@code index.html}, each with a read-only SAS on the {@code sites} container. Every site gets a custom domain with a managed
  * certificate, its CNAME and validation TXT records in the platform's DNS zone, and a route
  * from its domain to the UI's prefix in the container. A site is provisioning until Front
  * Door has validated its hostname and deployed its certificate, which the provisioner keeps
@@ -272,6 +272,8 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
      */
     private static RuleInner rule(String name, String token) {
         boolean spa = SPA_RULE.equals(name);
+        // Front Door validates the destination as a literal that must begin with "/", and the
+        // url_path server variable expands without its leading slash
         return new RuleInner()
                 .withOrder(spa ? 2 : 1)
                 .withConditions(List.of(new DeliveryRuleUrlFileExtensionCondition()
@@ -282,7 +284,7 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
                 .withActions(List.of(new UrlRewriteAction()
                         .withParameters(new UrlRewriteActionParameters()
                                 .withSourcePattern("/")
-                                .withDestination((spa ? "/index.html" : "{url_path}") + "?" + token)
+                                .withDestination((spa ? "/index.html" : "/{url_path}") + "?" + token)
                                 .withPreserveUnmatchedPath(false))))
                 .withMatchProcessingBehavior(MatchProcessingBehavior.STOP);
     }

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/AzureProvisioningIntegrationTest.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/AzureProvisioningIntegrationTest.java
@@ -1,0 +1,273 @@
+package org.kinotic.system.internal.api.services;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.management.AzureEnvironment;
+import com.azure.core.management.profile.AzureProfile;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.resourcemanager.cdn.CdnManager;
+import com.azure.resourcemanager.cdn.fluent.CdnManagementClient;
+import com.azure.resourcemanager.cdn.fluent.models.AfdDomainInner;
+import com.azure.resourcemanager.cdn.fluent.models.AfdEndpointInner;
+import com.azure.resourcemanager.cdn.fluent.models.RouteInner;
+import com.azure.resourcemanager.cdn.fluent.models.RuleInner;
+import com.azure.resourcemanager.cdn.models.UrlRewriteAction;
+import com.azure.resourcemanager.dns.DnsZoneManager;
+import com.azure.resourcemanager.dns.models.CnameRecordSet;
+import com.azure.resourcemanager.dns.models.DnsZone;
+import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
+import com.azure.resourcemanager.storage.StorageManager;
+import com.azure.resourcemanager.storage.models.BlobContainer;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
+import org.kinotic.domain.api.model.DeploymentStatus;
+import org.kinotic.domain.api.model.DeploymentStatusType;
+import org.kinotic.domain.api.model.Organization;
+import org.kinotic.domain.api.model.OrganizationStorage;
+import org.kinotic.management.api.model.UiDeployment;
+import org.kinotic.system.api.config.KinoticSystemApiProperties;
+import org.kinotic.system.api.config.OrganizationStorageProperties;
+import org.kinotic.system.api.config.UiDeploymentProperties;
+import org.kinotic.system.api.services.OrganizationStorageProvisioner;
+import org.kinotic.system.api.services.UiStoragePaths;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Provisions one organization and one site against a real Azure subscription, the way the
+ * provisioning job and a deployment do, and reads back what Azure holds. Runs only on a
+ * developer machine set up as the contributing guide describes: the {@code local} profile in
+ * {@code kinotic-server/src/main/resources/application-local.yml} names the subscription,
+ * resource group, Front Door profile and DNS zone, and the service principal's
+ * {@code AZURE_*} variables are in the environment, which the module's test task takes from
+ * {@code .env.local}. Skipped everywhere else. Everything it creates is idempotent and left in
+ * place, so a second run reads through what the first created.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AzureProvisioningIntegrationTest {
+
+    private static final Path LOCAL_PROFILE = Path.of("..", "kinotic-server", "src", "main", "resources", "application-local.yml");
+    private static final String ORGANIZATION_ID = "kinotic-azure-it";
+    private static final String APPLICATION_ID = "azure-it-app";
+    private static final String PROJECT_ID = "azure-it-project";
+    private static final String UI_NAME = "web";
+    private static final String SITE_LABEL = "azure-it";
+    /** A storage account or a Front Door write takes minutes; a step past this is stuck. */
+    private static final long STEP_TIMEOUT_MINUTES = 15;
+
+    private Vertx vertx;
+    private KinoticSystemApiProperties properties;
+    private TokenCredential credential;
+    private AzureOrganizationStorageProvisioner storageProvisioner;
+    private FrontDoorUiDeploymentProvisioner siteProvisioner;
+    private Organization organization;
+
+    @BeforeAll
+    void requireAzure() throws IOException {
+        assumeTrue(Files.exists(LOCAL_PROFILE), "no " + LOCAL_PROFILE + ": not a developer machine set up for Azure");
+        assumeTrue(System.getenv("AZURE_CLIENT_ID") != null, "AZURE_CLIENT_ID is not set: .env.local is not in the environment");
+        properties = load(LOCAL_PROFILE);
+        assumeFalse(storageProperties().isDisableProvisioner(), "the local profile disables the storage provisioner");
+        assumeFalse(uiProperties().isDisableProvisioner(), "the local profile disables the site provisioner");
+
+        vertx = Vertx.vertx();
+        credential = new DefaultAzureCredentialBuilder().build();
+        StubOrganizationService organizations = new StubOrganizationService();
+        organizations.saved.put(ORGANIZATION_ID, new Organization().setId(ORGANIZATION_ID)
+                                                                   .setName("Azure integration test")
+                                                                   .setCreated(new Date()));
+        storageProvisioner = new AzureOrganizationStorageProvisioner(organizations, vertx, properties);
+        siteProvisioner = new FrontDoorUiDeploymentProvisioner(vertx, properties,
+                                                               new AzureOrganizationStorageService(vertx, properties),
+                                                               new StubUiDeploymentRepository());
+    }
+
+    @AfterAll
+    void close() {
+        if (vertx != null) {
+            vertx.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    @Timeout(value = STEP_TIMEOUT_MINUTES, unit = TimeUnit.MINUTES)
+    void provisionsTheStorageAccount() {
+        organization = await(storageProvisioner.ensureStorage(ORGANIZATION_ID));
+
+        OrganizationStorage storage = organization.getStorage();
+        assertEquals(DeploymentStatusType.READY, storage.getStatus().type(), storage.getStatus().message());
+        assertTrue(storage.getAzureBlobEndpoint().startsWith("https://"), storage.getAzureBlobEndpoint());
+
+        StorageManager storageManager = StorageManager.authenticate(credential, profileOf(storage.getAzureSubscriptionId()));
+        BlobContainer container = storageManager.blobContainers().get(storageProperties().getResourceGroup(),
+                                                                      storage.getAzureAccountName(),
+                                                                      OrganizationStorageProvisioner.UI_CONTAINER);
+        assertNotNull(container, "the " + OrganizationStorageProvisioner.UI_CONTAINER + " container exists");
+    }
+
+    @Test
+    @Order(2)
+    @Timeout(value = STEP_TIMEOUT_MINUTES, unit = TimeUnit.MINUTES)
+    void preparesFrontDoorForTheOrganization() {
+        assumeTrue(organization != null, "the storage step did not complete");
+
+        await(siteProvisioner.prepareOrganization(organization));
+
+        CdnManagementClient cdn = cdnClient();
+        assertNotNull(cdn.getAfdOriginGroups().get(resourceGroup(), profileName(), "org-" + ORGANIZATION_ID),
+                      "the organization's origin group exists");
+        String ruleSet = "org" + ORGANIZATION_ID.replace("-", "");
+        for (String name : List.of("asset", "spa")) {
+            RuleInner rule = cdn.getRules().get(resourceGroup(), profileName(), ruleSet, name);
+            UrlRewriteAction rewrite = (UrlRewriteAction) rule.actions().getFirst();
+            String destination = rewrite.parameters().destination();
+            assertTrue(destination.startsWith("/"), name + " rule rewrites to " + destination);
+            assertTrue(destination.contains("sig="), name + " rule carries the SAS: " + destination);
+        }
+    }
+
+    @Test
+    @Order(3)
+    @Timeout(value = STEP_TIMEOUT_MINUTES, unit = TimeUnit.MINUTES)
+    void provisionsASite() {
+        assumeTrue(organization != null, "the storage step did not complete");
+        UiDeployment deployment = new UiDeployment().setId(SITE_LABEL)
+                                                    .setOrganizationId(ORGANIZATION_ID)
+                                                    .setApplicationId(APPLICATION_ID)
+                                                    .setProjectId(PROJECT_ID)
+                                                    .setName(UI_NAME)
+                                                    .setCommitSha("0000000000000000000000000000000000000000")
+                                                    .setStatus(new DeploymentStatus(DeploymentStatusType.PROVISIONING))
+                                                    .setCreated(new Date())
+                                                    .setUpdated(new Date());
+
+        UiDeployment provisioned = await(siteProvisioner.provision(deployment, organization));
+
+        // ready only once Front Door has validated the hostname, which takes minutes; provisioning is the expected first answer
+        assertNotEquals(DeploymentStatusType.FAILED, provisioned.getStatus().type(), provisioned.getStatus().message());
+
+        String hostname = uiProperties().resolveHostname(SITE_LABEL);
+        CdnManagementClient cdn = cdnClient();
+        AfdDomainInner domain = cdn.getAfdCustomDomains().get(resourceGroup(), profileName(), SITE_LABEL);
+        assertEquals(hostname, domain.hostname());
+        RouteInner route = cdn.getRoutes().get(resourceGroup(), profileName(), endpointName(cdn), SITE_LABEL);
+        assertEquals("/" + OrganizationStorageProvisioner.UI_CONTAINER + "/" + UiStoragePaths.uiPrefix(APPLICATION_ID, UI_NAME),
+                     route.originPath());
+
+        DnsZone zone = DnsZoneManager.authenticate(credential, profileOf(ResourceId.fromString(uiProperties().getDnsZoneId()).subscriptionId()))
+                                     .zones()
+                                     .getById(uiProperties().getDnsZoneId());
+        String suffix = recordSuffix(uiProperties().getSitesDomain(), zone.name());
+        CnameRecordSet cname = zone.cNameRecordSets().getByName(SITE_LABEL + suffix);
+        assertEquals(uiProperties().getFrontDoorEndpointHostName().toLowerCase(), cname.canonicalName().toLowerCase());
+        assertNotNull(zone.txtRecordSets().getByName("_dnsauth." + SITE_LABEL + suffix), "the validation TXT record exists");
+    }
+
+    private <T> T await(Future<T> future) {
+        T ret = null;
+        try {
+            ret = future.toCompletionStage().toCompletableFuture().get(STEP_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+        } catch (ExecutionException e) {
+            fail(e.getCause().getMessage(), e.getCause());
+        } catch (Exception e) {
+            fail(e);
+        }
+        return ret;
+    }
+
+    private OrganizationStorageProperties storageProperties() {
+        return properties.getSystemApi().getOrganizationStorage();
+    }
+
+    private UiDeploymentProperties uiProperties() {
+        return properties.getSystemApi().getUiDeployment();
+    }
+
+    private String resourceGroup() {
+        return ResourceId.fromString(uiProperties().getFrontDoorProfileId()).resourceGroupName();
+    }
+
+    private String profileName() {
+        return ResourceId.fromString(uiProperties().getFrontDoorProfileId()).name();
+    }
+
+    private CdnManagementClient cdnClient() {
+        return CdnManager.authenticate(credential, profileOf(ResourceId.fromString(uiProperties().getFrontDoorProfileId()).subscriptionId()))
+                         .serviceClient();
+    }
+
+    private String endpointName(CdnManagementClient cdn) {
+        String host = uiProperties().getFrontDoorEndpointHostName();
+        return cdn.getAfdEndpoints().listByProfile(resourceGroup(), profileName()).stream()
+                  .filter(endpoint -> host.equalsIgnoreCase(endpoint.hostname()))
+                  .map(AfdEndpointInner::name)
+                  .findFirst()
+                  .orElseThrow(() -> new AssertionError("Front Door profile " + profileName() + " has no endpoint with host name " + host));
+    }
+
+    private static AzureProfile profileOf(String subscriptionId) {
+        return new AzureProfile(null, subscriptionId, AzureEnvironment.AZURE);
+    }
+
+    /** The sites domain relative to the zone, as the provisioner names records: {@code .apps-local} for {@code apps-local.kinotic.ai}. */
+    private static String recordSuffix(String sitesDomain, String zoneName) {
+        return sitesDomain.equalsIgnoreCase(zoneName)
+                ? ""
+                : "." + sitesDomain.substring(0, sitesDomain.length() - zoneName.length() - 1);
+    }
+
+    /** Binds the two property blocks the provisioners read from the local profile's YAML. */
+    @SuppressWarnings("unchecked")
+    private static KinoticSystemApiProperties load(Path localProfile) throws IOException {
+        Map<String, Object> yaml;
+        try (Reader reader = Files.newBufferedReader(localProfile)) {
+            yaml = new Yaml().load(reader);
+        }
+        Map<String, Object> systemApi = (Map<String, Object>) ((Map<String, Object>) yaml.get("kinotic")).get("systemApi");
+        Map<String, Object> storage = (Map<String, Object>) systemApi.get("organizationStorage");
+        Map<String, Object> sites = (Map<String, Object>) systemApi.get("uiDeployment");
+
+        KinoticSystemApiProperties ret = new KinoticSystemApiProperties();
+        ret.getSystemApi().getOrganizationStorage()
+           .setDisableProvisioner(Boolean.TRUE.equals(storage.get("disableProvisioner")))
+           // the development profile turns private endpoints off for every developer machine; the local profile inherits that
+           .setDisablePrivateEndpoint(!Boolean.FALSE.equals(storage.get("disablePrivateEndpoint")))
+           .setSubscriptionIds((List<String>) storage.get("subscriptionIds"))
+           .setResourceGroup((String) storage.get("resourceGroup"))
+           .setLocation((String) storage.get("location"));
+        ret.getSystemApi().getUiDeployment()
+           .setDisableProvisioner(Boolean.TRUE.equals(sites.get("disableProvisioner")))
+           .setSitesDomain((String) sites.get("sitesDomain"))
+           .setDnsZoneId((String) sites.get("dnsZoneId"))
+           .setFrontDoorProfileId((String) sites.get("frontDoorProfileId"))
+           .setFrontDoorEndpointHostName((String) sites.get("frontDoorEndpointHostName"));
+        return ret;
+    }
+
+}

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubOrganizationService.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubOrganizationService.java
@@ -1,0 +1,82 @@
+package org.kinotic.system.internal.api.services;
+
+import io.vertx.core.Future;
+import org.kinotic.core.api.crud.Page;
+import org.kinotic.core.api.crud.Pageable;
+import org.kinotic.domain.api.model.Organization;
+import org.kinotic.domain.api.services.OrganizationService;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * In-memory stand-in for the Elasticsearch backed {@link OrganizationService}: what the
+ * provisioners save is read back from {@link #saved}.
+ */
+public class StubOrganizationService implements OrganizationService {
+
+    public final Map<String, Organization> saved = new LinkedHashMap<>();
+
+    @Override
+    public Future<Organization> save(Organization entity) {
+        saved.put(entity.getId(), entity);
+        return Future.succeededFuture(entity);
+    }
+
+    @Override
+    public Future<Organization> saveSync(Organization entity) {
+        return save(entity);
+    }
+
+    @Override
+    public Future<Organization> create(Organization entity) {
+        return save(entity);
+    }
+
+    @Override
+    public Future<Organization> createSync(Organization entity) {
+        return save(entity);
+    }
+
+    @Override
+    public Future<Organization> findById(String id) {
+        return Future.succeededFuture(saved.get(id));
+    }
+
+    @Override
+    public Future<Long> count() {
+        return Future.succeededFuture((long) saved.size());
+    }
+
+    @Override
+    public Future<Void> deleteById(String id) {
+        saved.remove(id);
+        return Future.succeededFuture();
+    }
+
+    @Override
+    public Future<Void> deleteByIdSync(String id) {
+        return deleteById(id);
+    }
+
+    @Override
+    public Future<Page<Organization>> findAll(Pageable pageable) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Future<Page<Organization>> search(String searchText, Pageable pageable) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Future<Void> syncIndex() {
+        return Future.succeededFuture();
+    }
+
+    @Override
+    public Future<Organization> provision(String organizationId) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubUiDeploymentRepository.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubUiDeploymentRepository.java
@@ -1,0 +1,44 @@
+package org.kinotic.system.internal.api.services;
+
+import io.vertx.core.Future;
+import org.kinotic.management.api.model.UiDeployment;
+import org.kinotic.management.api.repositories.UiDeploymentRepository;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory stand-in for the Elasticsearch backed {@link UiDeploymentRepository}; what is
+ * saved is read back from {@link #saved}.
+ */
+public class StubUiDeploymentRepository extends UiDeploymentRepository {
+
+    public final Map<String, UiDeployment> saved = new LinkedHashMap<>();
+
+    public StubUiDeploymentRepository() {
+        super(null);
+    }
+
+    @Override
+    public Future<UiDeployment> findById(String id) {
+        return Future.succeededFuture(saved.get(id));
+    }
+
+    @Override
+    public Future<UiDeployment> save(UiDeployment value) {
+        saved.put(value.getId(), value);
+        return Future.succeededFuture(value);
+    }
+
+    @Override
+    public Future<UiDeployment> saveSync(UiDeployment value) {
+        return save(value);
+    }
+
+    @Override
+    public Future<List<UiDeployment>> findAllForProject(String projectId) {
+        return Future.succeededFuture(saved.values().stream().filter(row -> projectId.equals(row.getProjectId())).toList());
+    }
+
+}

--- a/website/content/02.platform/09.contributing.md
+++ b/website/content/02.platform/09.contributing.md
@@ -105,6 +105,20 @@ a developer machine is outside any platform VNet, so the server and the publish 
 each storage account over its public endpoint, and the workload's egress allowlist names that
 host.
 
+Before involving the server, run the provisioning against your subscription as a test. It
+does what the provisioning job and a deployment do, for a fixed organization `kinotic-azure-it`
+and a site `azure-it.apps-<environment>.<zone>`, and reads back from Azure what each step
+created, so a step Azure rejects fails naming the call:
+
+```bash
+./gradlew :kinotic-system-api:test --tests '*AzureProvisioningIntegrationTest*'
+```
+
+The module's test task puts `.env.local` in the test's environment, and the test reads your
+`application-local.yml`; without either it skips. What it creates is left in place, so a second
+run is quick, and `terraform destroy` removes the account with the resource group; the site's
+records under `apps-<environment>` in the zone are removed by hand.
+
 Then sign up an organization, or open an existing one in the system console and choose
 **Provision again**: the `provision-organization-<id>` job creates its storage account and
 prepares its Front Door origin group and rule set, and the organization's overview shows the

--- a/website/content/02.platform/11.reference/03.project-publishing-design.md
+++ b/website/content/02.platform/11.reference/03.project-publishing-design.md
@@ -243,10 +243,11 @@ notification of publishes, and service endpoints instead of private endpoints.
   system server when the organization is created, asked through the proxy by
   `DefaultOrganizationProvisioner`, the management module's `OrganizationProvisioner`, and
   whenever the system console's **Provision again** asks; the Front Door preparation is the
-  second. The provisioners, the storage service and their settings live in system-api. A deployment that publishes a UI reads the outcome and fails when the storage is
-  not ready.
-  `MockOrganizationStorageProvisioner` points every
-  organization at Azurite. Terraform owns the resource group, private-endpoints subnet, private DNS zone and the
+  second. The provisioners, the storage service and their settings live in system-api. A
+  deployment that publishes a UI reads the outcome and fails when the storage is not ready.
+  `AzureProvisioningIntegrationTest` in system-api runs both provisioners against a
+  developer's subscription, from the `local` profile and `.env.local`, and skips elsewhere.
+  `MockOrganizationStorageProvisioner` points every organization at Azurite. Terraform owns the resource group, private-endpoints subnet, private DNS zone and the
   kinotic-server roles. The account's public network stays open, with anonymous access off,
   so Front Door can read it; the platform comes in through the private endpoint, or over the
   public endpoint where it has none. A developer runs the real path against their own


### PR DESCRIPTION
## Summary

The "Prepare Front Door" task failed on the organization's rule set:

```
Status code 400, BadRequest: Destination must always start with '/' and be a single line. The max length of Destination is 260.
```

Front Door validates a URL rewrite destination as a literal that must begin with `/`, and `{url_path}` expands without its leading slash, so the asset rule's destination gains one:

```java
// FrontDoorUiDeploymentProvisioner.rule
.withDestination((spa ? "/index.html" : "/{url_path}") + "?" + token)   // was "{url_path}?<sas>" for the asset rule
```

### Provisioning as a test, not a browser

`AzureProvisioningIntegrationTest` in `kinotic-system-api` does what the provisioning job and a deployment do, against a real subscription, and reads each step back through the SDK:

1. `ensureStorage` for a fixed organization `kinotic-azure-it`: status `READY`, the `sites` container exists.
2. `prepareOrganization`: the origin group exists; both rewrite rules exist with a destination that begins with `/` and carries the SAS.
3. `provision` for one site `azure-it`: not `FAILED`; the custom domain has the expected hostname; the route's origin path is `/sites/prod/<app>/ui/<name>`; the CNAME points at the profile's endpoint and the `_dnsauth` TXT exists.

It binds the two property blocks from the developer's `application-local.yml` and runs as the principal in `.env.local`, which the module's test task now puts in the test environment:

```groovy
// kinotic-system-api/build.gradle
tasks.named('test') {
    def envLocal = rootProject.file('.env.local')
    if (envLocal.exists()) { ... environment key, value ... }
}
```

Without either file the test skips itself (three skips here, where neither exists), so CI pays nothing. Everything it creates is idempotent and left in place, so a second run is a read-through. Two in-memory stubs stand in for the organization service and the UI deployment repository, the only collaborators that are not Azure.

```bash
./gradlew :kinotic-system-api:test --tests '*AzureProvisioningIntegrationTest*'
```

A step Azure rejects fails naming the call, which is the loop to iterate on from a local session instead of Provision again in the console.

The contributing guide, the dev root README and the design doc describe the test.

## Verification

- `:kinotic-system-api:test` passes; the integration test reports skipped in an environment without the local profile
- Not run against Azure from here; the first run on a developer machine is the real check, and the point of the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZo7VFb5umbA2xP2MwmSGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZo7VFb5umbA2xP2MwmSGW)_