### PR TITLE
Trace search: sortable columns, with the caption saying what they sort within

### DIFF
--- a/kinotic-frontend/packages/common/src/components/telemetry/TraceSearch.vue
+++ b/kinotic-frontend/packages/common/src/components/telemetry/TraceSearch.vue
@@ -23,28 +23,35 @@
 
     <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>
 
+    <!-- Tempo returns the first traces its search finds, up to the limit, in no order of its
+         own; the columns sort within that set, and the caption says so -->
+    <p v-if="traces.length > 0" class="text-xs text-muted-color">
+      {{ traces.length }} traces Tempo found in the range{{ traces.length >= SEARCH_LIMIT ? ', its limit' : '' }}; the columns sort within them.
+    </p>
     <DataTable
       :value="traces"
       dataKey="traceId"
       size="small"
       selectionMode="single"
+      sort-field="startMs"
+      :sort-order="-1"
       :class="['text-sm', { 'datatable-loading': loading }]"
       @row-select="openTrace($event.data)"
     >
       <template #empty>
         <div class="py-6 text-center text-sm text-muted-color">{{ loading ? 'Searching traces…' : 'No traces match in this range' }}</div>
       </template>
-      <Column header="Started" style="width: 12rem">
+      <Column field="startMs" header="Started" sortable style="width: 12rem">
         <template #body="{ data }">
           <span class="font-mono text-xs">{{ formatDateFromEpoch(data.startMs) }}</span>
         </template>
       </Column>
-      <Column field="rootService" header="Service" />
-      <Column field="rootName" header="Root span" />
-      <Column header="Duration" style="width: 8rem">
+      <Column field="rootService" header="Service" sortable />
+      <Column field="rootName" header="Root span" sortable />
+      <Column field="durationMs" header="Duration" sortable style="width: 8rem">
         <template #body="{ data }">{{ formatDuration(data.durationMs) }}</template>
       </Column>
-      <Column field="matchedSpans" header="Spans" style="width: 6rem" />
+      <Column field="matchedSpans" header="Spans" sortable style="width: 6rem" />
       <Column header="Trace" style="width: 10rem">
         <template #body="{ data }">
           <span class="font-mono text-xs text-muted-color">{{ data.traceId.slice(0, 16) }}</span>

--- a/kinotic-frontend/packages/common/src/components/telemetry/telemetryApi.ts
+++ b/kinotic-frontend/packages/common/src/components/telemetry/telemetryApi.ts
@@ -88,11 +88,11 @@ export function redQueries(applicationId: string | null, range: TimeRange): { re
     }
 }
 
-/** Searches the organization's traces, newest first. */
+/** Searches the organization's traces: the first ones Tempo finds in the range, up to the limit, in no particular order. */
 export async function searchTraces(organizationId: string | null, query: string, range: TimeRange, limit: number): Promise<TraceSummary[]> {
     // Raw Tempo search response: {traces: [{traceID, rootServiceName, rootTraceName, startTimeUnixNano, durationMs, spanSets}]}
     const body = parseJsonBytes(await Kinotic.telemetry.searchTraces({ organizationId, query, start: range.start, end: range.end, limit }))
-    return ((body?.traces ?? []) as any[]).map(parseTraceSummary).sort((a, b) => b.startMs - a.startMs)
+    return ((body?.traces ?? []) as any[]).map(parseTraceSummary)
 }
 
 function parseTraceSummary(trace: any): TraceSummary {


### PR DESCRIPTION
## What this does

Makes the trace search table's columns sortable, in place, and says so.

Tempo's `/api/search` takes `q`, `start`, `end`, `limit` and a few tag filters, with no order parameter, and TraceQL has no ordering clause; its docs say a search "takes the first N results". So the columns sort the returned set, newest first to begin with, and a caption above the table names that set so the order is never read as a ranking of the whole range:

```vue
<!-- packages/common/src/components/telemetry/TraceSearch.vue -->
<p v-if="traces.length > 0" class="text-xs text-muted-color">
  {{ traces.length }} traces Tempo found in the range{{ traces.length >= SEARCH_LIMIT ? ', its limit' : '' }}; the columns sort within them.
</p>
<DataTable :value="traces" ... sort-field="startMs" :sort-order="-1">
  <Column field="startMs"      header="Started"   sortable ... />
  <Column field="rootService"  header="Service"   sortable />
  <Column field="rootName"     header="Root span" sortable />
  <Column field="durationMs"   header="Duration"  sortable ... />
  <Column field="matchedSpans" header="Spans"     sortable ... />
```

The newest-first sort that `searchTraces` applied client-side moves into the table, which now owns the order:

```ts
// packages/common/src/components/telemetry/telemetryApi.ts
/** Searches the organization's traces: the first ones Tempo finds in the range, up to the limit, in no particular order. */
export async function searchTraces(...): Promise<TraceSummary[]> {
    ...
    return ((body?.traces ?? []) as any[]).map(parseTraceSummary)     // was: .sort((a, b) => b.startMs - a.startMs)
}
```

`TraceSearch` is shared, so the portal's Observability pages sort the same way.

## Verification

`vue-tsc -b` passes for both apps; `vite build` passes for the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA)_