### PR TITLE
Portal polish: table loading line, deployment failure spacing, run durations

### DIFF
--- a/kinotic-frontend/apps/portal/src/pages/ProjectDeploymentPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ProjectDeploymentPage.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col">
     <PageHeader title="Deployment" />
 
-    <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>
+    <Message v-if="error" severity="error" :closable="false" class="mb-4">{{ error }}</Message>
 
     <div v-if="!loading && !deployment" class="p-6 text-sm text-muted-color">
       This project has never been deployed. Pushing to its repository's default branch deploys it.
@@ -19,7 +19,7 @@
       </div>
 
       <Message v-if="deployment.status.type === StatusType.FAILED && deployment.status.message"
-               severity="error" :closable="false">{{ deployment.status.message }}</Message>
+               severity="error" :closable="false" class="mb-4">{{ deployment.status.message }}</Message>
 
       <JobRunProgress v-if="deployment.lastJobRunId"
                       :key="deployment.lastJobRunId"

--- a/kinotic-frontend/packages/common/src/components/CrudTable.vue
+++ b/kinotic-frontend/packages/common/src/components/CrudTable.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { useRoute } from "vue-router";
+import "../styles/datatable-loading.css";
 
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
@@ -527,7 +528,7 @@ defineExpose({ find });
           <DataTable
             :class="[
               'crud-table__datatable',
-              { 'crud-table__datatable--loading': loading },
+              { 'datatable-loading': loading },
               displayRows.length > 0 ? 'min-h-0 flex-1' : ''
             ]"
             :pt="dataTablePt"
@@ -622,33 +623,6 @@ defineExpose({ find });
 </template>
 
 <style>
