### PR TITLE
Read timestamps as they arrive wherever they are compared; runs chart: axis labels clear of the legend

### DIFF
--- a/kinotic-frontend/apps/system/src/components/JobRunsByDayChart.vue
+++ b/kinotic-frontend/apps/system/src/components/JobRunsByDayChart.vue
@@ -20,7 +20,7 @@ import { RouterLink, type RouteLocationRaw } from 'vue-router'
 import VChart from 'vue-echarts'
 
 import { ExecutionStatus, type JobRun } from '@kinotic-ai/management-api'
-import { accentColor, chartGridColor, chartLegend, chartTextColor, isDark } from '@kinotic-ai/frontend-common'
+import { DatetimeUtil, accentColor, chartGridColor, chartLegend, chartTextColor, isDark } from '@kinotic-ai/frontend-common'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -43,8 +43,9 @@ const buckets = computed(() => {
     return { label: day.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric' }), completed: 0, failed: 0 }
   })
   for (const run of props.runs) {
-    if (run.started === null) continue
-    const index = Math.floor((run.started - firstDay) / DAY_MS)
+    const started = DatetimeUtil.toEpochMillis(run.started)
+    if (started === null) continue
+    const index = Math.floor((started - firstDay) / DAY_MS)
     const bucket = ret[index]
     if (!bucket) continue
     if (run.status === ExecutionStatus.COMPLETED) {

--- a/kinotic-frontend/apps/system/src/components/JobRunsByDayChart.vue
+++ b/kinotic-frontend/apps/system/src/components/JobRunsByDayChart.vue
@@ -7,8 +7,11 @@
       </div>
       <RouterLink v-if="viewAllTo" :to="viewAllTo" class="whitespace-nowrap text-sm text-muted-color hover:text-color">View all</RouterLink>
     </div>
+    <div v-if="runs.length === 0" class="flex h-44 items-center justify-center text-sm text-muted-color">
+      No runs in the last {{ days }} days
+    </div>
     <!-- vue-echarts sizes from inline style, so the fixed height lives on a wrapper -->
-    <div class="h-44 w-full">
+    <div v-else class="h-44 w-full">
       <VChart style="height: 100%; width: 100%;" :option="option" autoresize />
     </div>
   </div>
@@ -71,7 +74,8 @@ const option = computed(() => {
   })
   return {
     animationDuration: 300,
-    grid: { left: 28, right: 8, top: 8, bottom: 30, containLabel: false },
+    // containLabel keeps the axis labels inside the grid's box; the bottom margin is the legend's row
+    grid: { left: 8, right: 16, top: 12, bottom: 36, containLabel: true },
     tooltip: { trigger: 'axis', confine: true },
     legend: chartLegend(dark),
     xAxis: {

--- a/kinotic-frontend/apps/system/src/components/WorkloadsTable.vue
+++ b/kinotic-frontend/apps/system/src/components/WorkloadsTable.vue
@@ -172,7 +172,7 @@ function sortRows(rows: WorkloadRow[], sort: Sort | null | undefined): void {
     } else if (property === 'status') {
       cmp = a.status.localeCompare(b.status)
     } else {
-      cmp = (a.created ?? 0) - (b.created ?? 0)
+      cmp = (DatetimeUtil.toEpochMillis(a.created) ?? 0) - (DatetimeUtil.toEpochMillis(b.created) ?? 0)
     }
     return ascending ? cmp : -cmp
   })

--- a/kinotic-frontend/apps/system/src/pages/Dashboard.vue
+++ b/kinotic-frontend/apps/system/src/pages/Dashboard.vue
@@ -60,7 +60,7 @@ import { Kinotic, Pageable } from '@kinotic-ai/core'
 import { DeploymentStatusType, ExecutionStatus, WorkloadStatus,
          type JobRun, type Organization, type Workload } from '@kinotic-ai/management-api'
 import { VmNodeStatusType, type KinoticClusterInfo, type VmNode } from '@kinotic-ai/system-api'
-import { PageHeader, accentColor, errorMessage, isDark, scanJobRuns } from '@kinotic-ai/frontend-common'
+import { DatetimeUtil, PageHeader, accentColor, errorMessage, isDark, scanJobRuns } from '@kinotic-ai/frontend-common'
 
 import AttentionList from '@/components/AttentionList.vue'
 import CapacityRows from '@/components/CapacityRows.vue'
@@ -119,7 +119,7 @@ interface Stat {
 const stats = computed<Stat[]>(() => {
   const running = workloads.value.filter(workload => workload.status === WorkloadStatus.RUNNING).length
   const dayAgo = Date.now() - DAY_MS
-  const today = runs.value.filter(run => (run.started ?? 0) >= dayAgo)
+  const today = runs.value.filter(run => (DatetimeUtil.toEpochMillis(run.started) ?? 0) >= dayAgo)
   const runningRuns = runs.value.filter(run => run.status === ExecutionStatus.RUNNING).length
   const ready = organizations.value.filter(org => org.storage?.status.type === DeploymentStatusType.READY).length
   return [

--- a/kinotic-frontend/apps/system/src/pages/ProjectsPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/ProjectsPage.vue
@@ -151,7 +151,9 @@ function sortRows(list: ProjectRow[], sort: Sort | null | undefined): void {
   const byUpdated = order?.property === 'updated'
   const ascending = order ? order.direction === Direction.ASC : true
   list.sort((a, b) => {
-    const cmp = byUpdated ? (a.updated ?? 0) - (b.updated ?? 0) : a.name.localeCompare(b.name)
+    const cmp = byUpdated
+        ? (DatetimeUtil.toEpochMillis(a.updated) ?? 0) - (DatetimeUtil.toEpochMillis(b.updated) ?? 0)
+        : a.name.localeCompare(b.name)
     return ascending ? cmp : -cmp
   })
 }

--- a/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
+++ b/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
@@ -177,8 +177,10 @@ function resolveRange(): TimeRange | null {
 // From the workload's creation to its last status change once it has ended, or to now while it runs
 function runRange(): TimeRange {
   const workload = props.workload
-  const start = workload?.created ?? Date.now() - TIME_RANGE_PRESETS[1]!.ms
-  const end = isFinished(workload) && workload?.updated ? workload.updated + RUN_MARGIN_MS : Date.now()
+  const created = DatetimeUtil.toEpochMillis(workload?.created ?? null)
+  const updated = DatetimeUtil.toEpochMillis(workload?.updated ?? null)
+  const start = created ?? Date.now() - TIME_RANGE_PRESETS[1]!.ms
+  const end = isFinished(workload) && updated !== null ? updated + RUN_MARGIN_MS : Date.now()
   return { start: start - RUN_MARGIN_MS, end }
 }
 

--- a/kinotic-frontend/packages/common/src/components/grind/JobRunsTable.vue
+++ b/kinotic-frontend/packages/common/src/components/grind/JobRunsTable.vue
@@ -188,7 +188,7 @@ function sortRuns(runs: JobRun[], sort: Sort | null | undefined): void {
   runs.sort((a, b) => {
     const cmp = byName
         ? a.name.localeCompare(b.name)
-        : (a.started ?? 0) - (b.started ?? 0)
+        : (DatetimeUtil.toEpochMillis(a.started) ?? 0) - (DatetimeUtil.toEpochMillis(b.started) ?? 0)
     return ascending ? cmp : -cmp
   })
 }

--- a/kinotic-frontend/packages/common/src/components/grind/jobRunScan.ts
+++ b/kinotic-frontend/packages/common/src/components/grind/jobRunScan.ts
@@ -1,5 +1,6 @@
 import { Direction, Kinotic, Order, Pageable, Sort } from '@kinotic-ai/core'
 import type { ExecutionStatus, JobRun } from '@kinotic-ai/management-api'
+import DatetimeUtil from '../../util/DatetimeUtil'
 
 /**
  * Which job runs a scan keeps. An unset field matches every run; {@code organizationId} set
@@ -25,7 +26,7 @@ export function matchesJobRunFilter(run: JobRun, filter: JobRunFilter): boolean 
       && (filter.applicationId === undefined || run.applicationId === filter.applicationId)
       && (filter.projectId === undefined || run.projectId === filter.projectId)
       && (filter.status === undefined || run.status === filter.status)
-      && (filter.since === undefined || (run.started ?? 0) >= filter.since)
+      && (filter.since === undefined || (DatetimeUtil.toEpochMillis(run.started) ?? 0) >= filter.since)
 }
 
 /**
@@ -48,7 +49,8 @@ export async function scanJobRuns(filter: JobRunFilter, limit: number = JOB_RUN_
     }
     read += content.length
     const oldest = content[content.length - 1]
-    const pastSince = filter.since !== undefined && oldest !== undefined && (oldest.started ?? 0) < filter.since
+    const pastSince = filter.since !== undefined && oldest !== undefined
+        && (DatetimeUtil.toEpochMillis(oldest.started) ?? 0) < filter.since
     if (content.length < SCAN_PAGE_SIZE || pastSince) {
       break
     }

--- a/kinotic-frontend/packages/common/src/util/DatetimeUtil.ts
+++ b/kinotic-frontend/packages/common/src/util/DatetimeUtil.ts
@@ -68,7 +68,7 @@ public static formatDuration(started: number | string | Date | null, finished: n
 }
 
 /** Epoch millis of a timestamp however it arrived (millis, a date string, a Date), or null when absent or unreadable. */
-private static toEpochMillis(value: number | string | Date | null): number | null {
+public static toEpochMillis(value: number | string | Date | null): number | null {
     let ret: number | null
     if (!value) {
         ret = null


### PR DESCRIPTION
## What this does

Two commits that were on #528's branch after it merged.

**Timestamps are read through `toEpochMillis` wherever they are compared or subtracted.** `Workload.created`/`updated` and `JobRun.started` are `java.util.Date` on the server and do not arrive as the numbers the TypeScript models declare. The display formatters already read either form; the arithmetic did not. The visible failure was the log view's "Whole run" span:

```ts
// packages/common/src/components/WorkloadLogView.vue (before)
const start = workload?.created ?? Date.now() - ...     // a date string
return { start: start - RUN_MARGIN_MS, end }            // NaN → serialized as null
```

```
JSON decoding error: Cannot map `null` into type `long`
```

The same assumption made the job-run scan's `since` window match nothing, so the dashboard's "Jobs · 24 h", runs-per-day chart and failed-run attention rows were empty, and it left the started/created/updated sorts inert. Each site now normalizes first:

```ts
const created = DatetimeUtil.toEpochMillis(workload?.created ?? null)
const updated = DatetimeUtil.toEpochMillis(workload?.updated ?? null)
```

`DatetimeUtil.toEpochMillis`, added by the duration fix, is public now that it has a second consumer. It returns the same millis for a number, so nothing changes if the wire ever carries numbers.

**The runs-per-day chart's legend sat on its axis labels.** The grid left no row for the labels, so the legend at the bottom drew over them. The grid now keeps its labels inside its box the way the metric charts do, with the bottom margin as the legend's row, and a window with no runs says so instead of drawing an empty plot:

```ts
// apps/system/src/components/JobRunsByDayChart.vue
grid: { left: 8, right: 16, top: 12, bottom: 36, containLabel: true },   // was: { left: 28, ..., bottom: 30, containLabel: false }
```

```vue
<div v-if="runs.length === 0" class="flex h-44 items-center justify-center text-sm text-muted-color">
  No runs in the last {{ days }} days
</div>
```

## Verification

`vue-tsc -b` passes for both apps; `vite build` passes for the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdrJ6dBf3G2hJYgmrEpUDA)_