### PR TITLE
Hand a UI build the platform's address as the consoles' three Vite variables

### DIFF
--- a/kinotic-js/workload-runner/README.md
+++ b/kinotic-js/workload-runner/README.md
@@ -39,7 +39,7 @@ micro VMs sharing a host mount, and inotify events do not cross the VM boundary.
 | `GIT_TOKEN` | token authorizing the fetch; omit for a public repository | — |
 | `KINOTIC_WORKSPACE_DIR` | the shared checkout directory | `/workspace` |
 | `KINOTIC_PROJECT_ID` | the project the checkout belongs to, named in the artifact report | required with credentials |
-| `KINOTIC_UI_SERVER_URL` | the address a browser reaches the platform on, handed to every UI build | — |
+| `KINOTIC_UI_SERVER_URL` | the address a browser reaches the platform on, handed to every UI build as `VITE_KINOTIC_HOST`, `VITE_KINOTIC_PORT` and `VITE_KINOTIC_USE_SSL` | — |
 | `KINOTIC_SERVER_HOST/PORT/USE_SSL`, `KINOTIC_CLIENT_ID`, `KINOTIC_CLIENT_SECRET`, `KINOTIC_ORGANIZATION_ID` | machine identity and server the CLI and the artifact report connect with; both are skipped when no credentials are present | — |
 | `KINOTIC_CLI_BIN` | overrides the kinotic CLI entry script (development/tests) | resolved from the image install |
 
@@ -60,9 +60,10 @@ sharing a name, fails the run naming the package. The result is reported to the 
 through `ProjectArtifactService.recordArtifacts`, authenticated as the sync machine, so
 the deployment run can bind it once this workload exits.
 
-Every UI artifact is then built in place with `bun run build`, handed
-`KINOTIC_UI_SERVER_URL`. A build that leaves no `dist/index.html` fails the run naming the
-UI. `publish-ui.ts` later uploads `dist` as it is: files under `assets/` carry a content
+Every UI artifact is then built in place with `bun run build`, handed the platform's
+address as `VITE_KINOTIC_HOST`, `VITE_KINOTIC_PORT` and `VITE_KINOTIC_USE_SSL`, the
+variables the platform's own consoles connect with. A build that leaves no `dist/index.html`
+fails the run naming the UI. `publish-ui.ts` later uploads `dist` as it is: files under `assets/` carry a content
 hash in their name and are cached for a year, everything else is never cached, and every
 blob is stamped with the commit so the deploy can delete what older publishes left.
 

--- a/kinotic-js/workload-runner/src/sync.ts
+++ b/kinotic-js/workload-runner/src/sync.ts
@@ -24,7 +24,7 @@ import { forwardOutput, log, logError } from './log.ts'
  * - KINOTIC_WORKSPACE_DIR  the shared checkout directory (default /workspace)
  * - KINOTIC_PROJECT_ID     the project the checkout belongs to; required to report artifacts
  * - KINOTIC_UI_SERVER_URL  the address a browser reaches the platform on, handed to every UI
- *                          build
+ *                          build as VITE_KINOTIC_HOST, VITE_KINOTIC_PORT and VITE_KINOTIC_USE_SSL
  * - KINOTIC_SERVER_* / KINOTIC_CLIENT_ID / KINOTIC_CLIENT_SECRET — standard Kinotic
  *   connection settings the CLI and the artifact report authenticate with; both are
  *   skipped when no credentials are present