-/* While loading, an indeterminate line overlays the header row's bottom divider. */
-.crud-table__datatable--loading .p-datatable-thead {
-  position: relative;
-}
-
-.crud-table__datatable--loading .p-datatable-thead::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 3px;
-  background: linear-gradient(90deg, transparent, var(--p-primary-500), transparent);
-  background-size: 40% 100%;
-  background-repeat: no-repeat;
-  animation: crud-table-loading-slide 1.2s ease-in-out infinite;
-}
-
-@keyframes crud-table-loading-slide {
-  0% {
-    background-position: -100% 0;
-  }
-  100% {
-    background-position: 200% 0;
-  }
-}
-
 .p-datatable-paginator-bottom {
   border: none !important;
   box-shadow: none !important;

--- a/kinotic-frontend/packages/common/src/components/telemetry/TraceSearch.vue
+++ b/kinotic-frontend/packages/common/src/components/telemetry/TraceSearch.vue
@@ -25,15 +25,14 @@
 
     <DataTable
       :value="traces"
-      :loading="loading"
       dataKey="traceId"
       size="small"
       selectionMode="single"
-      class="text-sm"
+      :class="['text-sm', { 'datatable-loading': loading }]"
       @row-select="openTrace($event.data)"
     >
       <template #empty>
-        <div class="py-6 text-center text-sm text-muted-color">No traces match in this range</div>
+        <div class="py-6 text-center text-sm text-muted-color">{{ loading ? 'Searching traces…' : 'No traces match in this range' }}</div>
       </template>
       <Column header="Started" style="width: 12rem">
         <template #body="{ data }">
@@ -71,6 +70,7 @@ import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
 import Message from 'primevue/message'
 
+import '../../styles/datatable-loading.css'
 import DatetimeUtil from '../../util/DatetimeUtil'
 import { errorMessage } from '../../util/helpers'
 import TraceDetail from './TraceDetail.vue'

--- a/kinotic-frontend/packages/common/src/styles/datatable-loading.css
+++ b/kinotic-frontend/packages/common/src/styles/datatable-loading.css
@@ -1,0 +1,27 @@
+/* A DataTable that is loading: an indeterminate line runs along the header row's bottom divider,
+   in place of PrimeVue's mask over the rows, so the rows stay readable while the next page loads. */
+.datatable-loading .p-datatable-thead {
+  position: relative;
+}
+
+.datatable-loading .p-datatable-thead::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, var(--p-primary-500), transparent);
+  background-size: 40% 100%;
+  background-repeat: no-repeat;
+  animation: datatable-loading-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes datatable-loading-slide {
+  0% {
+    background-position: -100% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}

--- a/kinotic-frontend/packages/common/src/util/DatetimeUtil.ts
+++ b/kinotic-frontend/packages/common/src/util/DatetimeUtil.ts
@@ -43,15 +43,16 @@ public static formatEpochDate(epochMillis: number | null): string {
 }
 
 /**
- * Formats the elapsed time between two epoch timestamps, measuring against nowMs while
- * finished is absent. Returns an em dash when started is absent.
+ * Formats the elapsed time between two timestamps, measuring against nowMs while finished is
+ * absent. Returns an em dash when started is absent or unreadable.
  */
-public static formatDuration(started: number | null, finished: number | null, nowMs: number = Date.now()): string {
+public static formatDuration(started: number | string | Date | null, finished: number | string | Date | null, nowMs: number = Date.now()): string {
     let ret: string
-    if (!started) {
+    const startedMs = DatetimeUtil.toEpochMillis(started)
+    if (startedMs === null) {
         ret = '—'
     } else {
-        const totalSeconds = Math.max(0, Math.floor(((finished ?? nowMs) - started) / 1000))
+        const totalSeconds = Math.max(0, Math.floor(((DatetimeUtil.toEpochMillis(finished) ?? nowMs) - startedMs) / 1000))
         const hours = Math.floor(totalSeconds / 3600)
         const minutes = Math.floor((totalSeconds % 3600) / 60)
         const seconds = totalSeconds % 60
@@ -62,6 +63,18 @@ public static formatDuration(started: number | null, finished: number | null, no
         } else {
             ret = `${seconds}s`
         }
+    }
+    return ret
+}
+
+/** Epoch millis of a timestamp however it arrived (millis, a date string, a Date), or null when absent or unreadable. */
+private static toEpochMillis(value: number | string | Date | null): number | null {
+    let ret: number | null
+    if (!value) {
+        ret = null
+    } else {
+        const millis = new Date(value).getTime()
+        ret = isNaN(millis) ? null : millis
     }
     return ret
 }


### PR DESCRIPTION
Three small fixes to pages the navigation PR (#515) touched, each one visible in the portal.

## Trace search loading

`TraceSearch` handed PrimeVue its `loading` prop, which paints a grey mask and spinner over the rows, while every other table draws an indeterminate line under the header row (CrudTable's style). The line's rule moves out of `CrudTable.vue` into `packages/common/src/styles/datatable-loading.css`, imported by both components, and the trace table applies the same `datatable-loading` class while a search runs. The empty message reads "Searching traces…" until results arrive, since the rows are empty on the first search. The console's trace search gets the same treatment through the shared component.

## Deployment failure message

On the project's Deployment page the Message carrying a failed deployment's reason sat directly on the job run's header, so the reason and the run title read as one block. It gets the same bottom margin as the status row above it, and so does the page's load error.

## "Duration NaNs"

The same page rendered a run's duration as `NaNs`, in the run header and on every task row. `DatetimeUtil.formatDuration` subtracted the timestamps directly, which only works when both are numbers; the utility's other formatters already read a timestamp through `new Date()` whatever form it arrived in. `formatDuration` now does the same through a `toEpochMillis` helper, and an unreadable start renders the em dash it already used for a missing one. `JobRunsTable` benefits too.

## Verified

- `vue-tsc -b` for `kinotic-portal` and `kinotic-system-console`; `vite build` for the portal, with both the loading line and CrudTable's paginator rules present in the built CSS.
- Not verified at runtime: the portal needs a signed-in session against a backend, which the build environment does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA)_