### PR TITLE
Trace search: label the TraceQL preview; read timestamps as they arrive wherever compared; runs chart: axis labels clear of the legend

### DIFF
--- a/kinotic-frontend/packages/common/src/components/telemetry/TraceSearch.vue
+++ b/kinotic-frontend/packages/common/src/components/telemetry/TraceSearch.vue
@@ -18,7 +18,12 @@
         <label for="only-errors" class="text-sm">Errors only</label>
       </div>
       <Button label="Search" icon="pi pi-search" size="small" :loading="loading" @click="search" />
-      <span class="pb-2 font-mono text-xs text-muted-color">{{ query }}</span>
+    </div>
+
+    <!-- The query the filters amount to, as one would paste it into Tempo -->
+    <div class="flex items-center gap-2 text-xs text-muted-color">
+      <span class="font-medium uppercase tracking-wide">TraceQL</span>
+      <code class="font-mono">{{ query }}</code>
     </div>
 
     <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>


### PR DESCRIPTION
## What this does

Three commits.

**The TraceQL preview gets a label and its own line.** The query the filters amount to sat unlabeled beside the Search button, where an empty form showed two bare braces. It now sits under the filters, labeled, so it reads as the query Tempo will run:

```vue
<!-- packages/common/src/components/telemetry/TraceSearch.vue -->
<div class="flex items-center gap-2 text-xs text-muted-color">
  <span class="font-medium uppercase tracking-wide">TraceQL</span>
  <code class="font-mono">{{ query }}</code>
</div>
```

**Timestamps are read through `toEpochMillis` wherever they are compared or subtracted.** `Workload.created`/`updated` and `JobRun.started` are `java.util.Date` on the server and do not arrive as the numbers the TypeScript models declare. The display formatters already read either form; the arithmetic did not. The visible failure was the log view's "Whole run" span:

```ts
// packages/common/src/components/WorkloadLogView.vue (before)
const start = workload?.created ?? Date.now() - ...     // a date string
return { start: start - RUN_MARGIN_MS, end }            // NaN → serialized as null
```

```
JSON decoding error: Cannot map `null` into type `long`
```

The same assumption made the job-run scan's `since` window match nothing, the runs-per-day chart bucket nothing, and the started/created/updated sorts inert. Each site now normalizes first:

```ts
const created = DatetimeUtil.toEpochMillis(workload?.created ?? null)
const updated = DatetimeUtil.toEpochMillis(workload?.updated ?? null)
```

`DatetimeUtil.toEpochMillis`, added by the duration fix, is public now that it has a second consumer. It returns the same millis for a number, so nothing changes if the wire ever carries numbers.

**The runs-per-day chart's legend sat on its axis labels.** The grid left no row for the labels, so the legend at the bottom drew over them. The grid now keeps its labels inside its box the way the metric charts do, with the bottom margin as the legend's row, and a window with no runs says so instead of drawing an empty plot:

```ts
// apps/system/src/components/JobRunsByDayChart.vue
grid: { left: 8, right: 16, top: 12, bottom: 36, containLabel: true },   // was: { left: 28, ..., bottom: 30, containLabel: false }
```

```vue
<div v-if="runs.length === 0" class="flex h-44 items-center justify-center text-sm text-muted-color">
  No runs in the last {{ days }} days
</div>
```

## Verification

`vue-tsc -b` passes for both apps; `vite build` passes for the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA