### PR TITLE
Add COMPLETED workload status for foreground runs

### DIFF
--- a/kinotic-frontend/apps/system/src/components/WorkloadStateCard.vue
+++ b/kinotic-frontend/apps/system/src/components/WorkloadStateCard.vue
@@ -40,6 +40,7 @@ const ACCENT_BY_STATE: Record<WorkloadStatus, ChartAccent | null> = {
   [WorkloadStatus.STARTING]: 'sky',
   [WorkloadStatus.PENDING]: 'violet',
   [WorkloadStatus.STOPPING]: 'amber',
+  [WorkloadStatus.COMPLETED]: 'teal',
   [WorkloadStatus.STOPPED]: null,
   [WorkloadStatus.FAILED]: 'red'
 }

--- a/kinotic-frontend/apps/system/src/components/WorkloadsTable.vue
+++ b/kinotic-frontend/apps/system/src/components/WorkloadsTable.vue
@@ -62,12 +62,12 @@ import { useConfirm } from 'primevue/useconfirm'
 
 import { Direction, FunctionalIterablePage, Kinotic, Order,
          type IterablePage, type Page, type Pageable, type Sort } from '@kinotic-ai/core'
-import { WorkloadStatus, type Workload } from '@kinotic-ai/management-api'
+import type { Workload, WorkloadStatus } from '@kinotic-ai/management-api'
 import { CrudTable, DatetimeUtil, WorkloadLogsDialog, formatMb, pageNumberOf, useCrudTablePage,
          type CrudHeader, type DescriptiveIdentifiable } from '@kinotic-ai/frontend-common'
 
 import { scopePath, type Scope } from '@/util/scope'
-import { shortImage, workloadSeverity } from '@/util/workloads'
+import { WORKLOAD_STATES, canRestart, canStop, shortImage, workloadSeverity } from '@/util/workloads'
 
 /**
  * The given workloads as a searchable, sortable table whose rows open the workload's page
@@ -103,7 +103,8 @@ interface WorkloadRow extends DescriptiveIdentifiable {
   autoRemove: boolean
 }
 
-const DEFAULT_SORT = [new Order('created', Direction.DESC)]
+/** Live workloads first, the ended ones after, newest first within a state. */
+const DEFAULT_SORT = [new Order('status', Direction.ASC), new Order('created', Direction.DESC)]
 
 const router = useRouter()
 const confirm = useConfirm()
@@ -161,21 +162,31 @@ async function load(pageable: Pageable, searchText: string | null): Promise<Iter
   return new FunctionalIterablePage(pageable, page, (next: Pageable) => load(next, searchText))
 }
 
+// The default sort breaks the ties the table's own sort leaves
 function sortRows(rows: WorkloadRow[], sort: Sort | null | undefined): void {
-  const order = sort?.orders?.[0]
-  const property = order?.property ?? 'created'
-  const ascending = order?.direction === Direction.ASC
+  const orders = [...(sort?.orders ?? []), ...DEFAULT_SORT]
   rows.sort((a, b) => {
-    let cmp: number
-    if (property === 'name') {
-      cmp = a.name.localeCompare(b.name)
-    } else if (property === 'status') {
-      cmp = a.status.localeCompare(b.status)
-    } else {
-      cmp = (DatetimeUtil.toEpochMillis(a.created) ?? 0) - (DatetimeUtil.toEpochMillis(b.created) ?? 0)
+    let ret = 0
+    for (const order of orders) {
+      if (ret === 0) {
+        const cmp = compareBy(order.property, a, b)
+        ret = order.direction === Direction.DESC ? -cmp : cmp
+      }
     }
-    return ascending ? cmp : -cmp
+    return ret
   })
+}
+
+function compareBy(property: string, a: WorkloadRow, b: WorkloadRow): number {
+  let ret: number
+  if (property === 'name') {
+    ret = a.name.localeCompare(b.name)
+  } else if (property === 'status') {
+    ret = WORKLOAD_STATES.indexOf(a.status) - WORKLOAD_STATES.indexOf(b.status)
+  } else {
+    ret = (DatetimeUtil.toEpochMillis(a.created) ?? 0) - (DatetimeUtil.toEpochMillis(b.created) ?? 0)
+  }
+  return ret
 }
 
 function ownerOf(workload: Workload): string | null {
@@ -225,15 +236,14 @@ function rowActions(item: WorkloadRow): MenuItem[] {
       }
     }
   ]
