### PR TITLE
Cluster: release at display size; workload logs: a finished workload opens on its run

### DIFF
--- a/kinotic-frontend/apps/system/src/components/WorkloadsTable.vue
+++ b/kinotic-frontend/apps/system/src/components/WorkloadsTable.vue
@@ -46,8 +46,9 @@
     <WorkloadLogsDialog
       v-if="logsWorkload"
       v-model:visible="logsVisible"
-      :workload-id="logsWorkload.id"
+      :workload-id="logsWorkload.id ?? ''"
       :workload-name="logsWorkload.name"
+      :workload="logsWorkload"
     />
   </div>
 </template>
@@ -108,7 +109,7 @@ const router = useRouter()
 const confirm = useConfirm()
 const formatEpochDateTime = DatetimeUtil.formatEpochDateTime
 
-const logsWorkload = ref<{ id: string; name: string } | null>(null)
+const logsWorkload = ref<Workload | null>(null)
 const logsVisible = ref(false)
 
 const ownerHeader = computed<string | null>(() => {
@@ -219,7 +220,7 @@ function rowActions(item: WorkloadRow): MenuItem[] {
       label: 'View logs',
       icon: 'pi pi-align-left',
       command: () => {
-        logsWorkload.value = { id: item.id, name: item.name }
+        logsWorkload.value = props.workloads.find(workload => workload.id === item.id) ?? null
         logsVisible.value = true
       }
     }

--- a/kinotic-frontend/apps/system/src/pages/ClusterPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/ClusterPage.vue
@@ -29,7 +29,8 @@
           </Column>
           <Column header="Version">
             <template #body="{ data }">
-              {{ data.version }}
+              {{ splitVersion(data.version).release }}
+              <span v-if="splitVersion(data.version).build" class="font-mono text-xs text-muted-color">{{ splitVersion(data.version).build }}</span>
               <Tag v-if="commonVersion && data.version !== commonVersion" value="behind" severity="warn" class="ml-1" />
             </template>
           </Column>
@@ -116,6 +117,12 @@ const commonVersion = computed<string | null>(() => {
 
 const mixedVersions = computed(() => new Set((cluster.value?.nodes ?? []).map(node => node.version)).size > 1)
 
+/** A node version as the release it is and the build stamp after the '#', e.g. 2.18.0 and 20260423-sha1:d49adada. */
+function splitVersion(version: string): { release: string; build: string | null } {
+  const at = version.indexOf('#')
+  return at < 0 ? { release: version, build: null } : { release: version.slice(0, at), build: version.slice(at + 1) }
+}
+
 interface Stat {
   label: string
   value: string
@@ -148,15 +155,33 @@ const stats = computed<Stat[]>(() => [
     icon: 'pi-sync',
     accent: 'violet'
   },
-  {
-    label: 'Versions',
-    value: mixedVersions.value ? 'Mixed' : (commonVersion.value ?? '—'),
-    description: mixedVersions.value ? 'Not every node runs the same build' : 'Every node runs this build',
-    tag: mixedVersions.value ? 'warn' : undefined,
-    icon: 'pi-tag',
-    accent: mixedVersions.value ? 'amber' : 'teal'
-  }
+  versionStat.value
 ])
+
+// The release reads at display size; the build stamp behind the '#' goes in the caption
+const versionStat = computed<Stat>(() => {
+  let ret: Stat
+  if (mixedVersions.value) {
+    ret = {
+      label: 'Versions',
+      value: 'Mixed',
+      description: 'Not every node runs the same build',
+      tag: 'warn',
+      icon: 'pi-tag',
+      accent: 'amber'
+    }
+  } else {
+    const common = commonVersion.value ? splitVersion(commonVersion.value) : null
+    ret = {
+      label: 'Version',
+      value: common?.release ?? '—',
+      description: common?.build ? `build ${common.build} · every node runs it` : 'Every node runs this build',
+      icon: 'pi-tag',
+      accent: 'teal'
+    }
+  }
+  return ret
+})
 
 function openLogLevel(nodeId: string) {
   logLevelNodeId.value = nodeId

--- a/kinotic-frontend/apps/system/src/pages/WorkloadPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/WorkloadPage.vue
@@ -96,7 +96,7 @@
         </TabPanel>
         <TabPanel value="logs">
           <!-- Mounted with the tab, so a return starts a fresh history load and tail -->
-          <WorkloadLogView v-if="tab === 'logs'" :workload-id="workloadId" class="pt-2" />
+          <WorkloadLogView v-if="tab === 'logs'" :workload-id="workloadId" :workload="workload ?? undefined" class="pt-2" />
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
+++ b/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
@@ -10,7 +10,7 @@
         size="small"
         :disabled="span === CUSTOM_SPAN"
       />
-      <SelectButton v-model="span" :options="SPAN_OPTIONS" option-label="label" option-value="value"
+      <SelectButton v-model="span" :options="spanOptions" option-label="label" option-value="value"
                     :allow-empty="false" size="small" />
       <Select v-model="limit" :options="LIMIT_OPTIONS" option-label="label" option-value="value" size="small" />
       <Button label="Reload" icon="pi pi-refresh" severity="secondary" outlined size="small"
@@ -57,6 +57,7 @@ import ToggleButton from 'primevue/togglebutton'
 import VirtualScroller from 'primevue/virtualscroller'
 
 import { Kinotic } from '@kinotic-ai/core'
+import { WorkloadStatus, type Workload } from '@kinotic-ai/management-api'
 import DatetimeUtil from '../util/DatetimeUtil'
 import { errorMessage, parseJsonBytes } from '../util/helpers'
 import type { TimeRange } from './telemetry/TimeRange'
@@ -64,16 +65,28 @@ import { TIME_RANGE_PRESETS, rangeEndingNow } from './telemetry/telemetryApi'
 
 const props = defineProps<{
   workloadId: string
+  /**
+   * The workload's record, when the caller has it. A workload whose run has ended opens on
+   * the span of that run rather than the last hour, and does not follow, since nothing more
+   * is coming; the run is also offered as a span for a workload still running.
+   */
+  workload?: Workload
 }>()
 
-/** The span option that reveals the absolute range pickers; every other option is a preset's milliseconds. */
+/** The span option that reveals the absolute range pickers. */
 const CUSTOM_SPAN = 'custom'
-type Span = number | typeof CUSTOM_SPAN
+/** The span option covering the workload's run, from its creation to its end or to now. */
+const RUN_SPAN = 'run'
+/** A preset's milliseconds, or one of the named spans. */
+type Span = number | typeof CUSTOM_SPAN | typeof RUN_SPAN
 
-const SPAN_OPTIONS: { label: string; value: Span; description: string }[] = [
-  ...TIME_RANGE_PRESETS.map(preset => ({ label: preset.shortLabel, value: preset.ms, description: `in the ${preset.label.toLowerCase()}` })),
-  { label: 'Custom', value: CUSTOM_SPAN, description: 'in the selected range' }
-]
+// Log lines carry the VM's clock and ship after the fact, so the run's span reaches a little past both ends
+const RUN_MARGIN_MS = 60_000
+
+const PRESET_OPTIONS: { label: string; value: Span; description: string }[] =
+    TIME_RANGE_PRESETS.map(preset => ({ label: preset.shortLabel, value: preset.ms, description: `in the ${preset.label.toLowerCase()}` }))
+const RUN_OPTION = { label: 'Whole run', value: RUN_SPAN, description: 'over the workload\'s run' }
+const CUSTOM_OPTION = { label: 'Custom', value: CUSTOM_SPAN, description: 'in the selected range' }
 // Loki rejects a limit above its max_entries_limit_per_query, 5000 unless configured higher
 const LIMIT_OPTIONS = [500, 1000, 2000, 5000].map(value => ({ value, label: `${value.toLocaleString()} lines` }))
 // The VirtualScroller keeps the DOM viewport-sized regardless of buffer length, so the
@@ -88,10 +101,16 @@ interface LogLine {
   line: string
 }
 
+function isFinished(workload: Workload | undefined): boolean {
+  return workload?.status === WorkloadStatus.STOPPED || workload?.status === WorkloadStatus.FAILED
+}
+
+const spanOptions = computed(() => props.workload ? [...PRESET_OPTIONS, RUN_OPTION, CUSTOM_OPTION] : [...PRESET_OPTIONS, CUSTOM_OPTION])
+
 // shallowRef: lines are immutable once parsed, so per-line reactive proxies buy nothing
 const lines = shallowRef<LogLine[]>([])
-const following = ref(true)
-const span = ref<Span>(TIME_RANGE_PRESETS[1]!.ms)
+const following = ref(!isFinished(props.workload))
+const span = ref<Span>(isFinished(props.workload) ? RUN_SPAN : TIME_RANGE_PRESETS[1]!.ms)
 const limit = ref(1000)
 const customStart = ref<Date | null>(null)
 const customEnd = ref<Date | null>(null)
@@ -111,7 +130,7 @@ const rangeDescription = computed(() => {
   if (span.value === CUSTOM_SPAN && range) {
     ret = `between ${DatetimeUtil.formatEpochDateTime(range.start)} and ${DatetimeUtil.formatEpochDateTime(range.end)}`
   } else {
-    ret = SPAN_OPTIONS.find(option => option.value === span.value)!.description
+    ret = spanOptions.value.find(option => option.value === span.value)!.description
   }
   return ret
 })
@@ -145,12 +164,22 @@ function resolveRange(): TimeRange | null {
   let ret: TimeRange | null
   if (typeof span.value === 'number') {
     ret = rangeEndingNow(span.value)
+  } else if (span.value === RUN_SPAN) {
+    ret = runRange()
   } else if (customStart.value && customEnd.value && customStart.value < customEnd.value) {
     ret = { start: customStart.value.getTime(), end: customEnd.value.getTime() }
   } else {
     ret = null
   }
   return ret
+}
+
+// From the workload's creation to its last status change once it has ended, or to now while it runs
+function runRange(): TimeRange {
+  const workload = props.workload
+  const start = workload?.created ?? Date.now() - TIME_RANGE_PRESETS[1]!.ms
+  const end = isFinished(workload) && workload?.updated ? workload.updated + RUN_MARGIN_MS : Date.now()
+  return { start: start - RUN_MARGIN_MS, end }
 }
 
 async function loadHistory() {
@@ -240,6 +269,14 @@ watch(span, selected => {
 })
 
 watch(limit, loadHistory)
+
+// A workload that ends while on screen has nothing more to tail; its run is what is left to read
+watch(() => isFinished(props.workload), finished => {
+  if (finished) {
+    following.value = false
+    span.value = RUN_SPAN
+  }
+})
 
 function onScroll(event: Event) {
   const el = event.target as HTMLElement

--- a/kinotic-frontend/packages/common/src/components/WorkloadLogsDialog.vue
+++ b/kinotic-frontend/packages/common/src/components/WorkloadLogsDialog.vue
@@ -6,17 +6,20 @@
     :style="{ width: '70rem', maxWidth: '95vw' }"
   >
     <!-- Mounted with the dialog, so a reopen starts a fresh history load and tail -->
-    <WorkloadLogView v-if="visible" :workload-id="workloadId" />
+    <WorkloadLogView v-if="visible" :workload-id="workloadId" :workload="workload" />
   </Dialog>
 </template>
 
 <script setup lang="ts">
 import Dialog from 'primevue/dialog'
+import type { Workload } from '@kinotic-ai/management-api'
 import WorkloadLogView from './WorkloadLogView.vue'
 
+/** The log view in a dialog; given the workload's record, the view opens on its run once it has ended. */
 defineProps<{
   workloadId: string
   workloadName: string
+  workload?: Workload
 }>()
 
 const visible = defineModel<boolean>('visible', { required: true })


### PR DESCRIPTION
## What this does

Two console fixes, one commit each.

**The Versions tile printed the whole build string at display size.** A node version reads `2.18.0#20260423-sha1:d49adada`, and the tile wrapped it across three lines.

```ts
// apps/system/src/pages/ClusterPage.vue (before)
value: mixedVersions.value ? 'Mixed' : (commonVersion.value ?? '—'),   // "2.18.0#20260423-sha1:d49adada"
```

The tile now shows the release before the `#` as its value and the build stamp in its caption; the server-node table shows the same split in each row.

```ts
/** A node version as the release it is and the build stamp after the '#', e.g. 2.18.0 and 20260423-sha1:d49adada. */
function splitVersion(version: string): { release: string; build: string | null }

label: 'Version',
value: common?.release ?? '—',                                        // "2.18.0"
description: common?.build ? `build ${common.build} · every node runs it` : 'Every node runs this build',
```

When nodes disagree the tile still reads "Mixed" as a warn tag. A version with no `#` shows unchanged.

**A finished workload's logs opened on the last hour, following.** The log view knew a workload only by id, so a workload stopped hours ago opened empty with a live tail nothing would feed. `WorkloadLogView` now takes the workload's record when the caller has it:

```ts
// packages/common/src/components/WorkloadLogView.vue
const following = ref(!isFinished(props.workload))
const span = ref<Span>(isFinished(props.workload) ? RUN_SPAN : TIME_RANGE_PRESETS[1]!.ms)

// From the workload's creation to its last status change once it has ended, or to now while it runs
function runRange(): TimeRange {
  const start = workload?.created ?? Date.now() - TIME_RANGE_PRESETS[1]!.ms
  const end = isFinished(workload) && workload?.updated ? workload.updated + RUN_MARGIN_MS : Date.now()
  return { start: start - RUN_MARGIN_MS, end }
}
```

A STOPPED or FAILED workload opens on the span of its run with following off; a running one keeps the last hour and the tail, and gains "Whole run" as a span to pick. A workload that ends while on screen switches over. `WorkloadLogsDialog` passes the record through; the console's workload page and its workloads table supply it. The portal's callers, which hold a `MicroserviceDeployment` rather than a `Workload`, are unchanged.

## Verification

`vue-tsc -b` passes for both apps; `vite build` passes for the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA