### PR TITLE
Choose the tenant policy when creating an application

### DIFF
--- a/kinotic-js/workspace/packages/management-api/src/api/services/IApplicationService.ts
+++ b/kinotic-js/workspace/packages/management-api/src/api/services/IApplicationService.ts
@@ -12,10 +12,14 @@ export interface IApplicationService extends ICrudServiceProxy<Application> {
      * the server.
      * @param name the name of the application to create
      * @param description the description of the application to create
+     * @param tenantPerUser true to give every APPLICATION-scope user of this application its
+     *        own tenant, isolating each user's MultiTenancyType.SHARED entity data; false or
+     *        omitted to leave all users sharing one set of data. Applies to users created
+     *        while it is enabled, so it is chosen before the application has users
      * @return {@link Promise} emitting the created application, or the existing application
      *         whose id matches the slugified name
      */
-    createApplicationIfNotExist(name: string, description: string): Promise<Application>
+    createApplicationIfNotExist(name: string, description: string, tenantPerUser?: boolean): Promise<Application>
 
     /**
      * This operation makes all the recent writes immediately available for search.
@@ -31,8 +35,8 @@ export class ApplicationService extends CrudServiceProxy<Application> implements
         super(kinotic.serviceProxy(`${MANAGEMENT_API_ZONE}~org.kinotic.management.api.services.ApplicationService`))
     }
 
-    public createApplicationIfNotExist(id: string, description: string): Promise<Application> {
-        return this.serviceProxy.invoke('createApplicationIfNotExist', [id, description])
+    public createApplicationIfNotExist(name: string, description: string, tenantPerUser?: boolean): Promise<Application> {
+        return this.serviceProxy.invoke('createApplicationIfNotExist', [name, description, tenantPerUser])
     }
 
     public syncIndex(): Promise<void> {

--- a/kinotic-management-api/src/main/java/org/kinotic/management/api/services/ApplicationService.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/api/services/ApplicationService.java
@@ -23,10 +23,15 @@ public interface ApplicationService extends IdentifiableCrudService<Application,
      * The organization id is derived from the authenticated participant.
      * @param name the name of the application to create
      * @param description the description of the application to create
+     * @param tenantPerUser true to give every APPLICATION-scope user of this application its own
+     *                      tenant, isolating each user's {@code MultiTenancyType.SHARED} entity
+     *                      data; false or null to leave all users sharing one set of data.
+     *                      Applies to users created while it is enabled, so it is chosen before
+     *                      the application has users
      * @return {@link Future} emitting the created application, or the existing
      *         application whose id matches the slugified name
      */
-    Future<Application> createApplicationIfNotExist(String name, String description);
+    Future<Application> createApplicationIfNotExist(String name, String description, Boolean tenantPerUser);
 
     /**
      * Returns the enabled OIDC configurations registered on the given application.

--- a/kinotic-management-api/src/main/java/org/kinotic/management/internal/api/services/DefaultApplicationService.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/internal/api/services/DefaultApplicationService.java
@@ -34,18 +34,26 @@ public class DefaultApplicationService extends AbstractOrganizationScopedService
     }
 
     @Override
-    public Future<Application> createApplicationIfNotExist(String name, String description) {
+    public Future<Application> createApplicationIfNotExist(String name, String description, Boolean tenantPerUser) {
         String applicationId = DomainUtil.slugifyId(name);
         String organizationId = requireOrganizationId();
         return findById(applicationId)
                 .compose(application -> {
+                    Future<Application> ret;
                     if(application != null){
-                        return Future.succeededFuture(application);
+                        // an existing application keeps its tenant policy: flipping it here would
+                        // split its users into tenanted and untenanted halves, since only users
+                        // created while it is enabled receive a tenant
+                        ret = Future.succeededFuture(application);
                     }else{
                         Application newApplication = new Application(name, description);
                         newApplication.setOrganizationId(organizationId);
-                        return save(newApplication);
+                        // a caller with no tenancy opinion, such as the CLI ensuring the app row exists,
+                        // omits the argument and gets the shared default
+                        newApplication.setTenantPerUser(Boolean.TRUE.equals(tenantPerUser));
+                        ret = save(newApplication);
                     }
+                    return ret;
                 });
     }
 

--- a/kinotic-test/src/test/java/org/kinotic/test/support/sample/TestDataService.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/support/sample/TestDataService.java
@@ -129,7 +129,7 @@ public class TestDataService {
 
         structure.setSchema(carType);
 
-        return applicationService.createApplicationIfNotExist(SAMPLE_APP_ID, "Sample application")
+        return applicationService.createApplicationIfNotExist(SAMPLE_APP_ID, "Sample application", null)
                                .compose(v -> entityDefinitionService.create(structure)
                                                                     .compose(saved -> entityDefinitionService.publish(saved.getId())
                                                                                                              .map(saved)));
@@ -217,7 +217,7 @@ public class TestDataService {
 
         structure.setSchema(personType);
 
-        return applicationService.createApplicationIfNotExist(SAMPLE_APP_ID, "Sample application")
+        return applicationService.createApplicationIfNotExist(SAMPLE_APP_ID, "Sample application", null)
                                .compose(v -> entityDefinitionService.create(structure)
                                                                     .compose(saved -> entityDefinitionService.publish(saved.getId())
                                                                                                              .map(saved)));

--- a/website/content/01.apps/05.persistence/06.multi-tenancy.md
+++ b/website/content/01.apps/05.persistence/06.multi-tenancy.md
@@ -27,6 +27,25 @@ export class Person {
 
 The `@TenantId` field is populated automatically based on the authenticated user's tenant context. You do not need to set it manually when saving entities.
 
+## Where a user's tenant comes from
+
+Declaring the entity is only half of it. A user's tenant is assigned when the user is created, and only when the owning application has `tenantPerUser` enabled — the setting that decides whether each user of the application is isolated or everyone shares one set of data.
+
+| Application `tenantPerUser` | Entity | Result |
+| --- | --- | --- |
+| `false` | `MultiTenancyType.NONE` | One shared dataset — every user sees every other user's rows |
+| `true` | `MultiTenancyType.NONE` | Still one shared dataset; the setting has nothing to act on |
+| `false` | `SHARED` + `@TenantId` | Users have no tenant, and writes fail with `tenantId cannot be null or blank for shared multi tenancy` |
+| `true` | `SHARED` + `@TenantId` | Each user isolated in their own tenant |
+
+Choose it when the application is created — `createApplicationIfNotExist` takes it as an argument — and change it afterwards only from the portal, under **Application → Settings → Tenant per user**.
+
+It applies to users created while it is enabled. Existing users are never backfilled, so enabling it on an application that already has users leaves those users without a tenant, and every write they make to a `SHARED` entity fails. Settle it before the application has users.
+
+## Tenants and services
+
+A tenant comes from the authenticated participant, and only an application-scope participant carries one. A microservice running in a project's deployment connects at organization scope, so it cannot read or write a `SHARED` entity through the tenant-scoped repository — it uses the admin repository below, naming the tenants it means to act on. Per-user writes driven by the user belong on a client connected as that user.
+
 ## Tenant-Isolated Repository
 
 The standard generated `Repository` automatically filters all operations to the current tenant. No additional configuration is needed.


### PR DESCRIPTION
`createApplicationIfNotExist` took only a name and description, so an application was always created with `tenantPerUser` false and every user of it shared one set of data. An agent driving the MCP tool had no way to ask for anything else — a personal app built through the plugin exposed each user's rows to all the others.

**This unblocks kinotic-ai/claude-plugin#9, which is already merged.** That plugin version calls the tool with `tenantPerUser`, and `NamedJsonArgumentResolver:61-66` rejects any key that matches no parameter, so `/kinotic:new-app` fails at application creation until this is deployed.

## The change

```java
Future<Application> createApplicationIfNotExist(String name, String description, Boolean tenantPerUser);
```

Applied at creation only. An idempotent call that finds the application returns it with the policy it already had — flipping it on an existing application would split its users into tenanted and untenanted halves, since only users created while it is enabled receive a tenant.

## Why `Boolean` and not `boolean`

An absent key binds `null` (`NamedJsonArgumentResolver:57`), which a primitive parameter cannot accept. The workload-runner image bakes a pinned CLI, and `kinotic sync` calls this method on every deploy:

```typescript
// kinotic-cli/src/commands/synchronize.ts:65 — runs inside every deployment
await Kinotic.applications.createApplicationIfNotExist(kinoticProjectConfig.applicationId, '')
```

With a primitive, deploying this server would break that call for every image built against an older CLI — entity sync would fail on every deployment until the packages were published and the image rebuilt in lockstep. Boxed, the old CLI keeps working and the publishes can follow whenever convenient.

Callers with no tenancy opinion now omit the argument rather than passing a value they do not mean: the CLI, the e2e helpers, the load-generator fixtures. What forces an agent to make the decision is the emitted tool schema plus the plugin's create-app workflow, not a null-hostile signature.

## Docs

`06.multi-tenancy.md` documented the entity half and never mentioned the setting it depends on — `tenantPerUser` appeared nowhere in `website/content`. It now carries the four combinations, including the two that fail rather than isolate:

| Application `tenantPerUser` | Entity | Result |
| --- | --- | --- |
| `false` | `MultiTenancyType.NONE` | One shared dataset |
| `true` | `MultiTenancyType.NONE` | Still shared; nothing to act on |
| `false` | `SHARED` + `@TenantId` | Writes fail: `tenantId cannot be null or blank for shared multi tenancy` |
| `true` | `SHARED` + `@TenantId` | Each user isolated |

plus where a user's tenant comes from, and why a microservice at organization scope needs the admin repository.

## Verification

`kinotic-management-api` `compileJava` and `compileTestJava`; `@kinotic-ai/management-api` `type-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH1YoW6zNkZPtm4w3j6EFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH1YoW6zNkZPtm4w3j6EFH)_