@@ -157,13 +157,19 @@ async function reportArtifacts(commitSha: string, artifacts: ProjectArtifacts): 
 /**
  * Builds every UI of the commit in place, each with the three variables its build honors:
  * the base path its assets are served under, which is the commit so they can be cached
- * forever, the commit itself for the stale-tab check, and the server address. A build that
- * leaves no {@code dist/index.html} fails the run before the sentinel is written.
+ * forever, and the server address as the three variables the platform's own consoles
+ * connect with: Vite exposes VITE_* to the page on its own, so a Vite project needs no
+ * configuration to reach the platform. A build that leaves no {@code dist/index.html} fails
+ * the run before the sentinel is written.
  */
 async function buildUis(workspaceDir: string, uis: UiArtifact[]): Promise<void> {
     const env: Record<string, string> = {}
     if (process.env.KINOTIC_UI_SERVER_URL) {
-        env.KINOTIC_UI_SERVER_URL = process.env.KINOTIC_UI_SERVER_URL
+        const server = new URL(process.env.KINOTIC_UI_SERVER_URL)
+        const ssl = server.protocol === 'https:'
+        env.VITE_KINOTIC_HOST = server.hostname
+        env.VITE_KINOTIC_PORT = server.port || (ssl ? '443' : '80')
+        env.VITE_KINOTIC_USE_SSL = String(ssl)
     }
     for (const ui of uis) {
         log(`[workload-runner] building UI ${ui.name}`)

--- a/kinotic-js/workload-runner/test/sync.test.ts
+++ b/kinotic-js/workload-runner/test/sync.test.ts
@@ -221,7 +221,7 @@ describe('sync entrypoint', () => {
     it('builds each UI with the server address, before the sentinel', () => {
         // the build records what it was handed and writes the index the check looks for
         const sha = commitUi('admin',
-            'mkdir -p dist && echo "$KINOTIC_UI_SERVER_URL" > dist/env.txt && echo ok > dist/index.html')
+            'mkdir -p dist && echo "$VITE_KINOTIC_HOST $VITE_KINOTIC_PORT $VITE_KINOTIC_USE_SSL" > dist/env.txt && echo ok > dist/index.html')
 
         const result = runSync({
             GIT_CLONE_URL: `file://${originDir}`,
@@ -232,7 +232,7 @@ describe('sync entrypoint', () => {
 
         expect(result.status).toBe(0)
         expect(readFileSync(join(workspaceDir, 'packages', 'ui', 'admin', 'dist', 'env.txt'), 'utf-8').trim())
-            .toBe('https://api.kinotic.test')
+            .toBe('api.kinotic.test 443 true')
         expect(readFileSync(join(workspaceDir, '.kinotic', 'reload'), 'utf-8')).toBe(sha)
     }, 30_000)
 

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -76,10 +76,11 @@ kinotic:
       masterKey: 0qWH2oHEp27LLD7iBHEiABqJFf1q5GRYK6OdMc5Wdv4=
   apiGateway:
     cors:
-      # Covers both ways dev runs: localhost (pnpm dev) and an ngrok tunnel (pnpm dev:tunnel).
-      # The tunnel is same-origin but still CORS-checked, because the social login forms POST
-      # and browsers send Origin on a POST navigation.
-      allowedOriginPattern: "http:\\/\\/localhost:\\d+|https:\\/\\/[a-zA-Z0-9-]+\\.ngrok(-free)?\\.(app|dev|io)"
+      # Covers both ways dev runs: localhost (pnpm dev) and an ngrok tunnel (pnpm dev:tunnel),
+      # and the sites a developer publishes under apps-<environment>.kinotic.ai, which reach
+      # the server through the tunnel. The tunnel is same-origin but still CORS-checked,
+      # because the social login forms POST and browsers send Origin on a POST navigation.
+      allowedOriginPattern: "http:\\/\\/localhost:\\d+|https:\\/\\/[a-zA-Z0-9-]+\\.ngrok(-free)?\\.(app|dev|io)|https:\\/\\/[a-z0-9-]+\\.apps-[a-z0-9-]+\\.kinotic\\.ai"
       allowCredentials: true
   maxNumberOfCoresToUse: 4
   ignite:

--- a/website/content/01.apps/03.application-structure/02.applications-and-projects.md
+++ b/website/content/01.apps/03.application-structure/02.applications-and-projects.md
@@ -93,13 +93,26 @@ packages of its kind. The directory name never matters.
 
 ### The UI build contract
 
-Every UI is built during the deployment with `bun run build`, and the build is handed one
-variable. A UI built from the platform template honors it through its Vite config; a UI
-with its own build must too:
+Every UI is built during the deployment with `bun run build`, and the build is handed the
+platform's address as three variables. Vite exposes `VITE_*` variables to the page on its
+own, so a Vite project reads them with no configuration; a UI with another build tool must
+pass them through itself:
 
-| Variable | Value | What the build does with it |
+| Variable | Value | What the UI does with it |
 | --- | --- | --- |
-| `KINOTIC_UI_SERVER_URL` | the platform's public API address | The address the UI connects to Kinotic on from a browser |
+| `VITE_KINOTIC_HOST` | e.g. `api.kinotic.ai` | The host the UI connects to Kinotic on from a browser |
+| `VITE_KINOTIC_PORT` | e.g. `443` | Its port |
+| `VITE_KINOTIC_USE_SSL` | `true` or `false` | Whether to connect over TLS |
+
+```ts
+await Kinotic.connect({
+    server: {
+        host: import.meta.env.VITE_KINOTIC_HOST,
+        port: parseInt(import.meta.env.VITE_KINOTIC_PORT),
+        useSSL: import.meta.env.VITE_KINOTIC_USE_SSL === 'true',
+    },
+})
+```
 
 A build that does not write `dist/index.html` fails the deployment naming the UI.
 

--- a/website/content/02.platform/11.reference/03.project-publishing-design.md
+++ b/website/content/02.platform/11.reference/03.project-publishing-design.md
@@ -178,9 +178,11 @@ put on the Public Suffix List.
 
 ## Build and upload contracts
 
-The sync step sets, per UI build: `KINOTIC_UI_SERVER_URL` (from `DomainProperties.resolveApiBaseUrl()`, placed on the sync
-workload by the job factory; `DeploymentProperties.serverHost` is an IPv4 for egress and not
-usable by a browser). A build that leaves no `dist/index.html` fails the deploy before the
+The sync step sets, per UI build, `VITE_KINOTIC_HOST`, `VITE_KINOTIC_PORT` and
+`VITE_KINOTIC_USE_SSL`, split from `KINOTIC_UI_SERVER_URL` (`DomainProperties.resolveApiBaseUrl()`,
+placed on the sync workload by the job factory; `DeploymentProperties.serverHost` is an IPv4
+for egress and not usable by a browser). They are the variables the platform's own consoles
+connect with, and Vite exposes them to the page without configuration. A build that leaves no `dist/index.html` fails the deploy before the
 sentinel. `artifacts.ts` in workload-runner is the one enumeration of the artifacts, shared
 by the sync and publish entrypoints.
 
@@ -266,9 +268,10 @@ notification of publishes, and service endpoints instead of private endpoints.
   public endpoint where it has none. A developer runs the real path against their own
   subscription with the `deployment/terraform/azure/dev` root and the `local` profile.
 - **UIs built in the sync VM.** After the entity sync, `sync.ts` runs `bun run build` in
-  every UI artifact with `KINOTIC_UI_SERVER_URL`, placed on the sync workload from
+  every UI artifact with `VITE_KINOTIC_HOST`, `VITE_KINOTIC_PORT` and `VITE_KINOTIC_USE_SSL`,
+  split from the `KINOTIC_UI_SERVER_URL` placed on the sync workload from
   `DomainProperties.resolveApiBaseUrl()`, and fails the run naming a UI whose build leaves no
-  `dist/index.html`. The template repository's Vite config must honor the three variables.
+  `dist/index.html`.
 - **UI deployments and the storage data plane.** `UiDeployment` rows keyed by the site's
   hostname label, `OrganizationStorageService` (`issueUploadUrl`, `exists`, `listCommitDirs`,
   `deletePrefix`) over the blob SDK or Azurite, `UiStoragePaths` as the one home of the


### PR DESCRIPTION
## Why

A Kinotic app UI was built with one variable, `KINOTIC_UI_SERVER_URL`, which Vite does not expose to the page (only `VITE_*` is), so a stock Vite project could not reach the platform without build configuration of its own. The platform's own consoles connect with `VITE_KINOTIC_HOST`, `VITE_KINOTIC_PORT` and `VITE_KINOTIC_USE_SSL` (`kinotic-frontend/packages/common/src/util/helpers.ts`). App UIs now get the same three.

## What changed

```ts
// sync.ts: from https://api.kinotic.ai → host api.kinotic.ai, port 443, ssl true
const server = new URL(process.env.KINOTIC_UI_SERVER_URL)
const ssl = server.protocol === 'https:'
env.VITE_KINOTIC_HOST = server.hostname
env.VITE_KINOTIC_PORT = server.port || (ssl ? '443' : '80')
env.VITE_KINOTIC_USE_SSL = String(ssl)
```

A UI then needs no configuration, since Vite exposes `VITE_*` on its own:

```ts
await Kinotic.connect({ server: { host: import.meta.env.VITE_KINOTIC_HOST, port: parseInt(import.meta.env.VITE_KINOTIC_PORT), useSSL: import.meta.env.VITE_KINOTIC_USE_SSL === 'true' } })
```

The development profile's CORS pattern gains the sites a developer publishes, `https://<label>.apps-<environment>.kinotic.ai`, which call the server through the tunnel origin:

```
https://minds-ignited-todo-neon-app.apps-local.kinotic.ai    allowed
https://x.apps-local.kinotic.ai.evil.com                     rejected
```

Docs: the UI build contract table and the design record's build contract section; the workload-runner README.

## Verification

`sync.test.ts` builds a UI that records the three variables it received and asserts `api.kinotic.test 443 true`; the workload-runner suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD5Xz2gy6UZ9wyzF8sVWdN
