### PR TITLE
Publish UIs to the storage the organization was provisioned in, not the dev Azurite

### DIFF
--- a/kinotic-js/vmm-r&d/boxlite-test/README.md
+++ b/kinotic-js/vmm-r&d/boxlite-test/README.md
@@ -6,7 +6,8 @@ scripts probing detach behavior, named-box reuse, and shared-volume semantics.
 **Verified against:** `@boxlite-ai/boxlite@0.9.5` (findings 1–4) and `0.9.7`
 (findings 5–8), Bun 1.3.10, macOS arm64 (`@boxlite-ai/boxlite-darwin-arm64`). Findings
 9–15 were verified on 0.9.7 under Bun 1.3.14 on an Azure `Standard_D4s_v3`
-(Ubuntu 22.04, kernel 6.8, KVM), since they need nested virtualization and XFS. The
+(Ubuntu 22.04, kernel 6.8, KVM), since they need nested virtualization and XFS. Finding 16
+was verified on `0.10.0`, which the project now pins, under Bun 1.3.10 on macOS arm64. The
 original detach bug was filed on Linux/WSL2; findings here reproduce cross-platform.
 Re-run the probes after a boxlite upgrade to confirm the findings still hold.
 
@@ -369,6 +370,60 @@ than refusing to run it.
 
 ---
 
+### 16. An allowlist naming a CNAME chain's head permits the chain; wildcards and bare addresses do not (`network-policy-test.ts`)
+
+`github.com` and `registry.npmjs.org` resolve directly, but an Azure storage account host is
+a CNAME chain — `<account>.blob.core.windows.net` → `blob.<cluster>.store.core.windows.net`
+→ address — so the question was whether an allowlist must name every link, or whether boxlite
+attributes the answer to the canonical name and refuses the head. Verified on 0.10.0, whose
+shim log names the mechanism (`allowNet: DNS sinkhole configured`, `allowNet TCP: handler
+overridden with SNI-inspecting forwarder`):
+
+```
+=== I. mode 'enabled', allowNet ['kin00aca0a5a87cfeb0a1f11.blob.core.windows.net'] — the head of the CNAME chain only ===
+  dns:kin00aca0a5a87cfeb0a1f11.blob.core.windows.net REACHED  exit=0  Name:	kin00aca0a5a87cfeb0a1f11.blob.core.windows.net | Address: 57.150.160.33
+  https://kin00aca0a5a87cfeb0a1f11.blob.core.windows.net/ REACHED  exit=1  wget: server returned error: HTTP/1.1 400 Value for one of the query parameters specified in the request URI is invalid.
+  https://blob.dsm41prdstr11a.store.core.windows.net/ blocked  exit=1  wget: can't connect to remote host (0.0.0.0): Connection refused
+
+=== I. mode 'enabled', allowNet ['kin00aca0a5a87cfeb0a1f11.blob.core.windows.net', 'blob.dsm41prdstr11a.store.core.windows.net'] — the whole chain ===
+  dns:kin00aca0a5a87cfeb0a1f11.blob.core.windows.net REACHED  exit=0  Non-authoritative answer:
+  https://kin00aca0a5a87cfeb0a1f11.blob.core.windows.net/ REACHED  exit=1  wget: server returned error: HTTP/1.1 400 Value for one of the query parameters specified in the request URI is invalid.
+  https://blob.dsm41prdstr11a.store.core.windows.net/ REACHED  exit=1  wget: server returned error: HTTP/1.1 400 The requested URI does not represent any resource on the server.
+
+=== I. mode 'enabled', allowNet ['*.blob.core.windows.net'] — a wildcard ===
+  dns:kin00aca0a5a87cfeb0a1f11.blob.core.windows.net blocked  exit=1  Non-authoritative answer: | *** Can't find kin00aca0a5a87cfeb0a1f11.blob.core.windows.net: Parse error
+  https://kin00aca0a5a87cfeb0a1f11.blob.core.windows.net/ blocked  exit=1  wget: bad address 'kin00aca0a5a87cfeb0a1f11.blob.core.windows.net'
+  https://blob.dsm41prdstr11a.store.core.windows.net/ blocked  exit=1  wget: can't connect to remote host (0.0.0.0): Connection refused
+
+=== I. mode 'enabled', allowNet ['57.150.160.33'] — the address alone ===
+  dns:kin00aca0a5a87cfeb0a1f11.blob.core.windows.net REACHED  exit=0  Non-authoritative answer:
+  https://kin00aca0a5a87cfeb0a1f11.blob.core.windows.net/ blocked  exit=1  wget: can't connect to remote host (0.0.0.0): Connection refused
+  https://blob.dsm41prdstr11a.store.core.windows.net/ blocked  exit=1  wget: can't connect to remote host (0.0.0.0): Connection refused
+```
+
+Naming the head alone is enough: the guest resolves it to the real address and the TLS
+connection completes (Azure's `400` on `GET /` is the reply of a reached server; busybox
+`wget` exits non-zero on it, which is why the verdict reads the stderr line). The canonical
+name is reachable only when it is listed itself, so what the guest can connect to is decided
+by the name it asked for — the one carried in the TLS SNI — rather than by the answer's
+canonical name. A wildcard is not understood: `*.blob.core.windows.net` breaks name
+resolution for the account host outright (`Parse error`), and it reaches nothing. The bare
+address lets the name resolve but the connection is still sinkholed to `0.0.0.0`, so an
+address entry does not stand in for the name it resolves from.
+
+**Design implication:** a publish workload's allowlist names exactly the host of the URL it
+uploads to, as the head of the chain, and nothing more; resolving the CNAME chain at deploy
+time would add nothing. Wildcards are not an option on boxlite, and neither is the address.
+
+Two 0.10.0 changes the probe had to absorb: `exec` no longer boots a configured box
+(`Cannot exec box …: it is configured, and starting the box would run its main command`),
+so a box is started explicitly with `runtime.get(name).start()` before the first exec; and
+the legacy `network: { mode, allowNet }` shape is still accepted as an alias of
+`network.outbound`. The other scripts in `src/` were written against implicit boot and were
+not re-run on 0.10.0.
+
+---
+
 ## Scripts (`src/`)
 
 | File | Purpose | Leaves a box running? |
@@ -385,7 +440,7 @@ than refusing to run it.
 | `console-log-test.ts` | Does `boxes/<id>/logs/console.log` capture entrypoint stdout/stderr live? (finding #7 — it does not; kernel/guest-agent output only.) | self-cleaning |
 | `console-output-discovery-test.ts` | Sweeps `$BOXLITE_HOME` for any file that receives entrypoint output. | self-cleaning |
 | `log-capture-gaps-test.ts` | Demonstrates every entrypoint/exec output-capture gap in one run (basis of the upstream stdio-capture feature request). | self-cleaning |
-| `network-policy-test.ts` | What `network: { mode, allowNet }` actually enforces: whether `disabled` blocks egress, whether an allowlist blocks unlisted hosts, and whether it can be bypassed by connecting to a raw IP. Needs ordinary outbound internet. | self-cleaning |
+| `network-policy-test.ts` | What `network: { mode, allowNet }` actually enforces: whether `disabled` blocks egress, whether an allowlist blocks unlisted hosts, whether it can be bypassed by connecting to a raw IP, and how a CNAME chain is matched (finding #16). Needs ordinary outbound internet. An optional label prefix runs a subset: `bun run src/network-policy-test.ts azure`. | self-cleaning |
 | `disk-quota-test.ts` | Whether a workload's disk can be bounded: `diskSizeGb` as a rootfs cap and whether a rootfs above 1 GiB survives being filled (phases A and D, run anywhere), and an XFS project quota on a bind-mounted host directory as a volume cap, including the write cost of the accounting (phases B and C, need Linux + root + `xfsprogs`). | self-cleaning |
 | `repro-disk-size.ts` | Standalone reproducer, free of any dependency but the SDK, sweeping `diskSizeGb` 1/2/4/8 with the same 1536 MiB write in each to show whether a fixed ceiling applies regardless of the disk requested. Written to be handed to the boxlite maintainers as-is. | self-cleaning |
 | `boot-failure-test.ts` | Isolates the two generic "failed to start" errors behind findings #9 and #10 — whether `mode: 'disabled'` is bootable at all, and whether the volume ceiling counts volumes only or a shared device budget that ports and a sized rootfs also draw on. Dumps the full error, which carries the shim trace. | self-cleaning |

--- a/kinotic-js/vmm-r&d/boxlite-test/bun.lock
+++ b/kinotic-js/vmm-r&d/boxlite-test/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "boxlite-test",
       "dependencies": {
-        "@boxlite-ai/boxlite": "^0.9.7",
+        "@boxlite-ai/boxlite": "^0.10.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -14,13 +14,13 @@
     },
   },
   "packages": {
-    "@boxlite-ai/boxlite": ["@boxlite-ai/boxlite@0.9.7", "", { "optionalDependencies": { "@boxlite-ai/boxlite-darwin-arm64": "0.9.7", "@boxlite-ai/boxlite-linux-arm64-gnu": "0.9.7", "@boxlite-ai/boxlite-linux-x64-gnu": "0.9.7" }, "peerDependencies": { "playwright-core": ">=1.58.0" }, "optionalPeers": ["playwright-core"] }, "sha512-Y/XdJV6c3U6EdesOE4w02wkwOWCvVyCM/ARhXsyM+JbfTl1AAxEFphUSvbV9IYpTEHsiQp2AYJBujl592h/cjg=="],
+    "@boxlite-ai/boxlite": ["@boxlite-ai/boxlite@0.10.0", "", { "optionalDependencies": { "@boxlite-ai/boxlite-darwin-arm64": "0.10.0", "@boxlite-ai/boxlite-linux-arm64-gnu": "0.10.0", "@boxlite-ai/boxlite-linux-x64-gnu": "0.10.0" }, "peerDependencies": { "playwright-core": ">=1.58.0" }, "optionalPeers": ["playwright-core"] }, "sha512-ZM6gswJtmmk49BHBhbu2w/h+RU+CTqccC7GZ24+kZ9zQ1UQHrQCJCkad0iC4dcfLVxbEbKp5xf+iy9HtT+t2ig=="],
 
-    "@boxlite-ai/boxlite-darwin-arm64": ["@boxlite-ai/boxlite-darwin-arm64@0.9.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-a9Yh7RAB2qRJaYS6SIHszL6Dg7rY3XT0SDHmshm9RF604GpOv/yjm+6iqsjQPhAEnx229SJqCABXXHOkLoDpfw=="],
+    "@boxlite-ai/boxlite-darwin-arm64": ["@boxlite-ai/boxlite-darwin-arm64@0.10.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vJ6c9WO6ThkzlMdESuXLZD+zZIJalM7pndCB7zTqzFqVIIBuY88VKp8U4RV7KyaclYUKCgTMAx5RFnhgXv/y1w=="],
 
-    "@boxlite-ai/boxlite-linux-arm64-gnu": ["@boxlite-ai/boxlite-linux-arm64-gnu@0.9.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-8fCL+vX4d0sW2t27oifswFbakJnHot9hhJ8D2aFvm0vyPMnPnGP1UqP/g7FL+7+zlhKNuafkMDqstLpDjHRA7w=="],
+    "@boxlite-ai/boxlite-linux-arm64-gnu": ["@boxlite-ai/boxlite-linux-arm64-gnu@0.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-YsaitH6c1jSY5itgMVAuNA7zX73ELC2hZQkX8buQoup5iDrfF5dtdV9nsFtY0JxRBIhDGHhbYScMbDL9aguCdw=="],
 
-    "@boxlite-ai/boxlite-linux-x64-gnu": ["@boxlite-ai/boxlite-linux-x64-gnu@0.9.7", "", { "os": "linux", "cpu": "x64" }, "sha512-4FtqDNKF63+JGDlxyILl9UyVX6xKzK5c0535ziv5ZU18LUBrgqFI3IGZQ8R9pCQ+g7sbcEVFMLG/f2DJJTtWaQ=="],
+    "@boxlite-ai/boxlite-linux-x64-gnu": ["@boxlite-ai/boxlite-linux-x64-gnu@0.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JihXFR726cRgQc0Sjf2JjpWSfvcK4Irn7kIHBCwgX65wgLALTUGa96w0rttJrVztMFf2iEPa3xndIbeAYmaMZg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 

--- a/kinotic-js/vmm-r&d/boxlite-test/package.json
+++ b/kinotic-js/vmm-r&d/boxlite-test/package.json
@@ -6,7 +6,7 @@
     "start": "bun run src/index.ts"
   },
   "dependencies": {
-    "@boxlite-ai/boxlite": "^0.9.7"
+    "@boxlite-ai/boxlite": "^0.10.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/kinotic-js/vmm-r&d/boxlite-test/src/network-policy-test.ts
+++ b/kinotic-js/vmm-r&d/boxlite-test/src/network-policy-test.ts
@@ -1,4 +1,5 @@
 import { SimpleBox, getJsBoxlite, type NetworkSpec } from "@boxlite-ai/boxlite";
+import { resolve4, resolveCname } from "node:dns/promises";
 
 // What does SimpleBoxOptions.network actually enforce? The kinotic vm-manager now sends a
 // policy on every box (Workload.network -> { mode, allowNet }) so that what a guest can
@@ -30,6 +31,13 @@ import { SimpleBox, getJsBoxlite, type NetworkSpec } from "@boxlite-ai/boxlite";
 //                               for a no-egress policy. Whether it boots and denies
 //                               everything decides if NetworkMode.DISABLED can be
 //                               implemented at all on 0.9.7.
+//  I. CNAME chain           — github.com and registry.npmjs.org resolve directly, but an
+//                               Azure storage account host is a CNAME chain
+//                               (<account>.blob.core.windows.net -> blob.<cluster>.store.
+//                               core.windows.net -> address). Does an allowlist naming the
+//                               head of the chain permit the connection, or does boxlite
+//                               attribute the answer to the canonical name? The variants
+//                               name the whole chain, a wildcard, and the bare address.
 //
 // Requires ordinary outbound internet from the host. Every box is removed in cleanup.
 
@@ -47,6 +55,10 @@ const BLOCKED_IP = "1.1.1.1";
 // the .invalid TLD (RFC 2606) is guaranteed never to resolve.
 const SINK_IP = "192.0.2.1";
 const SINK_HOST = "no-egress.invalid";
+// A storage account host whose answer is a CNAME chain. The canonical name and address are
+// resolved on the host at startup rather than pinned, since Azure moves them.
+const AZURE_HOST = "kin00aca0a5a87cfeb0a1f11.blob.core.windows.net";
+const AZURE_WILDCARD = "*.blob.core.windows.net";
 
 interface Probe {
     /** What the guest was asked to reach. */
@@ -72,7 +84,10 @@ async function removeIfPresent(name: string) {
  * guest could reach it. The entrypoint idles so the work runs through exec, whose exit
  * code and stderr are observable (unlike an entrypoint's, per finding #7).
  */
-async function probeEgress(label: string, network: NetworkSpec | undefined): Promise<{ dns: Probe; targets: Probe[] }> {
+async function probeEgress(label: string,
+                           network: NetworkSpec | undefined,
+                           lookupHost = BLOCKED_HOST,
+                           urls = [`http://${ALLOWED_HOST}`, `http://${BLOCKED_HOST}`, `http://${BLOCKED_IP}`]): Promise<{ dns: Probe; targets: Probe[] }> {
     const name = `net-${RUN}-${label}`;
     try {
         const box = new SimpleBox({
@@ -86,6 +101,8 @@ async function probeEgress(label: string, network: NetworkSpec | undefined): Pro
             ...(network !== undefined ? { network } : {}),
         });
         await box.getId();
+        // 0.10 creates the record only; exec no longer boots the VM as a side effect
+        await (await runtime.get(name))!.start();
 
         // Separating name resolution from the fetch shows whether the allowlist is
         // enforced at DNS or on the connection itself
@@ -93,16 +110,16 @@ async function probeEgress(label: string, network: NetworkSpec | undefined): Pro
         // status of the LAST command in a pipeline, so piping nslookup into tail would
         // always report tail's success and hide a failed lookup
         const lookup = await box.exec("sh", "-c",
-            `nslookup ${BLOCKED_HOST} >/tmp/dns.out 2>&1; echo "lookup-exit=$?"; tail -n 3 /tmp/dns.out`);
+            `nslookup ${lookupHost} >/tmp/dns.out 2>&1; echo "lookup-exit=$?"; tail -n 3 /tmp/dns.out`);
         const reported = lookup.stdout.match(/lookup-exit=(\d+)/);
         const dns: Probe = {
-            target: `dns:${BLOCKED_HOST}`,
+            target: `dns:${lookupHost}`,
             exitCode: reported ? Number(reported[1]) : -1,
             detail: lookup.stdout.replace(/lookup-exit=\d+/, "").trim().split("\n").filter(Boolean).join(" | "),
         };
 
         const targets: Probe[] = [];
-        for (const target of [`http://${ALLOWED_HOST}`, `http://${BLOCKED_HOST}`, `http://${BLOCKED_IP}`]) {
+        for (const target of urls) {
             // -T bounds a silent drop, which is how a blocked connection usually presents
             const result = await box.exec("sh", "-c", `wget -T 8 -q -O /dev/null ${target}`);
             targets.push({
@@ -117,8 +134,16 @@ async function probeEgress(label: string, network: NetworkSpec | undefined): Pro
     }
 }
 
+/**
+ * Whether the guest got through to the target. Azure answers GET / with a 4xx, on which
+ * busybox wget exits non-zero, so an HTTP error response counts: TLS and HTTP happened.
+ */
+function reachedTarget(probe: Probe | undefined): boolean {
+    return probe !== undefined && (probe.exitCode === 0 || /server returned error: HTTP/.test(probe.detail));
+}
+
 function render(probe: Probe): string {
-    const verdict = probe.exitCode === 0 ? "REACHED" : "blocked";
+    const verdict = reachedTarget(probe) ? "REACHED" : "blocked";
     return `${probe.target.padEnd(28)} ${verdict.padEnd(8)} exit=${probe.exitCode}${probe.detail ? `  ${probe.detail}` : ""}`;
 }
 
@@ -126,9 +151,13 @@ async function main() {
     const boxliteVersion = (await import("@boxlite-ai/boxlite/package.json")).default.version as string;
     console.log(`boxlite version : ${boxliteVersion}`);
     console.log(`Platform        : ${process.platform} (${process.arch})  runtime: Bun ${Bun.version}`);
-    console.log(`Allowed host    : ${ALLOWED_HOST}   blocked host: ${BLOCKED_HOST}   blocked ip: ${BLOCKED_IP}\n`);
+    console.log(`Allowed host    : ${ALLOWED_HOST}   blocked host: ${BLOCKED_HOST}   blocked ip: ${BLOCKED_IP}`);
+    const [azureCname] = await resolveCname(AZURE_HOST);
+    const [azureIp] = await resolve4(AZURE_HOST);
+    console.log(`Azure host      : ${AZURE_HOST} -> ${azureCname} -> ${azureIp}\n`);
+    const azureUrls = [`https://${AZURE_HOST}/`, `https://${azureCname}/`];
 
-    const cases: Array<{ label: string; description: string; network: NetworkSpec | undefined }> = [
+    const cases: Array<{ label: string; description: string; network: NetworkSpec | undefined; lookupHost?: string; urls?: string[] }> = [
         { label: "omitted", description: "E. network option omitted entirely", network: undefined },
         { label: "enabled", description: "B. mode 'enabled', no allowNet", network: { mode: "enabled" } },
         { label: "disabled", description: "A. mode 'disabled'", network: { mode: "disabled" } },
@@ -152,13 +181,46 @@ async function main() {
             description: `H. mode 'enabled', allowNet ['${SINK_HOST}'] — a name that cannot resolve`,
             network: { mode: "enabled", allowNet: [SINK_HOST] },
         },
+        {
+            label: "azure-head",
+            description: `I. mode 'enabled', allowNet ['${AZURE_HOST}'] — the head of the CNAME chain only`,
+            network: { mode: "enabled", allowNet: [AZURE_HOST] },
+            lookupHost: AZURE_HOST,
+            urls: azureUrls,
+        },
+        {
+            label: "azure-chain",
+            description: `I. mode 'enabled', allowNet ['${AZURE_HOST}', '${azureCname}'] — the whole chain`,
+            network: { mode: "enabled", allowNet: [AZURE_HOST, azureCname] },
+            lookupHost: AZURE_HOST,
+            urls: azureUrls,
+        },
+        {
+            label: "azure-wildcard",
+            description: `I. mode 'enabled', allowNet ['${AZURE_WILDCARD}'] — a wildcard`,
+            network: { mode: "enabled", allowNet: [AZURE_WILDCARD] },
+            lookupHost: AZURE_HOST,
+            urls: azureUrls,
+        },
+        {
+            label: "azure-ip",
+            description: `I. mode 'enabled', allowNet ['${azureIp}'] — the address alone`,
+            network: { mode: "enabled", allowNet: [azureIp] },
+            lookupHost: AZURE_HOST,
+            urls: azureUrls,
+        },
     ];
 
+    // An optional label prefix runs a subset, e.g. `azure` for the CNAME cases alone
+    const only = process.argv[2];
     const results = new Map<string, { dns: Probe; targets: Probe[] }>();
-    for (const { label, description, network } of cases) {
+    for (const { label, description, network, lookupHost, urls } of cases) {
+        if (only && !label.startsWith(only)) {
+            continue;
+        }
         console.log(`=== ${description} ===`);
         try {
-            const result = await probeEgress(label, network);
+            const result = await probeEgress(label, network, lookupHost, urls);
             results.set(label, result);
             console.log(`  ${render(result.dns)}`);
             for (const probe of result.targets) {
@@ -174,7 +236,7 @@ async function main() {
 
     console.log("=== REPORT ===");
     const reached = (label: string, target: string) =>
-        results.get(label)?.targets.find(p => p.target.includes(target))?.exitCode === 0;
+        reachedTarget(results.get(label)?.targets.find(p => p.target.includes(target)));
 
     const allowlist = results.get("allowlist");
     console.log(`(a) 'disabled' blocks egress:              ${answer(results.has("disabled"), !reached("disabled", ALLOWED_HOST) && !reached("disabled", BLOCKED_IP))}`);
@@ -190,7 +252,17 @@ async function main() {
     console.log(`(h) a reserved-IP allowlist denies all:     ${denies("sink-ip")}`);
     console.log(`(i) an unresolvable-name allowlist denies:  ${denies("sink-name")}`);
     console.log(`    (either YES is a usable no-egress policy, since a populated list is enforced)`);
+    console.log(`(j) naming the chain's head alone reaches:   ${answer(results.has("azure-head"), reached("azure-head", AZURE_HOST))}`);
+    console.log(`(k) naming the whole chain reaches:         ${answer(results.has("azure-chain"), reached("azure-chain", AZURE_HOST))}`);
+    console.log(`(l) a wildcard reaches:                     ${answer(results.has("azure-wildcard"), reached("azure-wildcard", AZURE_HOST))}`);
+    console.log(`(m) the address alone reaches:              ${answer(results.has("azure-ip"), reached("azure-ip", AZURE_HOST))}`);
     console.log(`\nDNS under the allowlist: ${allowlist ? render(allowlist.dns) : "(not run)"}`);
+    for (const label of ["azure-head", "azure-chain", "azure-wildcard", "azure-ip"]) {
+        const result = results.get(label);
+        if (result) {
+            console.log(`DNS under ${label.padEnd(15)}: ${render(result.dns)}`);
+        }
+    }
 }
 
 function answer(ran: boolean, condition: boolean): string {

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/config/OrganizationStorageProperties.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/config/OrganizationStorageProperties.java
@@ -74,7 +74,8 @@ public class OrganizationStorageProperties {
     private String privateDnsZoneId;
 
     /**
-     * Connection string of the Azurite the mock provisioner points every organization at.
+     * Connection string of the Azurite the mock provisioner points every organization at, and
+     * that organization storage is reached through, while {@link #disableProvisioner} is true.
      */
     private String azuriteConnectionString;
 

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageService.java
@@ -40,8 +40,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Blob-SDK backed {@link OrganizationStorageService}. Reaches each organization's account at
  * its recorded blob endpoint as the server's Azure identity, which signs upload URLs with a
- * user delegation key; when an Azurite connection string is configured every organization is
- * reached through it instead, with its shared key.
+ * user delegation key; while the provisioner is disabled every organization is reached through
+ * the configured Azurite instead, with its shared key.
  */
 @Slf4j
 @Component
@@ -164,8 +164,10 @@ public class AzureOrganizationStorageService implements OrganizationStorageServi
         return organization.getStorage();
     }
 
+    // The switch that selects MockOrganizationStorageProvisioner, which is what points organizations
+    // at the Azurite; a profile layered on development keeps the connection string regardless
     private boolean azurite() {
-        return properties().getAzuriteConnectionString() != null && !properties().getAzuriteConnectionString().isBlank();
+        return properties().isDisableProvisioner();
     }
 
     private OrganizationStorageProperties properties() {

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
@@ -494,7 +494,7 @@ public class ProjectDeployJobDefinitionFactory {
 
     private Future<String> uploadUis(Project project, DeployTarget target, Organization organization, String commitSha) {
         return organizationStorageService.issueUploadUrl(organization, project.getApplicationId(), UPLOAD_URL_TTL)
-                .map(uploadUrl -> publishWorkload(project, target, organization, uploadUrl, commitSha))
+                .map(uploadUrl -> publishWorkload(project, target, uploadUrl, commitSha))
                 .compose(workloadOrchestrationService::deployWorkload)
                 .compose(finished -> requireSucceeded(finished, "UI publish"));
     }
@@ -612,7 +612,6 @@ public class ProjectDeployJobDefinitionFactory {
      */
     private Workload publishWorkload(Project project,
                                      DeployTarget target,
-                                     Organization organization,
                                      String uploadUrl,
                                      String commitSha) {
         DeploymentProperties deployment = deployment();
@@ -631,7 +630,7 @@ public class ProjectDeployJobDefinitionFactory {
         workload.getVolumeMounts().add(new VolumeMount().setHostPath(target.hostDir())
                                                         .setGuestPath("/workspace")
                                                         .setReadOnly(true));
-        workload.getNetwork().setAllowedHosts(List.of(URI.create(organization.getStorage().getAzureBlobEndpoint()).getHost()));
+        workload.getNetwork().setAllowedHosts(List.of(URI.create(uploadUrl).getHost()));
         return workload;
     }
 

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -173,7 +173,7 @@ configured under `kinotic.systemApi.organizationStorage.*`:
 | `location` | — | The Azure region the accounts are created in. Required |
 | `privateEndpointSubnetId` | — | Id of the subnet in the platform VNet each account's private endpoint is placed in. Required unless `disablePrivateEndpoint` is true |
 | `privateDnsZoneId` | — | Id of the `privatelink.blob.core.windows.net` private DNS zone each account is registered in. Required unless `disablePrivateEndpoint` is true |
-| `azuriteConnectionString` | — | Connection string of the Azurite the mock provisioner uses. Required when the provisioner is disabled |
+| `azuriteConnectionString` | — | Connection string of the Azurite the mock provisioner points every organization at, and that organization storage is reached through, while the provisioner is disabled. Required then, and unread otherwise |
 
 The required settings are validated at boot, like the GitHub App settings, so an environment
 that disables the provisioner still sets them, to placeholders; nothing reads them while it

--- a/website/content/02.platform/09.contributing.md
+++ b/website/content/02.platform/09.contributing.md
@@ -80,7 +80,10 @@ That is a resource group, a Front Door Standard profile with an endpoint, the
 for the server with the roles it needs: Contributor and Storage Blob Data Contributor on the
 group, DNS Zone Contributor on the zone, and Contributor on the email service, so it sends
 mail too. The written file is the git-ignored `local` profile: it turns both provisioners on
-and names those resources. The `environment` is yours alone: a site hostname can be bound to
+and names those resources. Turning the storage provisioner on is also what moves publishing
+off the development profile's Azurite, whose connection string the layered profile still
+carries: with the provisioner on, each organization is reached at the account it was
+provisioned in. The `environment` is yours alone: a site hostname can be bound to
 one Front Door profile in all of Azure, so two developers sharing a sites domain would
 collide.
 

--- a/website/content/02.platform/11.reference/03.project-publishing-design.md
+++ b/website/content/02.platform/11.reference/03.project-publishing-design.md
@@ -171,8 +171,8 @@ The publish workload is named `project-ui-publish-<projectId>`, with id
 the same image in the foreground with entrypoint `bun src/publish-ui.ts`, the checkout mounted
 read-only at `/workspace`, env `KINOTIC_UI_COMMIT`, and the secret `KINOTIC_UI_UPLOAD_URL` =
 `<blob endpoint>/sites/prod/<app>/ui?<container SAS, create+write, TTL the run>`. Its allowed
-hosts are the hostname of the organization's `storage.azureBlobEndpoint` only, which the
-platform network resolves to the account's private endpoint; it carries no Kinotic
+hosts are the host that upload URL names only — the organization's account, which the
+platform network resolves to its private endpoint, or the Azurite standing in for it; it carries no Kinotic
 credentials and no machine identity, is kept after its run, and is retired by the next run's
 `resolveTarget`. Its exit check is the one `syncSource` uses, extracted to one method with two
 consumers. `publish-ui.ts` uploads, per UI, everything in `dist` except `index.html` under


### PR DESCRIPTION
## What broke

A project deploy's publish VM failed its first upload with a refused connection. Its allowlist was right, and boxlite matched it; the URL was wrong.

The box boxlite recorded for the publish workload (`~/.boxlite/db/boxlite.db`, `box_config.json`):

```json
"KINOTIC_UI_UPLOAD_URL": "http://127.0.0.1:10000/devstoreaccount1/sites/prod/todo-neon/ui?sv=...",
"network": { "Enabled": { "allow_net": ["kin00aca0a5a87cfeb0a1f11.blob.core.windows.net"] } }
```

`127.0.0.1` inside a micro VM is the guest, so the upload was refused before egress mattered.

## Why

```java
// AzureOrganizationStorageService, before
private boolean azurite() {
    return properties().getAzuriteConnectionString() != null && !properties().getAzuriteConnectionString().isBlank();
}
```

`application-development.yml` sets `azuriteConnectionString`; the git-ignored `local` profile layered on it turns the real provisioner on (the organization got a real account and endpoint) but inherits the string, so every SAS was still minted against Azurite.

## Fix

```java
// AzureOrganizationStorageService, after: the switch that selects MockOrganizationStorageProvisioner
private boolean azurite() {
    return properties().isDisableProvisioner();
}
```

```java
// ProjectDeployJobDefinitionFactory.publishWorkload: the allowlist names the host the URL carries
workload.getNetwork().setAllowedHosts(List.of(URI.create(uploadUrl).getHost()));
```

The `organization` parameter of `publishWorkload` goes away with it.

## What boxlite does with a CNAME chain

`network-policy-test.ts` gained the Azure cases (finding 16 in the vmm-r&d README, verbatim output there). On 0.10.0:

| `allowNet` | account host | canonical `blob.<cluster>.store.core.windows.net` |
|---|---|---|
| `[<account>.blob.core.windows.net]` | **REACHED** (HTTP 400 from Azure) | blocked (`0.0.0.0` refused) |
| head + canonical | REACHED | REACHED |
| `['*.blob.core.windows.net']` | blocked (`Parse error` on lookup) | blocked |
| `['57.150.160.33']` | blocked (name resolves, connection sinkholed) | blocked |

So naming the URL's host is sufficient and correct; resolving the chain at deploy time would add nothing, and wildcards and addresses are not options.

## Verification

- `:kinotic-system-api:test`: 17 tests, 0 failures.
- The probe project now pins boxlite `0.10.0`, the version the node runs; 0.10 no longer boots a box on first `exec`, so the probe starts it explicitly.
- The end-to-end rerun of `todo-neon-main` still needs a portal sign-in, which I could not do; see the session summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3YzFEcUuryZvJNc3Rg5tw
