### PR TITLE
Portal: full-screen entity dialog, site links on the overviews, aligned deployment tables

### DIFF
--- a/kinotic-frontend/apps/portal/src/components/EntityDefinitionsList.vue
+++ b/kinotic-frontend/apps/portal/src/components/EntityDefinitionsList.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Tag from 'primevue/tag'
+import type { MenuItem } from 'primevue/menuitem'
 import { Kinotic, type IDataSource, type IterablePage, type Pageable } from '@kinotic-ai/core'
 import type { EntityDefinition } from '@kinotic-ai/management-api'
 import { CrudTable, DatetimeUtil, type CrudHeader } from '@kinotic-ai/frontend-common'
@@ -9,7 +10,8 @@ import { useEntityPublishing } from '@/composables/entity-definition/useEntityPu
 
 /**
  * The entity definitions of an application, or of one of its projects when projectId is
- * given. A row opens the entity's page; the row menu publishes or unpublishes it.
+ * given. A row opens the entity full screen on its data; the row menu opens either its data or
+ * its schema, and publishes or unpublishes it.
  */
 const props = defineProps<{
   applicationId: string
@@ -57,7 +59,15 @@ const dataSource = computed<IDataSource<EntityDefinition>>(() => ({
   }
 }))
 
-const { rowActions } = useEntityPublishing(refreshTable)
+const { rowActions: publishingActions } = useEntityPublishing(refreshTable)
+
+function rowActions(item: EntityDefinition): MenuItem[] {
+  return [
+    { label: 'Data', icon: 'pi pi-table', command: () => openEntity(item, 'data') },
+    { label: 'Schema', icon: 'pi pi-sitemap', command: () => openEntity(item, 'schema') },
+    ...publishingActions(item)
+  ]
+}
 
 function refreshTable(): void {
   crudTable.value?.find()
@@ -75,13 +85,13 @@ function updateRouteQuery(newSearch: string): void {
   refreshTable()
 }
 
-// The entity page opens in the scope of this list, so the sidebar and the way back stay put
-function openEntity(item: EntityDefinition): void {
+// The entity opens in the scope of this list, so the sidebar and the way back stay put
+function openEntity(item: EntityDefinition, tab: 'data' | 'schema' = 'data'): void {
   const applicationPath = `/application/${encodeURIComponent(props.applicationId)}`
   const listPath = props.projectId
       ? `${applicationPath}/project/${encodeURIComponent(props.projectId)}/entities`
       : `${applicationPath}/entities`
-  router.push(`${listPath}/${encodeURIComponent(item.id ?? '')}`)
+  router.push({ path: `${listPath}/${encodeURIComponent(item.id ?? '')}`, query: tab === 'schema' ? { tab } : {} })
 }
 </script>
 

--- a/kinotic-frontend/apps/portal/src/components/MicroserviceDeploymentsTable.vue
+++ b/kinotic-frontend/apps/portal/src/components/MicroserviceDeploymentsTable.vue
@@ -1,6 +1,6 @@
 <template>
   <DataTable :value="deployments" size="small">
-    <Column header="Microservice" style="width: 18%">
+    <Column header="Microservice" style="width: 20%">
       <template #body="{ data }"><span class="font-mono text-sm">{{ data.name }}</span></template>
     </Column>
     <Column header="Status" style="width: 14%">
@@ -17,7 +17,7 @@
         </span>
       </template>
     </Column>
-    <Column header="Entry point" style="width: 30%">
+    <Column header="Entry point" style="width: 28%">
       <template #body="{ data }"><span class="font-mono text-xs">{{ data.entryPoint ?? '—' }}</span></template>
     </Column>
     <Column style="width: 26%">

--- a/kinotic-frontend/apps/portal/src/components/UiDeploymentsTable.vue
+++ b/kinotic-frontend/apps/portal/src/components/UiDeploymentsTable.vue
@@ -1,18 +1,18 @@
 <template>
   <DataTable :value="deployments" size="small">
-    <Column header="UI" style="width: 16%">
+    <Column header="UI" style="width: 20%">
       <template #body="{ data }"><span class="font-mono text-sm">{{ data.name }}</span></template>
-    </Column>
-    <Column header="Site" style="width: 34%">
-      <template #body="{ data }">
-        <a :href="data.url" target="_blank" rel="noopener" class="font-mono text-sm break-all">{{ data.url }}</a>
-      </template>
     </Column>
     <Column header="Status" style="width: 14%">
       <template #body="{ data }">
         <span :title="data.status.message ?? undefined">
           <Tag :value="data.status.type" :severity="deploymentStatusSeverity(data.status.type)" />
         </span>
+      </template>
+    </Column>
+    <Column header="Site" style="width: 34%">
+      <template #body="{ data }">
+        <a :href="data.url" target="_blank" rel="noopener" class="font-mono text-sm break-all">{{ data.url }}</a>
       </template>
     </Column>
     <Column header="Commit" style="width: 12%">
@@ -22,7 +22,7 @@
         </span>
       </template>
     </Column>
-    <Column style="width: 24%">
+    <Column style="width: 20%">
       <template #body="{ data }">
         <div class="flex justify-end gap-1">
           <Button label="Retry" icon="pi pi-refresh" size="small" severity="secondary" text

--- a/kinotic-frontend/apps/portal/src/pages/ApplicationOverview.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ApplicationOverview.vue
@@ -65,6 +65,29 @@
         </dl>
       </section>
     </div>
+
+    <section :class="cardClass" class="mt-4">
+      <h2 class="text-sm font-semibold text-surface-950 dark:text-surface-0">UIs</h2>
+      <div v-if="loadingProjects" class="mt-4 flex flex-col gap-3">
+        <Skeleton v-for="n in 2" :key="n" height="2.25rem" />
+      </div>
+      <p v-else-if="uis.length === 0" class="mt-4 text-sm text-muted-color">
+        No UI has been published yet. A UI a project contains is published with that project's next deployment.
+      </p>
+      <ul v-else class="mt-2 divide-y divide-surface-200 dark:divide-surface-700">
+        <li v-for="ui in uis" :key="ui.id ?? `${ui.projectId}/${ui.name}`" class="flex items-center gap-3 py-3">
+          <i class="pi pi-globe text-surface-400" />
+          <div class="min-w-0 flex-1">
+            <div class="truncate text-sm font-medium">
+              {{ ui.name }}
+              <RouterLink :to="`${basePath}/project/${encodeURIComponent(ui.projectId)}`" class="ml-2 text-xs font-normal text-muted-color hover:underline">{{ ui.projectId }}</RouterLink>
+            </div>
+            <a :href="ui.url" target="_blank" rel="noopener" class="block truncate font-mono text-xs text-primary-500 hover:underline">{{ ui.url }}</a>
+          </div>
+          <Tag :value="ui.status.type" :severity="deploymentStatusSeverity(ui.status.type)" />
+        </li>
+      </ul>
+    </section>
   </div>
 </template>
 
@@ -75,7 +98,7 @@ import Button from 'primevue/button'
 import Skeleton from 'primevue/skeleton'
 import Tag from 'primevue/tag'
 import { Kinotic, Pageable } from '@kinotic-ai/core'
-import { type Project, DeploymentStatusType, RepositoryConnectionStatus } from '@kinotic-ai/management-api'
+import { type Project, DeploymentStatusType, RepositoryConnectionStatus, type UiDeployment } from '@kinotic-ai/management-api'
 import { createDebug, DatetimeUtil, deploymentStatusSeverity, PageHeader } from '@kinotic-ai/frontend-common'
 import { APPLICATION_STATE } from '@/states/IApplicationState'
 import { USER_STATE } from '@/states/IUserState'
@@ -84,7 +107,8 @@ const debug = createDebug('application-overview')
 
 /**
  * The landing page of one application: how much it holds, each count leading to its list,
- * its projects with their deployment state, and the facts that identify it.
+ * its projects with their deployment state, the facts that identify it, and every UI its
+ * projects have published with its site.
  */
 const props = defineProps<{
   applicationId: string
@@ -109,6 +133,7 @@ const application = computed(() => {
 const projects = ref<Project[]>([])
 const loadingProjects = ref(true)
 const deploymentStatus = ref<Record<string, DeploymentStatusType>>({})
+const uis = ref<UiDeployment[]>([])
 const usersCount = ref<number | null>(null)
 const machinesCount = ref<number | null>(null)
 
@@ -142,6 +167,7 @@ async function load(): Promise<void> {
   loadingProjects.value = true
   projects.value = []
   deploymentStatus.value = {}
+  uis.value = []
   usersCount.value = null
   machinesCount.value = null
   await Promise.all([loadProjects(), loadUsersCount(), loadMachinesCount()])
@@ -151,7 +177,7 @@ async function loadProjects(): Promise<void> {
   try {
     const page = await Kinotic.projects.findAllForApplication(props.applicationId, Pageable.create(0, PROJECT_PREVIEW_COUNT))
     projects.value = page.content ?? []
-    await Promise.all(projects.value.map(loadDeploymentStatus))
+    await Promise.all(projects.value.flatMap(project => [loadDeploymentStatus(project), loadUis(project)]))
   } catch (error) {
     debug('Failed to load projects: %O', error)
   } finally {
@@ -168,6 +194,16 @@ async function loadDeploymentStatus(project: Project): Promise<void> {
     }
   } catch (error) {
     debug('Failed to load deployment for %s: %O', project.id, error)
+  }
+}
+
+async function loadUis(project: Project): Promise<void> {
+  if (!project.id) return
+  try {
+    const published = await Kinotic.uiDeployments.findAllForProject(project.id)
+    uis.value = [...uis.value, ...published].sort((a, b) => a.name.localeCompare(b.name))
+  } catch (error) {
+    debug('Failed to load UIs for %s: %O', project.id, error)
   }
 }
 

--- a/kinotic-frontend/apps/portal/src/pages/EntityDetailPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/EntityDetailPage.vue
@@ -1,22 +1,36 @@
 <template>
-  <div class="flex h-full min-h-0 flex-col">
-    <PageHeader :title="entity?.name ?? entityDefinitionId" :description="entity?.description ?? undefined">
-      <template #eyebrow>
-        <RouterLink :to="entitiesPath" class="hover:underline">Entities</RouterLink>
-        <i class="pi pi-chevron-right" :style="{ fontSize: '10px' }" />
-        <span>{{ entity?.name ?? entityDefinitionId }}</span>
-      </template>
-      <template #actions>
-        <template v-if="entity">
-          <Tag :value="entity.published ? 'Published' : 'Unpublished'"
-               :severity="entity.published ? 'success' : 'secondary'" rounded />
+  <Dialog
+    :visible="true"
+    modal
+    :draggable="false"
+    :dismissable-mask="false"
+    class="p-dialog-maximized"
+    content-class="flex min-h-0 flex-1 flex-col"
+    @update:visible="close"
+  >
+    <template #header>
+      <div class="flex min-w-0 flex-1 flex-wrap items-center justify-between gap-4">
+        <div class="min-w-0">
+          <div class="mb-1 flex items-center gap-1.5 text-sm text-surface-500 dark:text-surface-400">
+            <RouterLink :to="entitiesPath" class="hover:underline">Entities</RouterLink>
+            <i class="pi pi-chevron-right" :style="{ fontSize: '10px' }" />
+            <span>{{ entity?.name ?? entityDefinitionId }}</span>
+          </div>
+          <div class="flex flex-wrap items-center gap-3">
+            <h1 class="m-0 text-xl font-semibold tracking-tight text-surface-950 dark:text-surface-0">{{ entity?.name ?? entityDefinitionId }}</h1>
+            <Tag v-if="entity" :value="entity.published ? 'Published' : 'Unpublished'"
+                 :severity="entity.published ? 'success' : 'secondary'" rounded />
+          </div>
+          <p v-if="entity?.description" class="m-0 mt-1 max-w-[640px] text-sm text-surface-500 dark:text-surface-400">{{ entity.description }}</p>
+        </div>
+        <div v-if="entity" class="flex shrink-0 items-center gap-2">
           <Button v-if="entity.published" label="Unpublish" icon="pi pi-eye-slash" severity="danger" outlined
                   :loading="busyId === entity.id" @click="unpublish(entity)" />
           <Button v-else label="Publish" icon="pi pi-eye"
                   :loading="busyId === entity.id" @click="publish(entity)" />
-        </template>
-      </template>
-    </PageHeader>
+        </div>
+      </div>
+    </template>
 
     <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>
     <div v-else-if="loading" class="p-6 text-sm text-muted-color">Loading entity…</div>
@@ -44,13 +58,15 @@
     </Tabs>
 
     <ConfirmDialog />
-  </div>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import Button from 'primevue/button'
 import ConfirmDialog from 'primevue/confirmdialog'
+import Dialog from 'primevue/dialog'
 import Message from 'primevue/message'
 import Tab from 'primevue/tab'
 import TabList from 'primevue/tablist'
@@ -60,7 +76,6 @@ import Tabs from 'primevue/tabs'
 import Tag from 'primevue/tag'
 import { Kinotic } from '@kinotic-ai/core'
 import type { EntityDefinition } from '@kinotic-ai/management-api'
-import { PageHeader } from '@kinotic-ai/frontend-common'
 import EntityDefinitionDiagram from '@/components/entity-definitions/EntityDefinitionDiagram.vue'
 import EntityList from '@/pages/EntityList.vue'
 import { useEntityPublishing } from '@/composables/entity-definition/useEntityPublishing'
@@ -68,8 +83,10 @@ import { useQueryTab } from '@/composables/useQueryTab'
 
 /**
  * One entity definition: the data stored under it and its schema, with publishing as the
- * action that turns the schema into a store. Opened from a project's Entities list or, without
- * a project, from the application's; the eyebrow leads back to whichever list it came from.
+ * action that turns the schema into a store. It has its own route under the Entities list it
+ * was opened from, and fills the viewport as a dialog over that list, since both the data table
+ * and the schema diagram need the room; closing it returns to the list. The dialog wears the
+ * theme's own maximized class, the one its maximize button would apply.
  */
 const props = defineProps<{
   applicationId: string
@@ -78,6 +95,8 @@ const props = defineProps<{
 }>()
 
 const TABS = ['data', 'schema'] as const
+
+const router = useRouter()
 
 const entity = ref<EntityDefinition | null>(null)
 const loading = ref(true)
@@ -109,5 +128,9 @@ async function load(): Promise<void> {
 
 function selectTab(value: string | number): void {
   activeTab.value = value === 'schema' ? 'schema' : 'data'
+}
+
+function close(): void {
+  router.push(entitiesPath.value)
 }
 </script>

--- a/kinotic-frontend/apps/portal/src/pages/ProjectDeploymentPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ProjectDeploymentPage.vue
@@ -62,16 +62,16 @@
           issued for.
         </p>
         <DataTable :value="machines" size="small">
-          <Column field="usedFor" header="Used for" style="width: 26%" />
-          <Column field="displayName" header="Name" style="width: 26%" />
-          <Column header="Client ID" style="width: 32%">
-            <template #body="{ data }"><span class="font-mono text-sm">{{ data.id }}</span></template>
-          </Column>
-          <Column header="Status" style="width: 16%">
+          <Column field="usedFor" header="Used for" style="width: 20%" />
+          <Column header="Status" style="width: 14%">
             <template #body="{ data }">
               <Tag :value="data.enabled ? 'Active' : 'Disabled'"
                    :severity="data.enabled ? 'success' : 'danger'" />
             </template>
+          </Column>
+          <Column field="displayName" header="Name" style="width: 26%" />
+          <Column header="Client ID" style="width: 40%">
+            <template #body="{ data }"><span class="font-mono text-sm">{{ data.id }}</span></template>
           </Column>
         </DataTable>
       </section>

--- a/kinotic-frontend/apps/portal/src/pages/ProjectOverview.vue
+++ b/kinotic-frontend/apps/portal/src/pages/ProjectOverview.vue
@@ -46,21 +46,46 @@
       </div>
     </div>
 
-    <section :class="cardClass">
-      <h2 class="text-sm font-semibold text-surface-950 dark:text-surface-0">About</h2>
-      <dl class="mt-3 grid grid-cols-[9rem_1fr] gap-x-4 gap-y-2 text-sm">
-        <dt class="text-muted-color">Project id</dt>
-        <dd class="m-0 font-mono">{{ projectId }}</dd>
-        <dt class="text-muted-color">Application</dt>
-        <dd class="m-0"><RouterLink :to="`/application/${encodeURIComponent(applicationId)}`" class="hover:underline">{{ applicationId }}</RouterLink></dd>
-        <dt class="text-muted-color">Repository</dt>
-        <dd class="m-0 font-mono">{{ project?.repoFullName ?? '—' }}<span v-if="project?.repoDefaultBranch"> · {{ project.repoDefaultBranch }}</span></dd>
-        <dt class="text-muted-color">Source of truth</dt>
-        <dd class="m-0">{{ project?.sourceOfTruth ?? '—' }}</dd>
-        <dt class="text-muted-color">Updated</dt>
-        <dd class="m-0">{{ project?.updated ? DatetimeUtil.formatRelativeDate(project.updated) : '—' }}</dd>
-      </dl>
-    </section>
+    <div class="grid gap-4 lg:grid-cols-2">
+      <section :class="cardClass">
+        <div class="flex items-center justify-between">
+          <h2 class="text-sm font-semibold text-surface-950 dark:text-surface-0">UIs</h2>
+          <RouterLink :to="`${basePath}/deployment`" class="text-xs font-medium text-primary-500 hover:underline">Deployment</RouterLink>
+        </div>
+        <div v-if="loading" class="mt-4 flex flex-col gap-3">
+          <Skeleton v-for="n in 2" :key="n" height="2.25rem" />
+        </div>
+        <p v-else-if="uis.length === 0" class="mt-4 text-sm text-muted-color">
+          No UI has been published yet. A UI the project contains is published with its next deployment.
+        </p>
+        <ul v-else class="mt-2 divide-y divide-surface-200 dark:divide-surface-700">
+          <li v-for="ui in uis" :key="ui.id ?? ui.name" class="flex items-center gap-3 py-3">
+            <i class="pi pi-globe text-surface-400" />
+            <div class="min-w-0 flex-1">
+              <div class="truncate text-sm font-medium">{{ ui.name }}</div>
+              <a :href="ui.url" target="_blank" rel="noopener" class="block truncate font-mono text-xs text-primary-500 hover:underline">{{ ui.url }}</a>
+            </div>
+            <Tag :value="ui.status.type" :severity="deploymentStatusSeverity(ui.status.type)" />
+          </li>
+        </ul>
+      </section>
+
+      <section :class="cardClass">
+        <h2 class="text-sm font-semibold text-surface-950 dark:text-surface-0">About</h2>
+        <dl class="mt-3 grid grid-cols-[9rem_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt class="text-muted-color">Project id</dt>
+          <dd class="m-0 font-mono">{{ projectId }}</dd>
+          <dt class="text-muted-color">Application</dt>
+          <dd class="m-0"><RouterLink :to="`/application/${encodeURIComponent(applicationId)}`" class="hover:underline">{{ applicationId }}</RouterLink></dd>
+          <dt class="text-muted-color">Repository</dt>
+          <dd class="m-0 font-mono">{{ project?.repoFullName ?? '—' }}<span v-if="project?.repoDefaultBranch"> · {{ project.repoDefaultBranch }}</span></dd>
+          <dt class="text-muted-color">Source of truth</dt>
+          <dd class="m-0">{{ project?.sourceOfTruth ?? '—' }}</dd>
+          <dt class="text-muted-color">Updated</dt>
+          <dd class="m-0">{{ project?.updated ? DatetimeUtil.formatRelativeDate(project.updated) : '—' }}</dd>
+        </dl>
+      </section>
+    </div>
   </div>
 </template>
 
@@ -71,12 +96,13 @@ import Message from 'primevue/message'
 import Skeleton from 'primevue/skeleton'
 import Tag from 'primevue/tag'
 import { Kinotic } from '@kinotic-ai/core'
-import { type Project, type ProjectDeployment, RepositoryConnectionStatus } from '@kinotic-ai/management-api'
+import { type Project, type ProjectDeployment, RepositoryConnectionStatus, type UiDeployment } from '@kinotic-ai/management-api'
 import { DatetimeUtil, deploymentStatusSeverity, PageHeader } from '@kinotic-ai/frontend-common'
 
 /**
  * The landing page of one project: its repository, its deployment state, how many entities
- * it defines, and the facts that identify it. Each tile leads to the page with the detail.
+ * it defines, the UIs it has published with their sites, and the facts that identify it. Each
+ * tile leads to the page with the detail.
  */
 const props = defineProps<{
   applicationId: string
@@ -93,7 +119,7 @@ const basePath = computed(() => `/application/${encodeURIComponent(props.applica
 const project = ref<Project | null>(null)
 const deployment = ref<ProjectDeployment | null>(null)
 const microserviceCount = ref(0)
-const uiCount = ref(0)
+const uis = ref<UiDeployment[]>([])
 const entityCount = ref<number | null>(null)
 const loading = ref(true)
 const error = ref<string | null>(null)
@@ -103,8 +129,8 @@ const workloadSummary = computed(() => {
   if (microserviceCount.value > 0) {
     parts.push(`${microserviceCount.value} microservice${microserviceCount.value === 1 ? '' : 's'}`)
   }
-  if (uiCount.value > 0) {
-    parts.push(`${uiCount.value} UI${uiCount.value === 1 ? '' : 's'}`)
+  if (uis.value.length > 0) {
+    parts.push(`${uis.value.length} UI${uis.value.length === 1 ? '' : 's'}`)
   }
   return parts.length > 0 ? parts.join(', ') : 'No workloads yet'
 })
@@ -117,10 +143,10 @@ async function load(): Promise<void> {
   project.value = null
   deployment.value = null
   microserviceCount.value = 0
-  uiCount.value = 0
+  uis.value = []
   entityCount.value = null
   try {
-    const [loadedProject, loadedDeployment, microservices, uis, count] = await Promise.all([
+    const [loadedProject, loadedDeployment, microservices, loadedUis, count] = await Promise.all([
       Kinotic.projects.findById(props.projectId),
       Kinotic.projects.findDeployment(props.projectId),
       Kinotic.microserviceDeployments.findAllForProject(props.projectId),
@@ -130,7 +156,7 @@ async function load(): Promise<void> {
     project.value = loadedProject
     deployment.value = loadedDeployment
     microserviceCount.value = microservices.length
-    uiCount.value = uis.length
+    uis.value = loadedUis
     entityCount.value = count
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)

--- a/website/content/01.apps/07.deployment/03.push-to-deploy.md
+++ b/website/content/01.apps/07.deployment/03.push-to-deploy.md
@@ -142,7 +142,8 @@ deployment, at a site minted anew. Deleting the project removes every one of its
 deployments the same way.
 
 The project's deployment page lists each UI with its site, status and the commit the site
-serves, and offers both actions. A tab left open on a site keeps working after a publish,
+serves, and offers both actions; the project's and the application's overview pages list the
+published UIs with their sites as well. A tab left open on a site keeps working after a publish,
 since the commit it was built from stays published alongside the new one; it can find out it
 is behind with `checkUiVersion` from `@kinotic-ai/core` (see
 [the UI build contract](/apps/application-structure/applications-and-projects#the-ui-build-contract)).


### PR DESCRIPTION
Three follow-ups to the navigation PR (#515), from using the portal.

## An entity opens full screen again

The entity's Data table and Schema diagram both need the whole viewport, which the tab panel inside the layout's 1200px column did not give them; as modals they had it. The entity keeps its own route under the Entities list it was opened from, so the URL, the back button and the sidebar behind it stay as they are, and it renders as a maximized `Dialog`: the theme's own `p-dialog-maximized` class (what the Dialog's maximize button applies) fills the viewport, the dialog header carries the eyebrow crumb, the title, the published state and the publish action, and closing it returns to the list.

The row still opens it on Data; the row menu adds **Data** and **Schema** ahead of Publish / Unpublish, so the schema is one click from the list as the old View action was. The tab is in the URL (`?tab=schema`).

## Published UIs on the overviews

A UI's site was reachable only from the project's Deployment page.

- The **project overview** lists the project's published UIs beside About, each with its site as a link and its status. The page already fetched them for the count.
- The **application overview** lists every UI its previewed projects have published, each naming its project, loaded alongside the per-project deployment status it already fetched.
- `website/content/01.apps/07.deployment/03.push-to-deploy.md` says the overviews list the sites too.

## Status column on the Deployment page

The three tables put Status in three different columns: second on Microservices, third on UIs, last on Machine identities. Status is now the second column of all three, and the first two columns share widths (20% / 14%), so the tags line up down the page.

## Verified

- `vue-tsc -b` and `vite build` for `kinotic-portal` on develop at `ab041dc`.
- Not verified at runtime: the portal needs a signed-in session against a backend, which the build environment does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA)_