-  if (item.status === WorkloadStatus.RUNNING || item.status === WorkloadStatus.STARTING) {
+  if (canStop(item)) {
     actions.push({
       label: 'Stop',
       icon: 'pi pi-stop-circle',
       command: () => act(() => Kinotic.workloadOrchestration.stopWorkload(item.id), 'Workload stopping', 'Failed to stop workload')
     })
   }
-  // A workload stopped with autoRemove has no VM left to restart
-  if ((item.status === WorkloadStatus.STOPPED && !item.autoRemove) || item.status === WorkloadStatus.FAILED) {
+  if (canRestart(item)) {
     actions.push({
       label: 'Restart',
       icon: 'pi pi-replay',

--- a/kinotic-frontend/apps/system/src/pages/WorkloadPage.vue
+++ b/kinotic-frontend/apps/system/src/pages/WorkloadPage.vue
@@ -9,9 +9,9 @@
       <template #actions>
         <Tag v-if="workload" :value="workload.status" :severity="workloadSeverity(workload.status)" />
         <Button label="View logs" icon="pi pi-align-left" severity="secondary" outlined @click="tab = 'logs'" />
-        <Button v-if="canStop" label="Stop" icon="pi pi-stop-circle" severity="secondary" outlined
+        <Button v-if="stoppable" label="Stop" icon="pi pi-stop-circle" severity="secondary" outlined
                 @click="act(() => Kinotic.workloadOrchestration.stopWorkload(workloadId), 'Workload stopping', 'Failed to stop workload')" />
-        <Button v-if="canRestart" label="Restart" icon="pi pi-replay" severity="secondary" outlined
+        <Button v-if="restartable" label="Restart" icon="pi pi-replay" severity="secondary" outlined
                 @click="act(() => Kinotic.workloadOrchestration.restartWorkload(workloadId), 'Workload restarting', 'Failed to restart workload')" />
         <Button label="Destroy" icon="pi pi-trash" severity="danger" outlined :disabled="!workload" @click="confirmDestroy" />
       </template>
@@ -124,7 +124,7 @@ import { DatetimeUtil, PageHeader, WorkloadLogView, errorMessage, formatMb, show
 
 import StatTile, { type StatTileAccent } from '@/components/StatTile.vue'
 import { applicationPath, organizationPath, scopePath, type Scope } from '@/util/scope'
-import { workloadSeverity } from '@/util/workloads'
+import { canRestart, canStop, workloadSeverity } from '@/util/workloads'
 
 /**
  * One workload, opened from a Workloads list: its state with the exit code, where it runs and
@@ -163,10 +163,8 @@ const tab = computed<string>({
   set: value => { router.replace({ query: { ...route.query, tab: value === 'logs' ? 'logs' : undefined } }) }
 })
 
-const canStop = computed(() => workload.value?.status === WorkloadStatus.RUNNING || workload.value?.status === WorkloadStatus.STARTING)
-// A workload stopped with autoRemove has no VM left to restart
-const canRestart = computed(() => (workload.value?.status === WorkloadStatus.STOPPED && !workload.value.autoRemove)
-    || workload.value?.status === WorkloadStatus.FAILED)
+const stoppable = computed(() => workload.value !== null && canStop(workload.value))
+const restartable = computed(() => workload.value !== null && canRestart(workload.value))
 
 const command = computed(() => [...(workload.value?.entrypoint ?? []), ...(workload.value?.cmd ?? [])].join(' '))
 const allowedHosts = computed(() => workload.value?.network?.allowedHosts ?? [])

--- a/kinotic-frontend/apps/system/src/util/workloads.ts
+++ b/kinotic-frontend/apps/system/src/util/workloads.ts
@@ -13,12 +13,13 @@ const SCAN_PAGE_SIZE = 100
 /** The organization filter value that keeps the platform's own workloads, the ones with no organization. */
 export const PLATFORM_ONLY = 'platform'
 
-/** The states in the order every breakdown lists them. */
+/** The states in the order every breakdown lists them: the live ones first, then the ended ones. */
 export const WORKLOAD_STATES: WorkloadStatus[] = [
     WorkloadStatus.RUNNING,
     WorkloadStatus.STARTING,
     WorkloadStatus.PENDING,
     WorkloadStatus.STOPPING,
+    WorkloadStatus.COMPLETED,
     WorkloadStatus.STOPPED,
     WorkloadStatus.FAILED
 ]
@@ -34,7 +35,7 @@ export interface WorkloadScanOptions {
 /** Maps a workload status to the PrimeVue Tag severity it renders with. */
 export function workloadSeverity(status: WorkloadStatus): string {
     let ret: string
-    if (status === WorkloadStatus.RUNNING) {
+    if (status === WorkloadStatus.RUNNING || status === WorkloadStatus.COMPLETED) {
         ret = 'success'
     } else if (status === WorkloadStatus.STARTING || status === WorkloadStatus.PENDING) {
         ret = 'info'
@@ -51,6 +52,19 @@ export function workloadSeverity(status: WorkloadStatus): string {
 /** A state's name as a word, e.g. Running. */
 export function workloadStateLabel(status: WorkloadStatus): string {
     return status.charAt(0) + status.slice(1).toLowerCase()
+}
+
+/** Whether the workload has a run in progress that stopWorkload can end. */
+export function canStop(workload: Pick<Workload, 'status'>): boolean {
+    return workload.status === WorkloadStatus.RUNNING || workload.status === WorkloadStatus.STARTING
+}
+
+/** Whether restartWorkload can boot the workload's VM again. */
+export function canRestart(workload: Pick<Workload, 'status' | 'autoRemove'>): boolean {
+    // A run that ended with autoRemove has no VM left to restart
+    const dormant = (workload.status === WorkloadStatus.STOPPED || workload.status === WorkloadStatus.COMPLETED)
+        && !workload.autoRemove
+    return dormant || workload.status === WorkloadStatus.FAILED
 }
 
 export function countByStatus(workloads: Workload[]): Record<WorkloadStatus, number> {

--- a/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
+++ b/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
@@ -26,7 +26,8 @@
               @click="loadHistory" />
     </div>
     <div v-if="lines.length === 0" class="h-[60vh] p-3 rounded-md bg-surface-950 text-surface-400 font-mono text-xs">
-      <span v-if="!loadingHistory">No log entries {{ rangeDescription }}</span>
+      <span v-if="pending && loadedRange === null">Waiting for the workload to start</span>
+      <span v-else-if="!loadingHistory">No log entries {{ rangeDescription }}</span>
     </div>
     <VirtualScroller
       v-else
@@ -71,6 +72,12 @@ const props = defineProps<{
    * is coming; the run is also offered as a span for a workload still running.
    */
   workload?: Workload
+  /**
+   * True while whatever creates the workload is still running, so the workload may not
+   * exist yet. A failure to reach its logs is then retried until it succeeds or pending
+   * turns false, instead of being reported.
+   */
+  pending?: boolean
 }>()
 
 /** The span option that reveals the absolute range pickers. */
@@ -95,6 +102,8 @@ const MAX_LINES = 25_000
 /** Fixed row height the VirtualScroller positions rows by; rows must render at exactly this height. */
 const LINE_HEIGHT_PX = 20
 const DAY_MS = 24 * 60 * 60_000
+/** How long a pending workload's logs are given before they are asked for again. */
+const RETRY_MS = 2000
 
 interface LogLine {
   ts: number
@@ -125,6 +134,7 @@ const scroller = ref<InstanceType<typeof VirtualScroller> | null>(null)
 // Auto-scroll only while the user is at the bottom; scrolling up pins the view in place
 let pinnedToBottom = true
 let tailSubscription: { unsubscribe(): void } | null = null
+let retryTimer: ReturnType<typeof setTimeout> | null = null
 
 const rangeDescription = computed(() => {
   let ret: string
@@ -208,9 +218,35 @@ async function loadHistory() {
     limitReached.value = lines.value.length >= limit.value
     scrollToBottom()
   } catch (err) {
-    error.value = errorMessage(err, 'Failed to load log history')
+    fail(err, 'Failed to load log history')
   } finally {
     loadingHistory.value = false
+  }
+}
+
+// A pending workload's record may not exist yet, which the log service reports as a failure
+function fail(err: unknown, fallback: string) {
+  if (props.pending) {
+    scheduleRetry()
+  } else {
+    error.value = errorMessage(err, fallback)
+  }
+}
+
+function scheduleRetry() {
+  if (retryTimer === null) {
+    retryTimer = setTimeout(retry, RETRY_MS)
+  }
+}
+
+function retry() {
+  if (retryTimer !== null) {
+    clearTimeout(retryTimer)
+    retryTimer = null
+  }
+  loadHistory()
+  if (following.value) {
+    startTail()
   }
 }
 
@@ -231,8 +267,12 @@ function startTail() {
     },
     error: (err: unknown) => {
       tailSubscription = null
-      following.value = false
-      error.value = errorMessage(err, 'Log tail disconnected')
+      if (props.pending) {
+        scheduleRetry()
+      } else {
+        following.value = false
+        error.value = errorMessage(err, 'Log tail disconnected')
+      }
     }
   })
 }
@@ -249,7 +289,20 @@ onMounted(() => {
   }
 })
 
-onUnmounted(stopTail)
+onUnmounted(() => {
+  stopTail()
+  if (retryTimer !== null) {
+    clearTimeout(retryTimer)
+  }
+})
+
+// The creator has finished, so the record exists if it ever will: a pending retry runs now
+// and reports what it finds
+watch(() => props.pending, pending => {
+  if (!pending && retryTimer !== null) {
+    retry()
+  }
+})
 
 watch(following, follow => {
   if (follow) {

--- a/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
+++ b/kinotic-frontend/packages/common/src/components/WorkloadLogView.vue
@@ -102,7 +102,9 @@ interface LogLine {
 }
 
 function isFinished(workload: Workload | undefined): boolean {
-  return workload?.status === WorkloadStatus.STOPPED || workload?.status === WorkloadStatus.FAILED
+  return workload?.status === WorkloadStatus.COMPLETED
+      || workload?.status === WorkloadStatus.STOPPED
+      || workload?.status === WorkloadStatus.FAILED
 }
 
 const spanOptions = computed(() => props.workload ? [...PRESET_OPTIONS, RUN_OPTION, CUSTOM_OPTION] : [...PRESET_OPTIONS, CUSTOM_OPTION])

--- a/kinotic-frontend/packages/common/src/components/deploy/ProjectDeployTaskDetail.vue
+++ b/kinotic-frontend/packages/common/src/components/deploy/ProjectDeployTaskDetail.vue
@@ -4,13 +4,15 @@
     <span v-else class="text-xs text-muted-color">Waiting for the sync workload's artifact report</span>
   </template>
   <template v-else>
-    <WorkloadLogView v-if="workloadId" :key="workloadId" :workload-id="workloadId" />
+    <WorkloadLogView v-if="workloadId" :key="workloadId" :workload-id="workloadId"
+                     :pending="node.status === ExecutionStatus.RUNNING" />
     <span v-else class="text-xs text-muted-color">Waiting for the deployment target</span>
   </template>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { ExecutionStatus } from '@kinotic-ai/management-api'
 import type { JobTaskNode } from '../grind/JobTaskNode'
 import WorkloadLogView from '../WorkloadLogView.vue'
 import ProjectArtifactsDetail from './ProjectArtifactsDetail.vue'
@@ -18,8 +20,10 @@ import ProjectDeployStores from './ProjectDeployStores'
 
 /**
  * The detail pane of one task row of a project deployment run: the artifacts the run bound,
- * or the log of the workload the task ran, with a placeholder until either is known. Pages
- * pair it with ProjectDeployStores.hasDetail as the JobRunProgress expandable predicate.
+ * or the log of the workload the task ran, with a placeholder until either is known. The
+ * workload's id is known before the task creates it, so while the task runs the log waits
+ * for the workload rather than report it missing. Pages pair it with
+ * ProjectDeployStores.hasDetail as the JobRunProgress expandable predicate.
  */
 const props = defineProps<{
   node: JobTaskNode

--- a/kinotic-frontend/pnpm-workspace.yaml
+++ b/kinotic-frontend/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ packages:
 catalog:
   '@kinotic-ai/core': ^5.0.0-beta.9
   '@kinotic-ai/idl': ^5.0.0-beta.1
-  '@kinotic-ai/management-api': ^5.0.0-beta.28
+  '@kinotic-ai/management-api': ^5.0.0-beta.29
   '@kinotic-ai/persistence': ^5.0.0-beta.9
   '@kinotic-ai/system-api': ^5.0.0-beta.11
 

--- a/kinotic-js/workspace/packages/management-api/package.json
+++ b/kinotic-js/workspace/packages/management-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/management-api",
-  "version": "5.0.0-beta.28",
+  "version": "5.0.0-beta.29",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/management-api/src/api/model/workload/Workload.ts
+++ b/kinotic-js/workspace/packages/management-api/src/api/model/workload/Workload.ts
@@ -88,8 +88,8 @@ export class Workload implements Identifiable<string> {
      * When true the VM runs detached from the vm-manager process and survives its restarts,
      * and calls that start its run (deploy, restart) complete as soon as it is running.
      * When false the workload runs in the foreground: it ends when the vm-manager exits,
-     * and calls that start its run complete only once the run has ended — STOPPED or
-     * FAILED, with the exit code set.
+     * and calls that start its run complete only once the run has ended — COMPLETED,
+     * STOPPED or FAILED, with the exit code set.
      */
     public detached: boolean = true
 

--- a/kinotic-js/workspace/packages/management-api/src/api/model/workload/WorkloadStatus.ts
+++ b/kinotic-js/workspace/packages/management-api/src/api/model/workload/WorkloadStatus.ts
@@ -1,9 +1,29 @@
 
+/**
+ * The current status of a Workload.
+ */
 export enum WorkloadStatus {
+    /** Accepted, not yet placed on a node. */
     PENDING = 'PENDING',
+    /** Placed on a node, which is bringing the VM up. */
     STARTING = 'STARTING',
+    /** The guest is executing. */
     RUNNING = 'RUNNING',
+    /** A stop was requested and the node is shutting the guest down. */
     STOPPING = 'STOPPING',
+    /**
+     * The run was ended by a stop request, or a detached run's guest exited on its own with
+     * code 0. The VM is dormant, unless autoRemove discarded it.
+     */
     STOPPED = 'STOPPED',
+    /**
+     * A non-detached run's guest ran to its end and exited with code 0. The VM is dormant,
+     * unless autoRemove discarded it.
+     */
+    COMPLETED = 'COMPLETED',
+    /**
+     * The VM could not be started, its guest exited on its own with a non-zero code, or its
+     * node went offline while it ran.
+     */
     FAILED = 'FAILED'
 }

--- a/kinotic-js/workspace/packages/system-api/src/api/services/IWorkloadOrchestrationService.ts
+++ b/kinotic-js/workspace/packages/system-api/src/api/services/IWorkloadOrchestrationService.ts
@@ -11,9 +11,9 @@ export interface IWorkloadOrchestrationService {
      * Deploys a new workload to an appropriate node in the cluster. A workload carrying a
      * nodeId is deployed to that node instead, failing when the node is not registered, not
      * taking workloads, or lacks the capacity the workload requires. When the workload is not
-     * detached the returned Promise resolves only once the run has ended — STOPPED or
-     * FAILED, with the exit code set; otherwise it resolves as soon as the workload is
-     * started.
+     * detached the returned Promise resolves only once the run has ended — COMPLETED,
+     * STOPPED or FAILED, with the exit code set; otherwise it resolves as soon as the
+     * workload is started.
      * @param workload the workload configuration to deploy
      * @return a Promise resolving to the deployed workload (including assigned nodeId and id)
      */

--- a/kinotic-js/workspace/packages/vm-manager/package.json
+++ b/kinotic-js/workspace/packages/vm-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/vm-manager",
-  "version": "5.0.0-beta.18",
+  "version": "5.0.0-beta.19",
   "type": "module",
   "files": [
     "bin",

--- a/kinotic-js/workspace/packages/vm-manager/src/internal/api/providers/BoxliteProvider.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/internal/api/providers/BoxliteProvider.ts
@@ -319,8 +319,8 @@ export class BoxliteProvider implements IVmProvider {
         if (!workload) {
             throw new Error(`Workload not found: ${workloadId}`)
         }
-        if (workload.status !== WorkloadStatus.STOPPED) {
-            throw new Error(`Workload ${workloadId} is not stopped (status: ${workload.status})`)
+        if (workload.status !== WorkloadStatus.STOPPED && workload.status !== WorkloadStatus.COMPLETED) {
+            throw new Error(`Workload ${workloadId} is neither stopped nor completed (status: ${workload.status})`)
         }
         const info = await this.runtime.getInfo(workloadId)
         if (!info) {
@@ -540,16 +540,19 @@ export class BoxliteProvider implements IVmProvider {
         await this.syncStatus(workload)
     }
 
-    // A guest that ended while no operation was in flight stopped cleanly only if it said so;
-    // anything else — including an exit whose code could not be read — is a failure
+    // A guest that ended while no operation was in flight ended cleanly only if it said so;
+    // anything else — including an exit whose code could not be read — is a failure. A clean
+    // end is what a foreground run is for, so it completed; a detached service merely stopped
     private exitedStatus(workload: Workload, exitCode: number | null): WorkloadStatus {
         let ret: WorkloadStatus
         if (workload.status === WorkloadStatus.STOPPING) {
             ret = WorkloadStatus.STOPPED
-        } else if (exitCode === 0) {
+        } else if (exitCode !== 0) {
+            ret = WorkloadStatus.FAILED
+        } else if (workload.detached ?? true) {
             ret = WorkloadStatus.STOPPED
         } else {
-            ret = WorkloadStatus.FAILED
+            ret = WorkloadStatus.COMPLETED
         }
         return ret
     }

--- a/kinotic-js/workspace/packages/vm-manager/src/internal/api/providers/CloudHypervisorProvider.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/internal/api/providers/CloudHypervisorProvider.ts
@@ -250,8 +250,8 @@ export class CloudHypervisorProvider implements IVmProvider {
 
     async restart(workloadId: string): Promise<Workload> {
         const workload = this.requireWorkload(workloadId)
-        if (workload.status !== WorkloadStatus.STOPPED) {
-            throw new Error(`Workload ${workloadId} is not stopped (status: ${workload.status})`)
+        if (workload.status !== WorkloadStatus.STOPPED && workload.status !== WorkloadStatus.COMPLETED) {
+            throw new Error(`Workload ${workloadId} is neither stopped nor completed (status: ${workload.status})`)
         }
 
         workload.status = WorkloadStatus.STARTING
@@ -440,16 +440,19 @@ export class CloudHypervisorProvider implements IVmProvider {
             })
     }
 
-    // A guest that ended while no operation was in flight stopped cleanly only if it said so;
-    // anything else — including the 137 a memory limit produces — is a failure
+    // A guest that ended while no operation was in flight ended cleanly only if it said so;
+    // anything else — including the 137 a memory limit produces — is a failure. A clean end
+    // is what a foreground run is for, so it completed; a detached service merely stopped
     private exitedStatus(workload: Workload, info: ContainerInspectInfo): WorkloadStatus {
         let ret: WorkloadStatus
         if (workload.status === WorkloadStatus.STOPPING) {
             ret = WorkloadStatus.STOPPED
-        } else if (info.State.ExitCode === 0) {
+        } else if (info.State.ExitCode !== 0) {
+            ret = WorkloadStatus.FAILED
+        } else if (workload.detached ?? true) {
             ret = WorkloadStatus.STOPPED
         } else {
-            ret = WorkloadStatus.FAILED
+            ret = WorkloadStatus.COMPLETED
         }
         return ret
     }

--- a/kinotic-js/workspace/packages/vm-manager/src/internal/api/providers/IVmProvider.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/internal/api/providers/IVmProvider.ts
@@ -44,9 +44,9 @@ export interface IVmProvider {
     start(workload: Workload): Promise<Workload>
 
     /**
-     * Restarts a stopped workload in place: the same VM boots again with its disk state
-     * intact and the workload's entrypoint runs again. Fails unless the workload is
-     * STOPPED and its VM still exists (a workload stopped with autoRemove has none).
+     * Restarts a stopped or completed workload in place: the same VM boots again with its
+     * disk state intact and the workload's entrypoint runs again. Fails unless the workload
+     * is STOPPED or COMPLETED and its VM still exists (a workload with autoRemove has none).
      * Resolves at boot the same way as {@link start}.
      * @param workloadId the id of the workload to restart
      * @return a Promise resolving to the workload with updated status

--- a/kinotic-management-api/src/main/java/org/kinotic/management/api/model/workload/Workload.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/api/model/workload/Workload.java
@@ -100,8 +100,8 @@ public class Workload implements Identifiable<String> {
      * restarts, and calls that start its run (deploy, restart) complete as soon as it is
      * running. When {@code false} the workload runs in the foreground: it ends when the
      * vm-manager exits, and calls that start its run complete only once the run has ended —
-     * {@link WorkloadStatus#STOPPED} or {@link WorkloadStatus#FAILED}, with
-     * {@link #getExitCode()} set.
+     * {@link WorkloadStatus#COMPLETED}, {@link WorkloadStatus#STOPPED} or
+     * {@link WorkloadStatus#FAILED}, with {@link #getExitCode()} set.
      */
     private boolean detached = true;
 

--- a/kinotic-management-api/src/main/java/org/kinotic/management/api/model/workload/WorkloadStatus.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/api/model/workload/WorkloadStatus.java
@@ -4,18 +4,44 @@ package org.kinotic.management.api.model.workload;
  * Represents the current status of a {@link Workload}.
  */
 public enum WorkloadStatus {
+    /**
+     * Accepted, not yet placed on a node.
+     */
     PENDING,
+    /**
+     * Placed on a node, which is bringing the VM up.
+     */
     STARTING,
+    /**
+     * The guest is executing.
+     */
     RUNNING,
+    /**
+     * A stop was requested and the node is shutting the guest down.
+     */
     STOPPING,
+    /**
+     * The run was ended by a stop request, or a detached run's guest exited on its own with
+     * code 0. The VM is dormant, unless {@link Workload#isAutoRemove()} discarded it.
+     */
     STOPPED,
+    /**
+     * A non-detached run's guest ran to its end and exited with code 0. The VM is dormant,
+     * unless {@link Workload#isAutoRemove()} discarded it.
+     */
+    COMPLETED,
+    /**
+     * The VM could not be started, its guest exited on its own with a non-zero code, or its
+     * node went offline while it ran.
+     */
     FAILED;
 
     /**
      * True when this run of the workload has ended — the guest is no longer executing.
-     * A {@link #STOPPED} workload may still be restarted in place, which begins a new run.
+     * A {@link #STOPPED} or {@link #COMPLETED} workload may still be restarted in place, which
+     * begins a new run.
      */
-    public boolean isComplete() {
-        return this == STOPPED || this == FAILED;
+    public boolean hasEnded() {
+        return this == STOPPED || this == COMPLETED || this == FAILED;
     }
 }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/WorkloadOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/WorkloadOrchestrationService.java
@@ -26,8 +26,9 @@ public interface WorkloadOrchestrationService {
      * requires.
      * <p>
      * When {@link Workload#isDetached()} is {@code false} the returned future completes only
-     * once the run has ended — the workload reached {@link WorkloadStatus#STOPPED} or
-     * {@link WorkloadStatus#FAILED}, with its {@link Workload#getExitCode() exit code} set.
+     * once the run has ended — the workload reached {@link WorkloadStatus#COMPLETED},
+     * {@link WorkloadStatus#STOPPED} or {@link WorkloadStatus#FAILED}, with its
+     * {@link Workload#getExitCode() exit code} set.
      * Otherwise it completes as soon as the workload is started.
      *
      * @param workload the workload configuration to deploy
@@ -36,10 +37,11 @@ public interface WorkloadOrchestrationService {
     Future<Workload> deployWorkload(Workload workload);
 
     /**
-     * Restarts a stopped workload in place on the node it is deployed to. The same VM
-     * boots again with its disk state intact and the workload's entrypoint runs again.
-     * Fails unless the workload is stopped; a workload stopped with
-     * {@link Workload#isAutoRemove()} {@code true} has no VM left to restart.
+     * Restarts a stopped or completed workload in place on the node it is deployed to. The
+     * same VM boots again with its disk state intact and the workload's entrypoint runs
+     * again. Fails unless the workload is {@link WorkloadStatus#STOPPED} or
+     * {@link WorkloadStatus#COMPLETED}; a workload with {@link Workload#isAutoRemove()}
+     * {@code true} has no VM left to restart.
      * Honors {@link Workload#isDetached()} the same way as {@link #deployWorkload(Workload)}.
      *
      * @param workloadId the id of the workload to restart

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultDeploymentOperationsService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultDeploymentOperationsService.java
@@ -58,7 +58,7 @@ public class DefaultDeploymentOperationsService implements DeploymentOperationsS
                                             + " no longer exists; deploy the project again");
                                 }
                                 // restartWorkload only boots a stopped VM, so a running one is stopped first
-                                Future<Void> stopped = workload.getStatus().isComplete()
+                                Future<Void> stopped = workload.getStatus().hasEnded()
                                         ? Future.succeededFuture()
                                         : workloadOrchestrationService.stopWorkload(workload.getId());
                                 return stopped.compose(v -> workloadOrchestrationService.restartWorkload(workload.getId()));

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
@@ -90,9 +90,10 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                         return Future.failedFuture(
                                 new IllegalArgumentException("Workload not found: " + workloadId));
                     }
-                    if (workload.getStatus() != WorkloadStatus.STOPPED) {
+                    WorkloadStatus status = workload.getStatus();
+                    if (status != WorkloadStatus.STOPPED && status != WorkloadStatus.COMPLETED) {
                         return Future.failedFuture(new IllegalStateException(
-                                "Workload " + workloadId + " is not stopped (status: " + workload.getStatus() + ")"));
+                                "Workload " + workloadId + " is neither stopped nor completed (status: " + status + ")"));
                     }
 
                     workload.setStatus(WorkloadStatus.STARTING);
@@ -180,7 +181,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                         // Destroyed while the dispatch was in flight — a save here would
                         // resurrect the record
                         ret = Future.succeededFuture(startedWorkload);
-                    } else if (startedWorkload.getStatus().isComplete()
+                    } else if (startedWorkload.getStatus().hasEnded()
                             || current.getStatus() == WorkloadStatus.STARTING) {
                         // A terminal reply — a non-detached run that already ended — is the
                         // node's final word. A RUNNING reply only promotes from STARTING: a

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/ProjectDeployJobDefinitionFactory.java
@@ -260,12 +260,13 @@ public class ProjectDeployJobDefinitionFactory {
     }
 
     /**
-     * Passes a foreground workload's run only when it exited cleanly; the workload is kept
-     * either way, so a failed run's logs stay inspectable.
+     * Passes a foreground workload's run only when it ran to completion; a run that was
+     * stopped or failed fails the job. The workload is kept either way, so a failed run's
+     * logs stay inspectable.
      */
     private static Future<String> requireSucceeded(Workload finished, String role) {
         Future<String> ret;
-        if (finished.getStatus() == WorkloadStatus.STOPPED && Integer.valueOf(0).equals(finished.getExitCode())) {
+        if (finished.getStatus() == WorkloadStatus.COMPLETED) {
             ret = Future.succeededFuture(finished.getId());
         } else {
             ret = Future.failedFuture(new IllegalStateException(

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
@@ -66,12 +66,12 @@ public class WorkloadOrchestrationTest {
         assertFalse(run.isComplete());
         assertEquals(WorkloadStatus.RUNNING, workloads.saved.get(vmManager.lastStarted.getId()).getStatus());
 
-        vmManager.completeRun(WorkloadStatus.STOPPED, 0);
+        vmManager.completeRun(WorkloadStatus.COMPLETED, 0);
 
         Workload finished = await(run);
-        assertEquals(WorkloadStatus.STOPPED, finished.getStatus());
+        assertEquals(WorkloadStatus.COMPLETED, finished.getStatus());
         assertEquals(0, finished.getExitCode());
-        assertEquals(WorkloadStatus.STOPPED, workloads.saved.get(finished.getId()).getStatus());
+        assertEquals(WorkloadStatus.COMPLETED, workloads.saved.get(finished.getId()).getStatus());
         assertEquals(0, workloads.saved.get(finished.getId()).getExitCode());
     }
 
@@ -114,12 +114,14 @@ public class WorkloadOrchestrationTest {
     public void foregroundRestartCompletesAtRunEnd() throws Exception {
         Future<Workload> firstRun = orchestration.deployWorkload(newForegroundWorkload());
         String workloadId = vmManager.lastStarted.getId();
-        vmManager.completeRun(WorkloadStatus.STOPPED, 0);
+        vmManager.completeRun(WorkloadStatus.COMPLETED, 0);
         await(firstRun);
 
+        // A completed run leaves the VM dormant, so it restarts the same way a stopped one does
         Future<Workload> secondRun = orchestration.restartWorkload(workloadId);
         assertFalse(secondRun.isComplete());
 
+        // Stopped by request mid-run this time
         vmManager.completeRun(WorkloadStatus.STOPPED, 3);
 
         Workload finished = await(secondRun);

--- a/website/content/02.platform/08.observability.md
+++ b/website/content/02.platform/08.observability.md
@@ -50,11 +50,11 @@ Every node runs a managed [Grafana Alloy](https://grafana.com/docs/alloy/latest/
 
 `CLOUD_HYPERVISOR` nodes label each stream `stdout` or `stderr`. Both providers bound what a workload's logs occupy on the node through `logPolicy` — `maxSizeMb` is the size at which the current file rotates, and `maxFiles` how many rotated files are kept beside it — the container runtime enforcing it on `CLOUD_HYPERVISOR`, and the image itself on `BOXLITE`.
 
-Workload VMs run detached from the vm-manager process by default (`Workload.detached`), and the vm-manager persists each workload's state on the node. If the vm-manager restarts (a crash, a systemd restart), it reattaches to the detached VMs that are still running and regenerates the Alloy pipeline, so their logs keep shipping. A non-detached workload runs in the foreground — the call that starts it resolves only once its run has ended, with the exit code — and ends with the vm-manager process.
+Workload VMs run detached from the vm-manager process by default (`Workload.detached`), and the vm-manager persists each workload's state on the node. If the vm-manager restarts (a crash, a systemd restart), it reattaches to the detached VMs that are still running and regenerates the Alloy pipeline, so their logs keep shipping. A non-detached workload runs in the foreground — the call that starts it resolves only once its run has ended, with the exit code — and ends with the vm-manager process. A foreground run whose guest exits with code 0 on its own ends `COMPLETED`; a run ended by a stop request ends `STOPPED` whatever its exit code, and any other exit is `FAILED`. A detached workload that exits with code 0 on its own is `STOPPED`, not `COMPLETED` — a service has nothing to complete.
 
 On a deployment's job run page the **Sync project source** step expands into the sync workload's log, the way a CI step does: open while the step runs, tailing live, and readable afterwards from the run's history. A workload whose run has ended keeps its log files on the node until it is destroyed, and a destroy waits for the shipper to read them to the end first, so a run over in seconds still ships every line it wrote.
 
-A stopped workload can be restarted in place (`restartWorkload`) unless it was stopped with `Workload.autoRemove`, which discards the VM and its disk at stop. A restart boots the same VM, so its log streams continue under the same `vm_id` label.
+A stopped or completed workload can be restarted in place (`restartWorkload`) unless it has `Workload.autoRemove`, which discards the VM and its disk when the run ends. A restart boots the same VM, so its log streams continue under the same `vm_id` label.
 
 Every log stream carries these labels:
 


### PR DESCRIPTION
Introduces a new `WorkloadStatus.COMPLETED` to distinguish foreground workloads that exited cleanly (exit code 0) from detached services that merely stopped. This allows the system to track whether a run succeeded or was interrupted, improving observability and enabling better restart/stop logic.

## Key Changes

- **New workload status**: `WorkloadStatus.COMPLETED` represents a foreground run that exited with code 0. Detached services that stop cleanly remain `STOPPED`.
  - `kinotic-management-api/src/main/java/org/kinotic/system/api/model/workload/WorkloadStatus.java`: Added `COMPLETED` enum value with documentation; renamed `isComplete()` to `hasEnded()` to clarify it includes all terminal states.
  - `kinotic-js/workspace/packages/management-api/src/api/model/workload/WorkloadStatus.ts`: Added `COMPLETED` enum value with matching documentation.

- **VM provider logic**: Both `BoxliteProvider` and `CloudHypervisorProvider` now distinguish exit outcomes:
  - Exit code 0 on a detached workload → `STOPPED`
  - Exit code 0 on a foreground workload → `COMPLETED`
  - Non-zero exit or failure → `FAILED`
  - Explicit stop request → `STOPPED`

- **Restart support**: Both Java and TypeScript restart methods now accept `COMPLETED` workloads (previously only `STOPPED`), since both states leave the VM dormant and restartable.

- **Frontend improvements**:
  - `WorkloadStatus.COMPLETED` renders with "success" severity (green) like `RUNNING`
  - `WORKLOAD_STATES` array reordered: live states first (RUNNING, STARTING, PENDING, STOPPING), then ended states (COMPLETED, STOPPED, FAILED)
  - `WorkloadsTable.vue` now sorts by status (live first) then creation date, with extracted `canStop()` and `canRestart()` helper functions
  - `WorkloadPage.vue` uses the same helpers for consistent button visibility

- **Job deployment**: `ProjectDeployJobDefinitionFactory.requireSucceeded()` now checks for `COMPLETED` status directly instead of inspecting exit code, making the intent clearer.

- **Documentation**: Updated all service interfaces and Javadoc to reflect that foreground runs complete with `COMPLETED`, `STOPPED`, or `FAILED` status.

## Implementation Details

The exit status logic (`exitedStatus()` in both providers) now checks `workload.detached ?? true` to determine the outcome: a clean exit (code 0) on a foreground run (detached=false) becomes `COMPLETED`, while the same exit on a detached service becomes `STOPPED`. This preserves the distinction between "the run succeeded" and "the service stopped" without requiring additional fields.

https://claude.ai/code/session_01NNmKdZCE8vQWgUXX6uofAK