### PR TITLE
Serve UI sites through Front Door with the profile's managed identity, not a SAS

### DIFF
--- a/deployment/terraform/azure/cluster/frontdoor.tf
+++ b/deployment/terraform/azure/cluster/frontdoor.tf
@@ -1,9 +1,11 @@
 # ── UI sites on Front Door ────────────────────────────────────────────────────
 # Every published UI is served at <label>.apps.<zone> through this one Front Door Standard
-# profile and endpoint. kinotic-server (FrontDoorUiDeploymentProvisioner) creates the rest
-# at runtime: per organization an origin group, an origin on its storage account and a
-# rule set carrying a read-only SAS; per site a custom domain with a managed certificate,
-# a route, and the CNAME and validation TXT records in the platform zone.
+# profile and endpoint, and the profile's identity, which reads every organization's storage
+# account. kinotic-server (FrontDoorUiDeploymentProvisioner) creates the rest at runtime:
+# per organization an origin group authenticating as that identity, with an origin on its
+# storage account; once, the rule set that serves a single-page application's routes; per
+# site a custom domain with a managed certificate, a route, and the CNAME and validation
+# TXT records in the platform zone.
 
 locals {
   sites_domain = "apps.${local.global.dns_zone_name}"
@@ -14,6 +16,20 @@ resource "azurerm_cdn_frontdoor_profile" "sites" {
   resource_group_name = azurerm_resource_group.main.name
   sku_name            = "Standard_AzureFrontDoor"
   tags                = local.common_tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# Every organization's account is created in the org storage group, so one assignment
+# covers them all. The provider cannot read a new identity's principal id in the plan that
+# creates it, so a fresh root applies the profile first:
+#   terraform apply -target=azurerm_cdn_frontdoor_profile.sites && terraform apply
+resource "azurerm_role_assignment" "sites_blob_reader" {
+  scope                = azurerm_resource_group.org_storage.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "sites" {

--- a/deployment/terraform/azure/dev/README.md
+++ b/deployment/terraform/azure/dev/README.md
@@ -7,7 +7,7 @@ uses. One apply creates:
 | Resource | Name | Purpose |
 |---|---|---|
 | Resource group | `rg-kinotic-<environment>` | Holds the Front Door profile and, created by the server at runtime, one storage account per organization |
-| Front Door Standard profile + endpoint | `afd-kinotic-<environment>-sites` | Serves every published UI at `<label>.apps-<environment>.kinotic.ai`; the server adds origin groups, rule sets, domains and routes at runtime |
+| Front Door Standard profile + endpoint | `afd-kinotic-<environment>-sites` | Serves every published UI at `<label>.apps-<environment>.kinotic.ai`; its system identity holds Storage Blob Data Reader on the group, and the server adds origin groups, the rule set, domains and routes at runtime |
 | Service principal | `kinotic-<environment>-server` | The identity the server runs as, with Contributor and Storage Blob Data Contributor on the group, DNS Zone Contributor on `kinotic.ai`, and Contributor on the email service |
 | `.env.local` at the repository root | | The principal's `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`, written by the apply |
 
@@ -43,6 +43,7 @@ environment = "local"   # e.g. your first name
 
 ```bash
 terraform init
+terraform apply -target=azurerm_cdn_frontdoor_profile.sites   # the profile first: the role below needs its identity's principal id
 terraform apply
 terraform output -raw application_local_yml > ../../../../kinotic-server/src/main/resources/application-local.yml
 ```

--- a/deployment/terraform/azure/dev/main.tf
+++ b/deployment/terraform/azure/dev/main.tf
@@ -81,6 +81,21 @@ resource "azurerm_cdn_frontdoor_profile" "sites" {
   resource_group_name = azurerm_resource_group.main.name
   sku_name            = "Standard_AzureFrontDoor"
   tags                = local.common_tags
+
+  # The profile reads each organization's storage account as this identity: the server
+  # sets origin authentication on every origin group it creates
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# The accounts live in the group above, so one assignment covers every organization. The
+# provider cannot read a new identity's principal id in the plan that creates it, so a fresh
+# root applies the profile first, as the README says
+resource "azurerm_role_assignment" "sites_blob_reader" {
+  scope                = azurerm_resource_group.main.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "sites" {

--- a/kinotic-system-api/build.gradle
+++ b/kinotic-system-api/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'com.azure.resourcemanager:azure-resourcemanager-storage'
 
     implementation 'io.vertx:vertx-core'
+    implementation 'io.vertx:vertx-web-client'
 
     implementation 'co.elastic.clients:elasticsearch-java'
     implementation 'co.elastic.clients:elasticsearch-rest5-client'

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/OrganizationStorageService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/OrganizationStorageService.java
@@ -29,18 +29,6 @@ public interface OrganizationStorageService {
     Future<String> issueUploadUrl(Organization organization, String applicationId, Duration ttl);
 
     /**
-     * Issues the token the serving layer reads the organization's published UIs with: a
-     * container SAS, as a query string without the leading {@code ?}, that allows reading any
-     * blob in the container until {@code ttl} has passed. Signed with the account's key, so it
-     * may last years where a delegation key is limited to days.
-     *
-     * @param organization the organization whose storage is read
-     * @param ttl          how long the SAS stays valid
-     * @return a future emitting the SAS query string
-     */
-    Future<String> issueReadToken(Organization organization, Duration ttl);
-
-    /**
      * Lists the commit directories published under a UI's prefix: the sha of every commit
      * whose assets are still stored.
      *

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/UiDeploymentProvisioner.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/UiDeploymentProvisioner.java
@@ -25,21 +25,23 @@ public interface UiDeploymentProvisioner {
 
     /**
      * Starts serving the deployment at its hostname, on what {@link #prepareOrganization}
-     * created for the organization. Returns the deployment with its status set: ready when serving at
-     * once, provisioning while the hostname is still being validated, failed with the reason
-     * otherwise. Idempotent: provisioning a deployment again completes whatever an earlier
-     * attempt left missing, and validates a hostname again whose validation lapsed.
+     * created for the organization. Returns the deployment with its status set: ready when the
+     * site already serves the deployment's commit and its index, provisioning until it does,
+     * failed with the reason otherwise. Idempotent: provisioning a deployment again completes
+     * whatever an earlier attempt left missing, and validates a hostname again whose validation
+     * lapsed.
      *
-     * @param deployment   the deployment, already persisted with its label as id
+     * @param deployment   the deployment, already persisted with its label as id and the
+     *                     commit its files were published from
      * @param organization the organization whose storage the site serves from
      * @return a future emitting the deployment with its status
      */
     Future<UiDeployment> provision(UiDeployment deployment, Organization organization);
 
     /**
-     * Advances a provisioning deployment: ready once its hostname validates and its
-     * certificate is deployed, failed with the reason when validation cannot succeed, and
-     * unchanged while still pending.
+     * Advances a provisioning deployment: ready once the site serves the deployment's commit
+     * and its index at its hostname, failed with the reason when its hostname's validation
+     * cannot succeed, and provisioning, with what was observed, while still pending.
      *
      * @param deployment a deployment whose status is provisioning
      * @return a future emitting the deployment with its status

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/AzureOrganizationStorageService.java
@@ -1,20 +1,14 @@
 package org.kinotic.system.internal.api.services;
 
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.management.AzureEnvironment;
-import com.azure.core.management.profile.AzureProfile;
 import com.azure.identity.DefaultAzureCredentialBuilder;
-import com.azure.resourcemanager.storage.StorageManager;
-import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.storage.blob.BlobContainerAsyncClient;
-import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
-import com.azure.storage.common.StorageSharedKeyCredential;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +22,6 @@ import org.kinotic.system.api.services.OrganizationStorageProvisioner;
 import org.kinotic.system.api.services.OrganizationStorageService;
 import org.kinotic.system.api.services.UiStoragePaths;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -76,40 +69,6 @@ public class AzureOrganizationStorageService implements OrganizationStorageServi
         }
         return sas.map(token -> container.getBlobContainerUrl() + "/" + UiStoragePaths.applicationPrefix(applicationId)
                 + "?" + token);
-    }
-
-    @Override
-    public Future<String> issueReadToken(Organization organization, Duration ttl) {
-        Validate.notNull(ttl, "ttl is required");
-        BlobServiceSasSignatureValues values = new BlobServiceSasSignatureValues(
-                OffsetDateTime.now(ZoneOffset.UTC).plus(ttl), new BlobContainerSasPermission().setReadPermission(true));
-        Future<String> ret;
-        if (azurite()) {
-            ret = Future.succeededFuture(container(organization).generateSas(values));
-        } else {
-            OrganizationStorage storage = requireStorage(organization);
-            ret = AzureUtil.toFuture(accountKey(organization).map(key -> new BlobContainerClientBuilder()
-                    .endpoint(storage.getAzureBlobEndpoint())
-                    .containerName(OrganizationStorageProvisioner.UI_CONTAINER)
-                    .credential(new StorageSharedKeyCredential(storage.getAzureAccountName(), key))
-                    .buildAsyncClient()
-                    .generateSas(values)), vertx);
-        }
-        return ret;
-    }
-
-    // The key is read through the management plane, where the server holds Storage Account
-    // Contributor on the resource group every organization account is created in
-    private Mono<String> accountKey(Organization organization) {
-        OrganizationStorage storage = requireStorage(organization);
-        Validate.notBlank(storage.getAzureSubscriptionId(), "Organization %s has no storage subscription recorded", organization.getId());
-        Validate.notBlank(storage.getAzureAccountName(), "Organization %s has no storage account recorded", organization.getId());
-        AzureProfile profile = new AzureProfile(null, storage.getAzureSubscriptionId(), AzureEnvironment.AZURE);
-        return StorageManager.authenticate(credential, profile)
-                             .storageAccounts()
-                             .getByResourceGroupAsync(properties().getResourceGroup(), storage.getAzureAccountName())
-                             .flatMap(StorageAccount::getKeysAsync)
-                             .map(keys -> keys.getFirst().value());
     }
 
     @Override

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/FrontDoorUiDeploymentProvisioner.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/FrontDoorUiDeploymentProvisioner.java
@@ -1,14 +1,17 @@
 package org.kinotic.system.internal.api.services;
 
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.management.AzureEnvironment;
+import com.azure.core.management.exception.ManagementException;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.resourcemanager.cdn.CdnManager;
 import com.azure.resourcemanager.cdn.fluent.CdnManagementClient;
 import com.azure.resourcemanager.cdn.fluent.models.AfdDomainInner;
 import com.azure.resourcemanager.cdn.fluent.models.AfdEndpointInner;
-import com.azure.resourcemanager.cdn.fluent.models.AfdOriginGroupInner;
 import com.azure.resourcemanager.cdn.fluent.models.AfdOriginInner;
 import com.azure.resourcemanager.cdn.fluent.models.RouteInner;
 import com.azure.resourcemanager.cdn.fluent.models.RuleInner;
@@ -17,6 +20,7 @@ import com.azure.resourcemanager.cdn.models.AfdCertificateType;
 import com.azure.resourcemanager.cdn.models.AfdDomainHttpsParameters;
 import com.azure.resourcemanager.cdn.models.AfdEndpointProtocols;
 import com.azure.resourcemanager.cdn.models.AfdMinimumTlsVersion;
+import com.azure.resourcemanager.cdn.models.AfdProvisioningState;
 import com.azure.resourcemanager.cdn.models.AfdQueryStringCachingBehavior;
 import com.azure.resourcemanager.cdn.models.AfdRouteCacheConfiguration;
 import com.azure.resourcemanager.cdn.models.CompressionSettings;
@@ -26,7 +30,6 @@ import com.azure.resourcemanager.cdn.models.EnabledState;
 import com.azure.resourcemanager.cdn.models.ForwardingProtocol;
 import com.azure.resourcemanager.cdn.models.HttpsRedirect;
 import com.azure.resourcemanager.cdn.models.LinkToDefaultDomain;
-import com.azure.resourcemanager.cdn.models.LoadBalancingSettingsParameters;
 import com.azure.resourcemanager.cdn.models.MatchProcessingBehavior;
 import com.azure.resourcemanager.cdn.models.ResourceReference;
 import com.azure.resourcemanager.cdn.models.UrlFileExtensionMatchConditionParameters;
@@ -39,18 +42,21 @@ import com.azure.resourcemanager.dns.models.TxtRecordSet;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.domain.api.model.DeploymentStatus;
 import org.kinotic.domain.api.model.DeploymentStatusType;
 import org.kinotic.domain.api.model.Organization;
-import org.kinotic.system.api.config.KinoticSystemApiProperties;
-import org.kinotic.system.api.config.UiDeploymentProperties;
 import org.kinotic.management.api.model.UiDeployment;
 import org.kinotic.management.api.repositories.UiDeploymentRepository;
+import org.kinotic.system.api.config.KinoticSystemApiProperties;
+import org.kinotic.system.api.config.UiDeploymentProperties;
 import org.kinotic.system.api.services.OrganizationStorageProvisioner;
-import org.kinotic.system.api.services.OrganizationStorageService;
 import org.kinotic.system.api.services.UiDeploymentProvisioner;
 import org.kinotic.system.api.services.UiStoragePaths;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -65,14 +71,13 @@ import java.util.function.Supplier;
 
 /**
  * Serves each published UI through the platform's Front Door Standard profile, at
- * {@code <label>.<sitesDomain>}. What an organization's sites share is created with the
- * organization, once its storage is ready: an origin group on the storage account and a rule
- * set that routes requests naming a file to that file and everything else to
- * {@code index.html}, each with a read-only SAS on the {@code sites} container. Every site gets a custom domain with a managed
- * certificate, its CNAME and validation TXT records in the platform's DNS zone, and a route
- * from its domain to the UI's prefix in the container. A site is provisioning until Front
- * Door has validated its hostname and deployed its certificate, which the provisioner keeps
- * checking in the background.
+ * {@code <label>.<sitesDomain>}. Per organization, created with the organization once its
+ * storage is ready, an origin group on the storage account that authenticates to it as the
+ * profile's managed identity. Shared by every site, a rule set that routes requests naming no
+ * file to {@code index.html}. Every site gets a custom domain with a managed certificate, its
+ * CNAME and validation TXT records in the platform's DNS zone, and a route from its domain to
+ * the UI's prefix in the container. A site is provisioning until it serves the deployment's
+ * commit at its hostname, which the provisioner keeps checking in the background.
  */
 @Slf4j
 @Component
@@ -82,11 +87,17 @@ import java.util.function.Supplier;
 public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner {
 
     private static final String ORIGIN_NAME = "blob";
-    private static final String ASSET_RULE = "asset";
+    private static final String RULE_SET_NAME = "sites";
     private static final String SPA_RULE = "spa";
     private static final String VALIDATION_RECORD_PREFIX = "_dnsauth.";
-    /** A rule is written once, with the SAS it carries; ten years outlasts any organization's sites. */
-    private static final Duration READ_TOKEN_TTL = Duration.ofDays(10 * 365);
+    private static final String VERSION_FILE = "version.json";
+    /** The audience of the token the profile presents to the storage account. */
+    private static final String STORAGE_SCOPE = "https://storage.azure.com/.default";
+    /** Origin authentication exists from this API version on, which the SDK's client does not speak yet. */
+    private static final String ORIGIN_GROUP_API_VERSION = "2025-06-01";
+    /** Container properties answer 200 to the identity's token; the longest interval Front Door allows. */
+    private static final String PROBE_PATH = "/" + OrganizationStorageProvisioner.UI_CONTAINER + "?restype=container";
+    private static final int PROBE_INTERVAL_SECONDS = 240;
     private static final List<String> COMPRESSED_CONTENT_TYPES = List.of(
             "text/html", "text/css", "text/plain", "text/xml", "text/javascript", "application/javascript",
             "application/x-javascript", "application/json", "application/xml", "application/wasm",
@@ -94,13 +105,14 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
     /** Front Door answers 409 while a write on the profile is in flight; a retry waits this long times the attempt. */
     private static final long CONFLICT_BACKOFF_MS = 10_000;
     private static final int CONFLICT_ATTEMPTS = 6;
+    private static final long PROVISIONING_POLL_MS = 5_000;
+    private static final long HTTP_TIMEOUT_MS = 10_000;
     private static final long POLL_INTERVAL_MS = 30_000;
-    /** Validation and the certificate take minutes once the records resolve; past this the site stays provisioning until it is checked again. */
+    /** Validation, the certificate and the configuration's propagation take minutes; past this the site stays provisioning until it is checked again. */
     private static final long POLL_TIMEOUT_MS = 2 * 60 * 60_000;
 
     private final Vertx vertx;
     private final KinoticSystemApiProperties kinoticProperties;
-    private final OrganizationStorageService organizationStorageService;
     private final UiDeploymentRepository uiDeploymentRepository;
     // On AKS this resolves to the kinotic-server workload identity, which holds CDN Profile
     // Contributor on the profile and DNS Zone Contributor on the zone
@@ -108,6 +120,7 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
     // Set once by ensureClients, which every entry point calls first
     private CdnManagementClient cdn;
     private DnsZoneManager dns;
+    private WebClient web;
     private String resourceGroup;
     private String profileName;
     private String recordSuffix;
@@ -120,7 +133,7 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
         requireStorage(organization);
         ensureClients();
         log.info("Preparing Front Door for organization {}", organization.getId());
-        return Future.all(ensureOriginGroup(organization), ensureRuleSet(organization)).mapEmpty();
+        return Future.all(ensureOriginGroup(organization), ensureRuleSet()).mapEmpty();
     }
 
     @Override
@@ -131,15 +144,14 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
         String label = deployment.getId();
         String hostname = properties().resolveHostname(label);
         log.info("Provisioning site {} for UI {} of project {}", hostname, deployment.getName(), deployment.getProjectId());
-        // the organization's origin group and rule set exist since its creation; the route names them by id
-        String profileId = properties().getFrontDoorProfileId();
-        String originGroupId = profileId + "/originGroups/" + originGroupName(organization);
-        String ruleSetId = profileId + "/ruleSets/" + ruleSetName(organization);
+        // the organization's origin group and the shared rule set exist since the organization's creation; the route names them by id
+        String originGroupId = originGroupId(organization);
         return ensureDomain(label, hostname)
                 .compose(domain -> ensureDnsRecords(label, domain)
-                        .compose(v -> ensureRoute(deployment, domain, originGroupId, ruleSetId))
+                        .compose(v -> ensureRoute(deployment, domain, originGroupId))
                         .map(v -> domain))
-                .map(domain -> deployment.setStatus(statusOf(domain)))
+                .compose(domain -> statusOf(deployment, domain))
+                .map(deployment::setStatus)
                 .recover(error -> {
                     log.error("Site {} could not be provisioned", hostname, error);
                     return Future.succeededFuture(deployment.setStatus(
@@ -158,10 +170,11 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
         Validate.notNull(deployment, "deployment is required");
         ensureClients();
         return AzureUtil.toFuture(AzureUtil.emptyIfNotFound(cdn.getAfdCustomDomains().getAsync(resourceGroup, profileName, deployment.getId())), vertx)
-                        .map(domain -> deployment.setStatus(domain == null
-                        ? new DeploymentStatus(DeploymentStatusType.FAILED,
-                                                 "The site's domain no longer exists; retry provisioning to create it again")
-                        : statusOf(domain)));
+                        .compose(domain -> domain == null
+                                ? Future.succeededFuture(new DeploymentStatus(DeploymentStatusType.FAILED,
+                                                                              "The site's domain no longer exists; retry provisioning to create it again"))
+                                : statusOf(deployment, domain))
+                        .map(deployment::setStatus);
     }
 
     @Override
@@ -196,6 +209,7 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
             cdn = CdnManager.authenticate(credential, new AzureProfile(null, profile.subscriptionId(), AzureEnvironment.AZURE))
                             .serviceClient();
             dns = DnsZoneManager.authenticate(credential, new AzureProfile(null, zone.subscriptionId(), AzureEnvironment.AZURE));
+            web = WebClient.create(vertx);
         }
     }
 
@@ -213,78 +227,141 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
         return ret;
     }
 
-    /** The organization's origin group and its one origin, the storage account's blob endpoint. Emits the group's id. */
-    private Future<String> ensureOriginGroup(Organization organization) {
+    /**
+     * The organization's origin group, authenticating to its storage account as the profile's
+     * identity, and its one origin, the account's blob endpoint. A group without that
+     * authentication is written again.
+     */
+    private Future<Void> ensureOriginGroup(Organization organization) {
         String groupName = originGroupName(organization);
+        String groupPath = originGroupId(organization);
         String host = URI.create(organization.getStorage().getAzureBlobEndpoint()).getHost();
-        return getOrCreate(cdn.getAfdOriginGroups().getAsync(resourceGroup, profileName, groupName),
-                           () -> cdn.getAfdOriginGroups().createAsync(resourceGroup, profileName, groupName, new AfdOriginGroupInner()
-                                   .withLoadBalancingSettings(new LoadBalancingSettingsParameters()
-                                           .withSampleSize(4)
-                                           .withSuccessfulSamplesRequired(3)
-                                           .withAdditionalLatencyInMilliseconds(50))
-                                   .withSessionAffinityState(EnabledState.DISABLED)))
-                .compose(group -> getOrCreate(cdn.getAfdOrigins().getAsync(resourceGroup, profileName, groupName, ORIGIN_NAME),
-                                              () -> cdn.getAfdOrigins().createAsync(resourceGroup, profileName, groupName, ORIGIN_NAME,
-                                                                                    new AfdOriginInner()
-                                                                                            .withHostname(host)
-                                                                                            .withOriginHostHeader(host)
-                                                                                            .withHttpPort(80)
-                                                                                            .withHttpsPort(443)
-                                                                                            .withPriority(1)
-                                                                                            .withWeight(1000)
-                                                                                            .withEnabledState(EnabledState.ENABLED)
-                                                                                            .withEnforceCertificateNameCheck(true)))
-                        .map(origin -> group.id()));
+        JsonObject desired = originGroup();
+        return arm(HttpMethod.GET, groupPath, null)
+                .compose(existing -> {
+                    Future<Void> ret;
+                    if (existing != null && authenticatesAsDesired(existing, desired)) {
+                        ret = Future.succeededFuture();
+                    } else {
+                        ret = write(() -> armCall(HttpMethod.PUT, groupPath, desired).then(awaitOriginGroup(groupName)));
+                    }
+                    return ret;
+                })
+                .compose(v -> getOrCreate(cdn.getAfdOrigins().getAsync(resourceGroup, profileName, groupName, ORIGIN_NAME),
+                                          () -> cdn.getAfdOrigins().createAsync(resourceGroup, profileName, groupName, ORIGIN_NAME,
+                                                                                new AfdOriginInner()
+                                                                                        .withHostname(host)
+                                                                                        .withOriginHostHeader(host)
+                                                                                        .withHttpPort(80)
+                                                                                        .withHttpsPort(443)
+                                                                                        .withPriority(1)
+                                                                                        .withWeight(1000)
+                                                                                        .withEnabledState(EnabledState.ENABLED)
+                                                                                        .withEnforceCertificateNameCheck(true))))
+                .mapEmpty();
     }
 
-    /** The organization's rule set and its two rules, each created when missing. Emits the rule set's id. */
-    private Future<String> ensureRuleSet(Organization organization) {
-        String ruleSetName = ruleSetName(organization);
-        return getOrCreate(cdn.getRuleSets().getAsync(resourceGroup, profileName, ruleSetName),
-                           () -> cdn.getRuleSets().createAsync(resourceGroup, profileName, ruleSetName))
-                .compose(ruleSet -> ensureRule(organization, ruleSetName, ASSET_RULE)
-                        .compose(v -> ensureRule(organization, ruleSetName, SPA_RULE))
-                        .map(v -> ruleSet.id()));
+    private static boolean authenticatesAsDesired(JsonObject existing, JsonObject desired) {
+        JsonObject actual = existing.getJsonObject("properties").getJsonObject("authentication");
+        JsonObject wanted = desired.getJsonObject("properties").getJsonObject("authentication");
+        return actual != null
+                && wanted.getString("type").equals(actual.getString("type"))
+                && wanted.getString("scope").equals(actual.getString("scope"));
     }
 
-    // The SAS is minted only for a rule being written, so an existing rule costs one read
-    private Future<Void> ensureRule(Organization organization, String ruleSetName, String ruleName) {
-        return AzureUtil.toFuture(AzureUtil.emptyIfNotFound(cdn.getRules().getAsync(resourceGroup, profileName, ruleSetName, ruleName)), vertx)
-                        .compose(existing -> {
-                            Future<Void> ret;
-                            if (existing != null) {
-                                ret = Future.succeededFuture();
-                            } else {
-                                ret = organizationStorageService.issueReadToken(organization, READ_TOKEN_TTL)
-                                        .compose(token -> write(() -> cdn.getRules().createAsync(
-                                                resourceGroup, profileName, ruleSetName, ruleName, rule(ruleName, token))))
-                                        .mapEmpty();
-                            }
-                            return ret;
-                        });
+    // Origin authentication requires HTTPS health probes on the group; the SDK's models
+    // predate the authentication property, so the group is written as the API's JSON
+    private static JsonObject originGroup() {
+        return new JsonObject().put("properties", new JsonObject()
+                .put("loadBalancingSettings", new JsonObject()
+                        .put("sampleSize", 4)
+                        .put("successfulSamplesRequired", 3)
+                        .put("additionalLatencyInMilliseconds", 50))
+                .put("healthProbeSettings", new JsonObject()
+                        .put("probePath", PROBE_PATH)
+                        .put("probeRequestType", "HEAD")
+                        .put("probeProtocol", "Https")
+                        .put("probeIntervalInSeconds", PROBE_INTERVAL_SECONDS))
+                .put("sessionAffinityState", "Disabled")
+                .put("authentication", new JsonObject()
+                        .put("type", "SystemAssignedIdentity")
+                        .put("scope", STORAGE_SCOPE)));
+    }
+
+    // The PUT is accepted before the group is provisioned; the SDK's read reports when it is
+    private Mono<Void> awaitOriginGroup(String groupName) {
+        return cdn.getAfdOriginGroups().getAsync(resourceGroup, profileName, groupName)
+                  .flatMap(group -> {
+                      Mono<Void> ret;
+                      AfdProvisioningState state = group.provisioningState();
+                      if (AfdProvisioningState.SUCCEEDED.equals(state)) {
+                          ret = Mono.empty();
+                      } else if (AfdProvisioningState.FAILED.equals(state)) {
+                          ret = Mono.error(new IllegalStateException("Origin group " + groupName + " failed to provision"));
+                      } else {
+                          ret = Mono.delay(Duration.ofMillis(PROVISIONING_POLL_MS)).then(Mono.defer(() -> awaitOriginGroup(groupName)));
+                      }
+                      return ret;
+                  });
+    }
+
+    private Future<JsonObject> arm(HttpMethod method, String path, JsonObject body) {
+        return AzureUtil.toFuture(armCall(method, path, body), vertx);
     }
 
     /**
-     * The asset rule rewrites a request whose path names a file to that file; the spa rule
-     * rewrites one that names no file, a route of the single-page application, to its
-     * {@code index.html}. Either way the SAS is appended for the origin.
+     * A call on the profile's resources at {@link #ORIGIN_GROUP_API_VERSION}, through the SDK's
+     * authenticated pipeline. Emits the response body, nothing for a 404, and fails with the
+     * management plane's exception otherwise, so a busy profile's 409 is retried like any write.
      */
-    private static RuleInner rule(String name, String token) {
-        boolean spa = SPA_RULE.equals(name);
-        // Front Door validates the destination as a literal that must begin with "/", and the
-        // url_path server variable expands without its leading slash
+    private Mono<JsonObject> armCall(HttpMethod method, String path, JsonObject body) {
+        HttpRequest request = new HttpRequest(method, cdn.getEndpoint() + path + "?api-version=" + ORIGIN_GROUP_API_VERSION);
+        if (body != null) {
+            request.setBody(body.encode()).setHeader(HttpHeaderName.CONTENT_TYPE, "application/json");
+        }
+        return cdn.getHttpPipeline().send(request)
+                  .flatMap(response -> response.getBodyAsString().defaultIfEmpty("").flatMap(text -> {
+                      Mono<JsonObject> ret;
+                      int status = response.getStatusCode();
+                      if (status == 404) {
+                          ret = Mono.empty();
+                      } else if (status >= 200 && status < 300) {
+                          ret = Mono.just(text.isEmpty() ? new JsonObject() : new JsonObject(text));
+                      } else {
+                          ret = Mono.error(new ManagementException(method + " " + path + " answered " + status + ": " + text, response));
+                      }
+                      return ret;
+                  }));
+    }
+
+    /** The rule set every route shares and its one rule, each created when missing. */
+    private Future<Void> ensureRuleSet() {
+        return getOrCreate(cdn.getRuleSets().getAsync(resourceGroup, profileName, RULE_SET_NAME),
+                           () -> cdn.getRuleSets().createAsync(resourceGroup, profileName, RULE_SET_NAME))
+                .compose(ruleSet -> getOrCreate(cdn.getRules().getAsync(resourceGroup, profileName, RULE_SET_NAME, SPA_RULE),
+                                                () -> cdn.getRules().createAsync(resourceGroup, profileName, RULE_SET_NAME, SPA_RULE, spaRule())))
+                .mapEmpty();
+    }
+
+    /**
+     * Rewrites a request whose path names no file, a route of the single-page application, to
+     * its {@code index.html}; a request naming a file reaches the origin as it is.
+     */
+    private static RuleInner spaRule() {
+        // Front Door validates the destination as a literal that must begin with "/".
+        // UrlFileExtension Any matches a path with no extension as well, so it cannot tell a
+        // file from a route; an extension longer than zero can
         return new RuleInner()
-                .withOrder(spa ? 2 : 1)
+                .withOrder(1)
                 .withConditions(List.of(new DeliveryRuleUrlFileExtensionCondition()
                         .withParameters(new UrlFileExtensionMatchConditionParameters()
-                                .withOperator(UrlFileExtensionOperator.ANY)
-                                .withNegateCondition(spa)
-                                .withMatchValues(List.of()))))
+                                .withOperator(UrlFileExtensionOperator.GREATER_THAN)
+                                .withNegateCondition(true)
+                                .withMatchValues(List.of("0")))))
                 .withActions(List.of(new UrlRewriteAction()
                         .withParameters(new UrlRewriteActionParameters()
                                 .withSourcePattern("/")
-                                .withDestination((spa ? "/index.html" : "/{url_path}") + "?" + token)
+                                .withDestination("/index.html")
                                 .withPreserveUnmatchedPath(false))))
                 .withMatchProcessingBehavior(MatchProcessingBehavior.STOP);
     }
@@ -364,30 +441,49 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
         return recordSet.records().stream().anyMatch(record -> text.equals(String.join("", record.value())));
     }
 
-    /** The site's route: its domain, every path, HTTPS only, the UI's prefix in the container as origin path, cached. */
-    private Future<Void> ensureRoute(UiDeployment deployment, AfdDomainInner domain, String originGroupId, String ruleSetId) {
+    /**
+     * The site's route: its domain, every path, HTTPS only, the UI's prefix in the container as
+     * origin path, the shared rule set, cached. An existing route naming another rule set is
+     * written again.
+     */
+    private Future<Void> ensureRoute(UiDeployment deployment, AfdDomainInner domain, String originGroupId) {
         String label = deployment.getId();
+        String ruleSetId = properties().getFrontDoorProfileId() + "/ruleSets/" + RULE_SET_NAME;
+        RouteInner desired = route(deployment, domain, originGroupId, ruleSetId);
+        return endpointName()
+                .compose(endpoint -> AzureUtil.toFuture(AzureUtil.emptyIfNotFound(cdn.getRoutes().getAsync(resourceGroup, profileName, endpoint, label)), vertx)
+                        .compose(existing -> {
+                            Future<Void> ret;
+                            if (existing != null && existing.ruleSets() != null && existing.ruleSets().size() == 1
+                                    && ruleSetId.equalsIgnoreCase(existing.ruleSets().getFirst().id())) {
+                                ret = Future.succeededFuture();
+                            } else {
+                                ret = write(() -> cdn.getRoutes().createAsync(resourceGroup, profileName, endpoint, label, desired)).mapEmpty();
+                            }
+                            return ret;
+                        }));
+    }
+
+    private static RouteInner route(UiDeployment deployment, AfdDomainInner domain, String originGroupId, String ruleSetId) {
         String originPath = "/" + OrganizationStorageProvisioner.UI_CONTAINER + "/"
                 + UiStoragePaths.uiPrefix(deployment.getApplicationId(), deployment.getName());
-        return endpointName()
-                .compose(endpoint -> getOrCreate(cdn.getRoutes().getAsync(resourceGroup, profileName, endpoint, label),
-                                                 () -> cdn.getRoutes().createAsync(resourceGroup, profileName, endpoint, label, new RouteInner()
-                                                         .withCustomDomains(List.of(new ActivatedResourceReference().withId(domain.id())))
-                                                         .withOriginGroup(new ResourceReference().withId(originGroupId))
-                                                         .withOriginPath(originPath)
-                                                         .withRuleSets(List.of(new ResourceReference().withId(ruleSetId)))
-                                                         .withSupportedProtocols(List.of(AfdEndpointProtocols.HTTP, AfdEndpointProtocols.HTTPS))
-                                                         .withPatternsToMatch(List.of("/*"))
-                                                         .withForwardingProtocol(ForwardingProtocol.HTTPS_ONLY)
-                                                         .withLinkToDefaultDomain(LinkToDefaultDomain.DISABLED)
-                                                         .withHttpsRedirect(HttpsRedirect.ENABLED)
-                                                         .withCacheConfiguration(new AfdRouteCacheConfiguration()
-                                                                 .withQueryStringCachingBehavior(AfdQueryStringCachingBehavior.IGNORE_QUERY_STRING)
-                                                                 .withCompressionSettings(new CompressionSettings()
-                                                                         .withIsCompressionEnabled(true)
-                                                                         .withContentTypesToCompress(COMPRESSED_CONTENT_TYPES)))
-                                                         .withEnabledState(EnabledState.ENABLED))))
-                .mapEmpty();
+        return new RouteInner()
+                .withCustomDomains(List.of(new ActivatedResourceReference().withId(domain.id())))
+                .withOriginGroup(new ResourceReference().withId(originGroupId))
+                .withOriginPath(originPath)
+                .withRuleSets(List.of(new ResourceReference().withId(ruleSetId)))
+                .withSupportedProtocols(List.of(AfdEndpointProtocols.HTTP, AfdEndpointProtocols.HTTPS))
+                .withPatternsToMatch(List.of("/*"))
+                // origin authentication requires HTTPS to the origin
+                .withForwardingProtocol(ForwardingProtocol.HTTPS_ONLY)
+                .withLinkToDefaultDomain(LinkToDefaultDomain.DISABLED)
+                .withHttpsRedirect(HttpsRedirect.ENABLED)
+                .withCacheConfiguration(new AfdRouteCacheConfiguration()
+                        .withQueryStringCachingBehavior(AfdQueryStringCachingBehavior.IGNORE_QUERY_STRING)
+                        .withCompressionSettings(new CompressionSettings()
+                                .withIsCompressionEnabled(true)
+                                .withContentTypesToCompress(COMPRESSED_CONTENT_TYPES)))
+                .withEnabledState(EnabledState.ENABLED);
     }
 
     /** The name of the profile's endpoint, resolved once from the configured host name. */
@@ -410,16 +506,66 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
         return ret;
     }
 
-    private static DeploymentStatus statusOf(AfdDomainInner domain) {
+    /**
+     * The site's status: failed when its domain's validation cannot succeed, ready once
+     * {@code version.json} at its hostname answers with the deployment's commit and the root
+     * answers with the index, and provisioning, with what was observed, until then.
+     */
+    private Future<DeploymentStatus> statusOf(UiDeployment deployment, AfdDomainInner domain) {
         DomainValidationState validation = domain.domainValidationState();
-        DeploymentStatus ret;
-        if (DomainValidationState.APPROVED.equals(validation) && com.azure.resourcemanager.cdn.models.DeploymentStatus.SUCCEEDED.equals(domain.deploymentStatus())) {
-            ret = new DeploymentStatus(DeploymentStatusType.READY);
-        } else if (validationLapsed(validation) || DomainValidationState.INTERNAL_ERROR.equals(validation)) {
-            ret = new DeploymentStatus(DeploymentStatusType.FAILED, "Validation of " + domain.hostname() + " "
-                    + validation + "; retry provisioning to validate again");
+        Future<DeploymentStatus> ret;
+        if (validationLapsed(validation) || DomainValidationState.INTERNAL_ERROR.equals(validation)) {
+            ret = Future.succeededFuture(new DeploymentStatus(DeploymentStatusType.FAILED, "Validation of " + domain.hostname() + " "
+                    + validation + "; retry provisioning to validate again"));
         } else {
-            ret = new DeploymentStatus(DeploymentStatusType.PROVISIONING);
+            ret = servingStatus(deployment);
+        }
+        return ret;
+    }
+
+    // Front Door reports a domain approved and its certificate deployed before the route
+    // serves, and a configuration change takes up to 15 minutes to reach its edges, longer
+    // when changes queue, so only requests through the site tell that it serves: the version
+    // file for the commit, and the root for the spa rule, which the version file bypasses
+    private Future<DeploymentStatus> servingStatus(UiDeployment deployment) {
+        String site = properties().resolveSiteUrl(deployment.getId());
+        String versionUrl = site + "/" + VERSION_FILE;
+        String rootUrl = site + "/";
+        return web.getAbs(versionUrl).timeout(HTTP_TIMEOUT_MS).send()
+                  .compose(version -> {
+                      Future<DeploymentStatus> ret;
+                      String served = version.statusCode() == 200 ? servedCommit(version) : null;
+                      if (served != null && served.equals(deployment.getCommitSha())) {
+                          ret = web.getAbs(rootUrl).timeout(HTTP_TIMEOUT_MS).send()
+                                   .map(root -> servesHtml(root)
+                                           ? new DeploymentStatus(DeploymentStatusType.READY)
+                                           : new DeploymentStatus(DeploymentStatusType.PROVISIONING,
+                                                                  rootUrl + " answered " + root.statusCode() + " " + root.getHeader("Content-Type")));
+                      } else if (version.statusCode() == 200) {
+                          ret = Future.succeededFuture(new DeploymentStatus(DeploymentStatusType.PROVISIONING,
+                                                                            versionUrl + " serves commit " + served + ", not " + deployment.getCommitSha()));
+                      } else {
+                          ret = Future.succeededFuture(new DeploymentStatus(DeploymentStatusType.PROVISIONING,
+                                                                            versionUrl + " answered " + version.statusCode()));
+                      }
+                      return ret;
+                  })
+                  .otherwise(error -> new DeploymentStatus(DeploymentStatusType.PROVISIONING, site + " is unreachable: " + error.getMessage()));
+    }
+
+    // The root unrewritten is the UI's directory, which the account answers with an empty 200
+    private static boolean servesHtml(HttpResponse<Buffer> response) {
+        String type = response.getHeader("Content-Type");
+        return response.statusCode() == 200 && type != null && type.startsWith("text/html");
+    }
+
+    // A 200 that is not the version file, such as the index the spa rule serves, is not a commit
+    private static String servedCommit(HttpResponse<Buffer> response) {
+        String ret;
+        try {
+            ret = response.bodyAsJsonObject().getString("commitSha");
+        } catch (RuntimeException e) {
+            ret = null;
         }
         return ret;
     }
@@ -501,9 +647,8 @@ public class FrontDoorUiDeploymentProvisioner implements UiDeploymentProvisioner
         return "org-" + organization.getId();
     }
 
-    // Rule set names allow no dash
-    private static String ruleSetName(Organization organization) {
-        return "org" + organization.getId().replace("-", "");
+    private String originGroupId(Organization organization) {
+        return properties().getFrontDoorProfileId() + "/originGroups/" + originGroupName(organization);
     }
 
     private static void requireStorage(Organization organization) {

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
@@ -520,8 +520,9 @@ public class ProjectDeployJobDefinitionFactory {
                                             String commitSha) {
         Future<UiDeployment> deployment;
         if (existing == null) {
+            // the files are up, so the site is ready once it serves this commit
             deployment = mintDeployment(project, ui)
-                    .compose(minted -> uiDeploymentProvisioner.provision(minted, organization));
+                    .compose(minted -> uiDeploymentProvisioner.provision(minted.setCommitSha(commitSha), organization));
         } else if (existing.getStatus().type() == DeploymentStatusType.ORPHANED) {
             // the site never stopped serving, so the UI's return needs no provisioning
             deployment = Future.succeededFuture(existing.setStatus(new DeploymentStatus(DeploymentStatusType.READY)));

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/AzureProvisioningIntegrationTest.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/AzureProvisioningIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.kinotic.system.internal.api.services;
 
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.identity.DefaultAzureCredentialBuilder;
@@ -17,8 +18,13 @@ import com.azure.resourcemanager.dns.models.DnsZone;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import com.azure.resourcemanager.storage.StorageManager;
 import com.azure.resourcemanager.storage.models.BlobContainer;
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.azure.storage.blob.models.BlobHttpHeaders;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -41,8 +47,13 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -77,14 +88,21 @@ class AzureProvisioningIntegrationTest {
     private static final String PROJECT_ID = "azure-it-project";
     private static final String UI_NAME = "web";
     private static final String SITE_LABEL = "azure-it";
+    private static final String COMMIT_SHA = "0000000000000000000000000000000000000000";
+    private static final String INDEX_HTML = "<!doctype html><title>azure-it</title>";
     /** A storage account or a Front Door write takes minutes; a step past this is stuck. */
     private static final long STEP_TIMEOUT_MINUTES = 15;
+    /** A site serves once its configuration reaches Front Door's edges, which Microsoft bounds at 15 minutes per change and longer when changes queue. */
+    private static final long SITE_TIMEOUT_MINUTES = 45;
+    private static final long SITE_POLL_MS = 30_000;
 
     private Vertx vertx;
     private KinoticSystemApiProperties properties;
     private TokenCredential credential;
     private AzureOrganizationStorageProvisioner storageProvisioner;
+    private AzureOrganizationStorageService storageService;
     private FrontDoorUiDeploymentProvisioner siteProvisioner;
+    private final HttpClient http = HttpClient.newHttpClient();
     private Organization organization;
 
     @BeforeAll
@@ -102,9 +120,8 @@ class AzureProvisioningIntegrationTest {
                                                                    .setName("Azure integration test")
                                                                    .setCreated(new Date()));
         storageProvisioner = new AzureOrganizationStorageProvisioner(organizations, vertx, properties);
-        siteProvisioner = new FrontDoorUiDeploymentProvisioner(vertx, properties,
-                                                               new AzureOrganizationStorageService(vertx, properties),
-                                                               new StubUiDeploymentRepository());
+        storageService = new AzureOrganizationStorageService(vertx, properties);
+        siteProvisioner = new FrontDoorUiDeploymentProvisioner(vertx, properties, new StubUiDeploymentRepository());
     }
 
     @AfterAll
@@ -134,42 +151,50 @@ class AzureProvisioningIntegrationTest {
     @Test
     @Order(2)
     @Timeout(value = STEP_TIMEOUT_MINUTES, unit = TimeUnit.MINUTES)
-    void preparesFrontDoorForTheOrganization() {
+    void preparesFrontDoorForTheOrganization() throws Exception {
         assumeTrue(organization != null, "the storage step did not complete");
 
         await(siteProvisioner.prepareOrganization(organization));
 
         CdnManagementClient cdn = cdnClient();
-        assertNotNull(cdn.getAfdOriginGroups().get(resourceGroup(), profileName(), "org-" + ORGANIZATION_ID),
-                      "the organization's origin group exists");
-        String ruleSet = "org" + ORGANIZATION_ID.replace("-", "");
-        for (String name : List.of("asset", "spa")) {
-            RuleInner rule = cdn.getRules().get(resourceGroup(), profileName(), ruleSet, name);
-            UrlRewriteAction rewrite = (UrlRewriteAction) rule.actions().getFirst();
-            String destination = rewrite.parameters().destination();
-            assertTrue(destination.startsWith("/"), name + " rule rewrites to " + destination);
-            assertTrue(destination.contains("sig="), name + " rule carries the SAS: " + destination);
-        }
+        // the SDK's client predates origin authentication, so the group is read at the API version that has it
+        String token = credential.getToken(new TokenRequestContext().addScopes("https://management.azure.com/.default")).block().getToken();
+        HttpRequest request = HttpRequest.newBuilder(URI.create("https://management.azure.com" + uiProperties().getFrontDoorProfileId()
+                                                                        + "/originGroups/org-" + ORGANIZATION_ID + "?api-version=2025-06-01"))
+                                         .header("Authorization", "Bearer " + token)
+                                         .build();
+        HttpResponse<String> group = http.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, group.statusCode(), "the organization's origin group exists: " + group.body());
+        JsonObject authentication = new JsonObject(group.body()).getJsonObject("properties").getJsonObject("authentication");
+        assertNotNull(authentication, "the origin group authenticates as the profile's identity");
+        assertEquals("SystemAssignedIdentity", authentication.getString("type"));
+
+        RuleInner rule = cdn.getRules().get(resourceGroup(), profileName(), "sites", "spa");
+        UrlRewriteAction rewrite = (UrlRewriteAction) rule.actions().getFirst();
+        assertEquals("/index.html", rewrite.parameters().destination(), "the spa rule rewrites to the index");
     }
 
     @Test
     @Order(3)
-    @Timeout(value = STEP_TIMEOUT_MINUTES, unit = TimeUnit.MINUTES)
-    void provisionsASite() {
+    @Timeout(value = SITE_TIMEOUT_MINUTES, unit = TimeUnit.MINUTES)
+    void provisionsASite() throws Exception {
         assumeTrue(organization != null, "the storage step did not complete");
+        // the files go up before the site is provisioned, as the publish task orders it
+        publish(UI_NAME + "/version.json", new JsonObject().put("commitSha", COMMIT_SHA).encode(), "application/json");
+        publish(UI_NAME + "/index.html", INDEX_HTML, "text/html");
         UiDeployment deployment = new UiDeployment().setId(SITE_LABEL)
                                                     .setOrganizationId(ORGANIZATION_ID)
                                                     .setApplicationId(APPLICATION_ID)
                                                     .setProjectId(PROJECT_ID)
                                                     .setName(UI_NAME)
-                                                    .setCommitSha("0000000000000000000000000000000000000000")
+                                                    .setCommitSha(COMMIT_SHA)
                                                     .setStatus(new DeploymentStatus(DeploymentStatusType.PROVISIONING))
                                                     .setCreated(new Date())
                                                     .setUpdated(new Date());
 
         UiDeployment provisioned = await(siteProvisioner.provision(deployment, organization));
 
-        // ready only once Front Door has validated the hostname, which takes minutes; provisioning is the expected first answer
+        // ready only once the site serves the commit through Front Door, minutes after a new hostname's records resolve
         assertNotEquals(DeploymentStatusType.FAILED, provisioned.getStatus().type(), provisioned.getStatus().message());
 
         String hostname = uiProperties().resolveHostname(SITE_LABEL);
@@ -187,6 +212,46 @@ class AzureProvisioningIntegrationTest {
         CnameRecordSet cname = zone.cNameRecordSets().getByName(SITE_LABEL + suffix);
         assertEquals(uiProperties().getFrontDoorEndpointHostName().toLowerCase(), cname.canonicalName().toLowerCase());
         assertNotNull(zone.txtRecordSets().getByName("_dnsauth." + SITE_LABEL + suffix), "the validation TXT record exists");
+
+        UiDeployment site = provisioned;
+        while (site.getStatus().type() == DeploymentStatusType.PROVISIONING) {
+            Thread.sleep(SITE_POLL_MS);
+            site = await(siteProvisioner.checkProvisioning(site));
+        }
+        assertEquals(DeploymentStatusType.READY, site.getStatus().type(), site.getStatus().message());
+
+        // a route or origin group written moments ago is still propagating to the edges, and an
+        // earlier configuration of the same site may answer meanwhile, so each check is retried
+        String url = uiProperties().resolveSiteUrl(SITE_LABEL);
+        assertServes(url + "/version.json", new JsonObject().put("commitSha", COMMIT_SHA).encode(), "a file is served as it is");
+        assertServes(url + "/", INDEX_HTML, "the spa rule serves index.html at the root");
+        assertServes(url + "/some/route", INDEX_HTML, "the spa rule serves index.html for a route");
+        assertServes(url + "/?code=abc&state=xyz", INDEX_HTML, "a query string, as an OAuth callback carries, reaches the index");
+        assertEquals(404, get(url + "/missing.js").statusCode(), "a file that is not published is not the index");
+    }
+
+    private HttpResponse<String> get(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private void assertServes(String url, String expected, String message) throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(SITE_TIMEOUT_MINUTES);
+        String body = get(url).body();
+        while (!expected.equals(body) && System.currentTimeMillis() < deadline) {
+            Thread.sleep(SITE_POLL_MS);
+            body = get(url).body();
+        }
+        assertEquals(expected, body, message);
+    }
+
+    /** Uploads one file of the UI the way the publish workload does: through the application's upload URL, uncached. */
+    private void publish(String path, String content, String contentType) {
+        String uploadUrl = await(storageService.issueUploadUrl(organization, APPLICATION_ID, Duration.ofMinutes(STEP_TIMEOUT_MINUTES)));
+        int query = uploadUrl.indexOf('?');
+        BlobClient blob = new BlobClientBuilder().endpoint(uploadUrl.substring(0, query) + "/" + path + uploadUrl.substring(query))
+                                                 .buildClient();
+        blob.upload(BinaryData.fromString(content), true);
+        blob.setHttpHeaders(new BlobHttpHeaders().setContentType(contentType).setCacheControl("no-cache"));
     }
 
     private <T> T await(Future<T> future) {

--- a/website/content/01.apps/07.deployment/03.push-to-deploy.md
+++ b/website/content/01.apps/07.deployment/03.push-to-deploy.md
@@ -130,7 +130,7 @@ year, and the site's index is replaced last.
 
 | Status | Meaning |
 |---|---|
-| `PROVISIONING` | The site is being created: its hostname is registered and its certificate issued |
+| `PROVISIONING` | The site is being created: its hostname is registered, its certificate issued, and it does not yet serve the recorded commit |
 | `READY` | The site serves the UI as of the recorded commit |
 | `ORPHANED` | The last deployed commit no longer contains the UI; the site keeps serving until removed |
 | `FAILED` | The site could not be created; the message says why |

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -202,9 +202,9 @@ that disables the provisioner sets them to placeholders. In the Azure deployment
 server; the development profile disables the provisioner, and the `local` profile of the
 [contributing guide](/platform/contributing#publishing-uis-against-azure) enables it against a
 developer's own profile. Front Door reads an organization's
-storage with a read-only container SAS its rule set carries, signed with the account key and
-written again whenever a site of the organization is provisioned; the account's public
-network is open to it, with anonymous access off.
+storage as the profile's managed identity, which terraform grants Storage Blob Data Reader
+on the group every organization's account is created in; the account's public network is
+open to it, with anonymous access off.
 
 ## Workload storage and log limits
 

--- a/website/content/02.platform/09.contributing.md
+++ b/website/content/02.platform/09.contributing.md
@@ -71,11 +71,13 @@ Create what the server cannot create itself, once:
 az login
 cd deployment/terraform/azure/dev
 terraform init
+terraform apply -target=azurerm_cdn_frontdoor_profile.sites   # the profile's identity first: its principal id is unknown until it exists
 terraform apply   # environment = "local" in terraform.tfvars; pick a name of your own
 terraform output -raw application_local_yml > ../../../../kinotic-server/src/main/resources/application-local.yml
 ```
 
-That is a resource group, a Front Door Standard profile with an endpoint, the
+That is a resource group, a Front Door Standard profile with an endpoint and an identity
+that reads every organization's storage, the
 `apps-<environment>.<zone>` sites domain in the platform's DNS zone, and a service principal
 for the server with the roles it needs: Contributor and Storage Blob Data Contributor on the
 group, DNS Zone Contributor on the zone, and Contributor on the email service, so it sends
@@ -124,11 +126,11 @@ records under `apps-<environment>` in the zone are removed by hand.
 
 Then sign up an organization, or open an existing one in the system console and choose
 **Provision again**: the `provision-organization-<id>` job creates its storage account and
-prepares its Front Door origin group and rule set, and the organization's overview shows the
+prepares its Front Door origin group, and the organization's overview shows the
 outcome. Deploy a project that contains a UI; the deployment publishes it and provisions its
 site, served at `https://<label>.apps-<environment>.<zone>` once Front Door has validated the
-domain and issued its certificate, which takes a few minutes and shows as the deployment
-turning from provisioning to ready.
+domain, issued its certificate and serves the UI's `version.json`, which takes a few minutes
+and shows as the deployment turning from provisioning to ready.
 
 `terraform destroy` removes the resource group with every storage account and Front Door
 resource the server created in it. The CNAME and validation TXT records of sites live in the

--- a/website/content/02.platform/11.reference/03.project-publishing-design.md
+++ b/website/content/02.platform/11.reference/03.project-publishing-design.md
@@ -84,7 +84,7 @@ the `MicroserviceDeployment` row; the sync identity stays on `ProjectDeployment`
 One storage account per organization, named `"kin" + hex(sha256(organizationId)).substring(0, 21)`:
 StorageV2, LRS, hierarchical namespace on, TLS 1.2, `allowBlobPublicAccess=false`, public
 network access open (Front Door reads from addresses the storage firewall cannot name, and
-every read is authorized by the SAS its rule set carries), a private endpoint in the platform
+every read is authorized by the bearer token of the profile's identity), a private endpoint in the platform
 VNet registered in `privatelink.blob.core.windows.net` unless
 `kinotic.systemApi.organizationStorage.disablePrivateEndpoint` is set, as it is where the server
 runs outside the VNet, tagged `org=<id>`. It holds one container, `sites` (container names
@@ -117,29 +117,45 @@ finalize step deletes every sha directory except the current one and the one it 
 
 ## Serving
 
-One Front Door Standard profile and endpoint, created by terraform. Per organization, created
-with the organization once its storage is ready, and named by id by every site's route:
-origin group
-`org-<orgId>` with health probes off, origin `<account>.blob.core.windows.net` with the same
-origin host header, and rule set `org<orgIdWithoutDashes>` holding two rules that carry a
-read-only SAS on container `ui`:
+One Front Door Standard profile and endpoint, created by terraform, with a system-assigned
+managed identity that terraform grants **Storage Blob Data Reader** on the resource group
+every organization's storage account is created in. Per organization, created with the
+organization once its storage is ready and named by id by every site's route: origin group
+`org-<orgId>`, authenticating to the origin as that identity (`SystemAssignedIdentity`,
+scope `https://storage.azure.com/.default`), with HTTPS health probes on the container's
+properties, which origin authentication requires, and origin `<account>.blob.core.windows.net`
+with the same origin host header. Front Door puts the identity's bearer token on every
+request it forwards, so no SAS travels in the configuration and a request's own query string
+reaches the origin unchanged. Origin authentication exists from API version `2025-06-01`,
+which the Java CDN SDK does not speak yet, so the provisioner writes the origin group as JSON
+through the SDK's pipeline and polls the SDK's read until it is provisioned.
+
+Shared by every route, created once, the rule set `sites` with one rule:
 
 ```
-asset  url_file_extension Any           → rewrite /  →  {url_path}?<sas>      preserve_unmatched_path = false
-spa    url_file_extension Any, negated  → rewrite /  →  /index.html?<sas>     preserve_unmatched_path = false
+spa    url_file_extension GreaterThan 0, negated  → rewrite /  →  /index.html     preserve_unmatched_path = false
 ```
+
+`url_file_extension Any` matches a path with no extension as well, so it cannot tell a file
+from a route of the single-page application; the extension's length can. A request naming a
+file reaches the origin as it is, under the route's origin path.
 
 Per site, created on first publish: a custom domain `<label>.<sitesDomain>` with a managed
 certificate; DNS in the `kinotic.ai` zone, `CNAME <label>.apps → <profile endpoint host>` and
 `TXT _dnsauth.<label>.apps → <validation token>`; and a route for that domain with pattern
-`/*`, HTTPS only with redirect, the organization's origin group, origin path
-`/sites/prod/<app>/ui/<ui>`, the organization's rule set, caching on and query strings ignored.
-The SAS is signed with the account key (`OrganizationStorageService.issueReadToken`) and
-lasts ten years; each rule is written once, with the organization, and nothing writes it
-again yet, so a rotated account key has no path back into the rule set. Front Door writes are slow, serialized per profile, and answer 409 when one is in
-flight, so the provisioner issues one write at a time per profile with backoff. A site is
-`PROVISIONING` until the domain validates and the certificate is deployed, then `READY`;
-`FAILED` with the message otherwise, with `retryProvisioning`. The provisioner checks a
+`/*`, HTTPS only with redirect (origin authentication requires HTTPS to the origin), the
+organization's origin group, origin path `/sites/prod/<app>/ui/<ui>`, the shared rule set,
+caching on and query strings ignored. A route naming another rule set is written again.
+Front Door writes are slow, serialized per profile, and answer 409 when one is in flight, so
+the provisioner issues one write at a time per profile with backoff; a change takes up to
+15 minutes to reach every edge, longer when changes queue. A site is `PROVISIONING` until
+`https://<hostname>/version.json` answers through Front Door with the deployment's commit
+and `https://<hostname>/` answers with HTML (the root unrewritten is the UI's directory, an
+empty 200, and a file bypasses the spa rule), then `READY`; the domain's validation and
+certificate flags say nothing about the route, the rule set or the propagation, so they are
+not consulted, and an earlier configuration of the same site may still answer while a new
+one propagates. `FAILED` with the message when the
+domain's validation cannot succeed, with `retryProvisioning`. The provisioner checks a
 provisioning site every 30 seconds for up to two hours after provisioning it and records the
 outcome on its row; a site still provisioning after that, or one whose polling died with the
 server, is checked again whenever its project's UI deployments are listed.
@@ -270,17 +286,19 @@ notification of publishes, and service endpoints instead of private endpoints.
   sites, adopts returning ones, orphans vanished ones, keeps the current and previous commit
   directories and deletes the rest. The exit check is shared with the sync task, and the
   previous publish workload is retired by the next run's target resolution.
-- **Sites on Front Door.** `FrontDoorUiDeploymentProvisioner` creates, per organization on
-  its first site, the origin group `org-<orgId>` on the storage account's blob host and the
-  rule set `org<orgIdWithoutDashes>` with the `asset` and `spa` rewrite rules carrying the
-  read-only SAS from `OrganizationStorageService.issueReadToken`; per site the custom domain
-  with a managed certificate, the CNAME and `_dnsauth` TXT records in the platform zone, and
-  the route with the UI's prefix as origin path, naming the organization's origin group and
-  rule set by id. Every step is get-or-create, a lapsed validation gets a new token, profile writes are queued and retried on 409, and a
-  provisioning site is polled in the background until it is `READY` or `FAILED`. `remove`
-  deletes the route, the domain and the two records. `AzureUtil` classifies the management
-  plane's 404 and 409 for both provisioners. Terraform (`frontdoor.tf`) owns the profile and
-  endpoint and grants the server CDN Profile Contributor and DNS Zone Contributor; the
+- **Sites on Front Door.** `FrontDoorUiDeploymentProvisioner` creates, per organization
+  when it is provisioned, the origin group `org-<orgId>` on the storage account's blob host,
+  authenticating as the profile's managed identity, and once the shared rule set `sites`
+  with the `spa` rewrite rule; per site the custom domain with a managed certificate, the
+  CNAME and `_dnsauth` TXT records in the platform zone, and the route with the UI's prefix
+  as origin path, naming the organization's origin group and the shared rule set by id.
+  Every step is get-or-create, a lapsed validation gets a new token, profile writes are
+  queued and retried on 409, and a provisioning site is polled in the background until
+  `version.json` serves its commit through Front Door and it is `READY`, or it is `FAILED`.
+  `remove` deletes the route, the domain and the two records. `AzureUtil` classifies the
+  management plane's 404 and 409 for both provisioners. Terraform (`frontdoor.tf`) owns the
+  profile, its identity and that identity's Storage Blob Data Reader on the organization
+  storage group, and grants the server CDN Profile Contributor and DNS Zone Contributor; the
   storage account's public network is open so Front Door can read it.
 - **UI deployments in the console.** `UiDeploymentService` (`findAllForProject`,
   `retryProvisioning`, `remove`), published from management-api and delegating to the


### PR DESCRIPTION
## What was wrong

The site answered `409 PublicAccessNotPermitted` because Front Door had not yet propagated the rules written minutes earlier: Microsoft bounds a configuration change at 15 minutes to reach the edges, ~30 when changes queue, and it has run longer since October ([FAQ](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-faq)). Every change observed today took 15 to 25 minutes. Two real defects came out of the investigation, and one design change replaces the SAS mechanism.

**`UrlFileExtension Any` matches a path with no extension**, so the negated `spa` rule never fired. From the storage account's request log, before the fix:

```
GetBlob BlobNotFound  /sites/prod/todo-neon/ui/app/some/route?sv=…    # a route, not rewritten to index.html
GetBlob InvalidRange  /sites/prod/todo-neon/ui/app/?sv=…              # the root: a 0-byte HNS directory
```

```java
// before
.withOperator(UrlFileExtensionOperator.ANY).withNegateCondition(spa).withMatchValues(List.of())
// after: an extension longer than zero names a file
.withOperator(UrlFileExtensionOperator.GREATER_THAN).withNegateCondition(true).withMatchValues(List.of("0"))
```

**READY came from the domain's flags**, which report `Approved`/`Succeeded` while the route serves nothing:

```java
// before
if (APPROVED.equals(validation) && SUCCEEDED.equals(domain.deploymentStatus())) ret = READY;
// after: only the site itself proves it serves
web.getAbs(site + "/version.json") … served.equals(deployment.getCommitSha())
web.getAbs(site + "/")            … 200 with text/html            // the spa rule, which the version file bypasses
```

## The design change

Front Door Standard authenticates to Blob Storage as the profile's managed identity ([origin authentication](https://learn.microsoft.com/en-us/azure/frontdoor/origin-authentication-with-managed-identities), API `2025-06-01`), so no SAS travels in a rewrite rule. It also fixes a third problem: Front Door appends the request's query string to the rewritten URL, so `/?code=…` on the SAS design reached storage as `…sig=xxx?code=…` and failed with `Signature fields not well formed`.

```java
// before, per organization: two rules carrying a 10-year SAS
.withDestination((spa ? "/index.html" : "/{url_path}") + "?" + token)

// after: the origin group authenticates; one shared rule set "sites" with one rule
.put("authentication", new JsonObject().put("type", "SystemAssignedIdentity").put("scope", "https://storage.azure.com/.default"))
.withDestination("/index.html")
```

The Java CDN SDK is pinned to API `2024-02-01` (2.53.10 is the latest on Maven), so the origin group is written as JSON through the SDK's authenticated pipeline and polled through the SDK's read. `OrganizationStorageService.issueReadToken` is gone.

Terraform, both roots: `identity { type = "SystemAssigned" }` on the profile and one `Storage Blob Data Reader` assignment on the organization storage group. The provider cannot read a new identity's principal id in the plan that creates it, so a fresh root applies the profile first (`terraform apply -target=azurerm_cdn_frontdoor_profile.sites && terraform apply`); documented in both roots.

## Verification

`:kinotic-system-api:test` passes. `AzureProvisioningIntegrationTest` provisions `kinotic-azure-it` against the local profile, reads the origin group's authentication at `2025-06-01`, uploads an index and `version.json`, waits for the site (21 minutes of propagation on the first run), then checks through Front Door:

```
/                    -> index.html
/some/route          -> index.html
/?code=abc&state=xyz -> index.html
/version.json        -> {"commitSha":"000…"}
/missing.js          -> 404
```

The storage account's log records Front Door's requests as `OAuthSuccess`, authentication type `bearer`.

## After merging

Restart the server on this branch, **Provision again** on each existing organization (writes its origin group's authentication) and **retry provisioning** on each site (moves its route to the shared rule set), then delete the old `org<id>` rule sets with `az afd rule-set delete`. Both writes take up to 15 minutes to propagate; the row stays PROVISIONING with the last observed answer until the site serves.

Not in this PR: the todo-neon project's `vite.config.ts` does not honor `KINOTIC_UI_BASE_PATH`, so its index references `/assets/…` while the assets are published under `/<sha>/assets/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD5Xz2gy6UZ9wyzF8sVWdN
