### PR TITLE
Portal: bottom padding on tall pages, a one-row entity dialog header, a plain search field on the data view

### DIFF
--- a/kinotic-frontend/apps/portal/src/components/entity-list/EntityTableToolbar.vue
+++ b/kinotic-frontend/apps/portal/src/components/entity-list/EntityTableToolbar.vue
@@ -1,24 +1,30 @@
 <template>
-  <Toolbar class="!w-full flex-shrink-0">
-    <template #start>
+  <div class="mb-3 flex shrink-0 items-center gap-2">
+    <IconField class="w-[236px] max-w-sm">
+      <InputIcon class="pi pi-search" />
       <InputText
         :modelValue="searchText"
-        @update:modelValue="$emit('update:searchText', $event)"
         placeholder="Search"
+        size="small"
+        name="search"
+        autocomplete="off"
+        @update:modelValue="$emit('update:searchText', $event)"
         @keyup.enter="$emit('search')"
         @focus="($event.target as HTMLInputElement)?.select()"
-        class="w-1/2"
       />
-      <Button icon="pi pi-times" class="ml-2" v-if="searchText" @click="$emit('clearSearch')" />
-    </template>
-  </Toolbar>
+    </IconField>
+    <Button v-if="searchText" icon="pi pi-times" severity="secondary" text rounded size="small"
+            aria-label="Clear search" @click="$emit('clearSearch')" />
+  </div>
 </template>
 
 <script setup lang="ts">
-import Toolbar from 'primevue/toolbar'
 import Button from 'primevue/button'
+import IconField from 'primevue/iconfield'
+import InputIcon from 'primevue/inputicon'
 import InputText from 'primevue/inputtext'
 
+/** The search field above the entity table, in the shape every CrudTable draws its own. */
 withDefaults(defineProps<{
   searchText?: string | null
 }>(), {

--- a/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
+++ b/kinotic-frontend/apps/portal/src/layouts/LayoutForPage.vue
@@ -89,14 +89,16 @@ function scopeFor(group: string | null): SidebarScopeProps {
                 isSidebarCollapsed ? 'md:pl-[64px]' : 'md:pl-[256px]'
             ]"
         >
-            <div :class="['h-[calc(100vh-64px)] overflow-y-auto px-4 py-4 transition-colors md:px-8 md:py-6', isDark ? 'bg-surface-900 text-surface-0' : 'bg-surface-0 text-surface-950']">
+            <div :class="['h-[calc(100vh-64px)] overflow-y-auto px-4 pt-4 transition-colors md:px-8 md:pt-6', isDark ? 'bg-surface-900 text-surface-0' : 'bg-surface-0 text-surface-950']">
                 <router-view v-if="isFullWidth" />
                 <!-- h-full (not min-h-full) gives the page a definite height to divide up, so a
                      page that scrolls a region internally — a table keeping its paginator in
                      place — can size that region. min-h-0 lets the page shrink to it; taller
-                     pages overflow and scroll in the wrapper above as before. -->
+                     pages overflow and scroll in the wrapper above. The bottom padding sits on
+                     the page for that reason: a scroll container pads after its child's box,
+                     and a tall page's content ends past that box. -->
                 <div v-else class="mx-auto flex h-full w-full max-w-[1200px] flex-col">
-                    <router-view class="min-h-0 flex-1" />
+                    <router-view class="min-h-0 flex-1 pb-4 md:pb-6" />
                 </div>
             </div>
         </div>

--- a/kinotic-frontend/apps/portal/src/pages/EntityDetailPage.vue
+++ b/kinotic-frontend/apps/portal/src/pages/EntityDetailPage.vue
@@ -5,31 +5,23 @@
     :draggable="false"
     :dismissable-mask="false"
     class="p-dialog-maximized"
+    :pt="{ header: { class: '!py-3' } }"
     content-class="flex min-h-0 flex-1 flex-col"
     @update:visible="close"
   >
     <template #header>
-      <div class="flex min-w-0 flex-1 flex-wrap items-center justify-between gap-4">
-        <div class="min-w-0">
-          <div class="mb-1 flex items-center gap-1.5 text-sm text-surface-500 dark:text-surface-400">
-            <RouterLink :to="entitiesPath" class="hover:underline">Entities</RouterLink>
-            <i class="pi pi-chevron-right" :style="{ fontSize: '10px' }" />
-            <span>{{ entity?.name ?? entityDefinitionId }}</span>
-          </div>
-          <div class="flex flex-wrap items-center gap-3">
-            <h1 class="m-0 text-xl font-semibold tracking-tight text-surface-950 dark:text-surface-0">{{ entity?.name ?? entityDefinitionId }}</h1>
-            <Tag v-if="entity" :value="entity.published ? 'Published' : 'Unpublished'"
-                 :severity="entity.published ? 'success' : 'secondary'" rounded />
-          </div>
-          <p v-if="entity?.description" class="m-0 mt-1 max-w-[640px] text-sm text-surface-500 dark:text-surface-400">{{ entity.description }}</p>
-        </div>
-        <div v-if="entity" class="flex shrink-0 items-center gap-2">
-          <Button v-if="entity.published" label="Unpublish" icon="pi pi-eye-slash" severity="danger" outlined
-                  :loading="busyId === entity.id" @click="unpublish(entity)" />
-          <Button v-else label="Publish" icon="pi pi-eye"
-                  :loading="busyId === entity.id" @click="publish(entity)" />
-        </div>
+      <div class="flex min-w-0 flex-1 items-center gap-2 text-sm">
+        <RouterLink :to="entitiesPath" class="text-surface-500 hover:underline dark:text-surface-400">Entities</RouterLink>
+        <i class="pi pi-chevron-right text-surface-500 dark:text-surface-400" :style="{ fontSize: '10px' }" />
+        <span class="truncate font-semibold text-surface-950 dark:text-surface-0" :title="entity?.description || undefined">{{ entity?.name ?? entityDefinitionId }}</span>
+        <Tag v-if="entity" :value="entity.published ? 'Published' : 'Unpublished'"
+             :severity="entity.published ? 'success' : 'secondary'" rounded />
       </div>
+    </template>
+    <!-- Rendered here rather than by the dialog, which would move focus to its own close
+         button on open and draw the button's focus ring around it -->
+    <template #closebutton="{ closeCallback }">
+      <Button icon="pi pi-times" severity="secondary" text rounded aria-label="Close" @click="closeCallback" />
     </template>
 
     <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>
@@ -48,7 +40,7 @@
         <TabPanel value="data" class="flex min-h-0 flex-1 flex-col">
           <EntityList v-if="entity.published" :key="entity.id ?? ''" :entity-definition-id="entity.id ?? undefined" />
           <div v-else class="rounded-2xl border border-dashed border-surface-300 p-8 text-center text-sm text-muted-color dark:border-surface-700">
-            Publish this entity to start storing data. Its schema is ready on the Schema tab.
+            Publish this entity from the Entities list to start storing data. Its schema is ready on the Schema tab.
           </div>
         </TabPanel>
         <TabPanel value="schema" class="flex min-h-0 flex-1 flex-col">
@@ -56,8 +48,6 @@
         </TabPanel>
       </TabPanels>
     </Tabs>
-
-    <ConfirmDialog />
   </Dialog>
 </template>
 
@@ -65,7 +55,6 @@
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import Button from 'primevue/button'
-import ConfirmDialog from 'primevue/confirmdialog'
 import Dialog from 'primevue/dialog'
 import Message from 'primevue/message'
 import Tab from 'primevue/tab'
@@ -78,15 +67,15 @@ import { Kinotic } from '@kinotic-ai/core'
 import type { EntityDefinition } from '@kinotic-ai/management-api'
 import EntityDefinitionDiagram from '@/components/entity-definitions/EntityDefinitionDiagram.vue'
 import EntityList from '@/pages/EntityList.vue'
-import { useEntityPublishing } from '@/composables/entity-definition/useEntityPublishing'
 import { useQueryTab } from '@/composables/useQueryTab'
 
 /**
- * One entity definition: the data stored under it and its schema, with publishing as the
- * action that turns the schema into a store. It has its own route under the Entities list it
- * was opened from, and fills the viewport as a dialog over that list, since both the data table
- * and the schema diagram need the room; closing it returns to the list. The dialog wears the
- * theme's own maximized class, the one its maximize button would apply.
+ * One entity definition: the data stored under it and its schema. It has its own route under
+ * the Entities list it was opened from, and fills the viewport as a dialog over that list,
+ * since both the data table and the schema diagram need the room; the header is one row so
+ * they get as much of it as possible, and closing it returns to the list. Publishing stays on
+ * the list. The dialog wears the theme's own maximized class, the one its maximize button
+ * would apply.
  */
 const props = defineProps<{
   applicationId: string
@@ -103,7 +92,6 @@ const loading = ref(true)
 const error = ref<string | null>(null)
 
 const activeTab = useQueryTab(TABS)
-const { busyId, publish, unpublish } = useEntityPublishing(load)
 
 const entitiesPath = computed(() => {
   const applicationPath = `/application/${encodeURIComponent(props.applicationId)}`

--- a/kinotic-frontend/apps/portal/src/pages/EntityList.vue
+++ b/kinotic-frontend/apps/portal/src/pages/EntityList.vue
@@ -703,10 +703,6 @@ provide(ENTITY_LIST_INJECTION_KEY, entityListContext)
 .p-datatable .p-button {
   margin-top: 1rem;
 }
-.p-toolbar-start {
-  width: 100% !important;
-}
-
 :deep(.truncate-text) {
   white-space: nowrap;
   overflow: hidden;
@@ -771,16 +767,6 @@ provide(ENTITY_LIST_INJECTION_KEY, entityListContext)
   overflow: hidden;
   border-top: none !important;
   border-bottom: none !important;
-}
-
-.entity-list--dark :deep(.p-toolbar) {
-  border-color: var(--p-surface-700) !important;
-  background: var(--p-surface-900) !important;
-  color: var(--p-surface-0) !important;
-}
-
-.entity-list--dark :deep(.p-toolbar-start) {
-  width: 100% !important;
 }
 
 .entity-list--dark :deep(.p-inputtext) {


### PR DESCRIPTION
## What this does

Four small portal fixes, one commit.

**Tall pages ended flush with the bottom of the viewport.** The layout's scroll container padded after its fixed-height wrapper, and a page taller than the viewport overflows that wrapper, so the padding never reached the end of the content. The bottom padding moves onto the page:

```vue
<!-- apps/portal/src/layouts/LayoutForPage.vue -->
<div :class="['h-[calc(100vh-64px)] overflow-y-auto px-4 pt-4 ... md:px-8 md:pt-6', ...]">
    ...
    <router-view class="min-h-0 flex-1 pb-4 md:pb-6" />
```

**A circle around the entity dialog's close button.** PrimeVue's Dialog moves focus to its own close button on open with `focusVisible: true`, which draws the secondary focus ring around it. The dialog renders its own close button through the `closebutton` slot, so nothing is force-focused:

```vue
<!-- apps/portal/src/pages/EntityDetailPage.vue -->
<template #closebutton="{ closeCallback }">
  <Button icon="pi pi-times" severity="secondary" text rounded aria-label="Close" @click="closeCallback" />
</template>
```

**The entity dialog's header, to give the data table and the diagram the room.** One row, `Entities › Board [Published]`, at reduced vertical padding. The title, description and the Publish/Unpublish buttons are gone; publishing stays on the Entities list rows, and the Data tab's unpublished-entity notice points there.

**The data view's search bar.** The boxed PrimeVue Toolbar with a half-width input becomes the same `IconField` search every CrudTable draws, with a small clear button when text is present. The dead toolbar styles in `EntityList.vue` go with it.

## Verification

`vue-tsc -b` and `vite build` pass for the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA)_