### PR TITLE
Rebuild the CLI and workload-runner against the tenant-policy application service

### DIFF
--- a/kinotic-js/kinotic-cli/package.json
+++ b/kinotic-js/kinotic-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kinotic-ai/kinotic-cli",
-    "version": "5.2.0-beta.12",
+    "version": "5.2.0-beta.13",
     "description": "Kinotic CLI provides the ability to build, deploy, and manage Kinotic applications that run on the Kinotic OS.",
     "author": "Kinotic Developers",
     "bin": {
@@ -22,10 +22,10 @@
     ],
     "dependencies": {
         "@inquirer/prompts": "^8.5.2",
-        "@kinotic-ai/core": "5.0.0-beta.7",
+        "@kinotic-ai/core": "5.0.0-beta.10",
         "@kinotic-ai/idl": "5.0.0-beta.1",
-        "@kinotic-ai/management-api": "5.0.0-beta.21",
-        "@kinotic-ai/persistence": "5.0.0-beta.7",
+        "@kinotic-ai/management-api": "5.0.0-beta.29",
+        "@kinotic-ai/persistence": "5.0.0-beta.9",
         "@kinotic-ai/spawn": "5.0.0-beta.1",
         "@oclif/core": "^4.13.3",
         "c12": "^3.3.4",

--- a/kinotic-js/kinotic-cli/pnpm-lock.yaml
+++ b/kinotic-js/kinotic-cli/pnpm-lock.yaml
@@ -16,17 +16,17 @@ importers:
         specifier: ^8.5.2
         version: 8.5.2(@types/node@25.9.5)
       '@kinotic-ai/core':
-        specifier: 5.0.0-beta.7
-        version: 5.0.0-beta.7
+        specifier: 5.0.0-beta.10
+        version: 5.0.0-beta.10
       '@kinotic-ai/idl':
         specifier: 5.0.0-beta.1
         version: 5.0.0-beta.1
       '@kinotic-ai/management-api':
-        specifier: 5.0.0-beta.21
-        version: 5.0.0-beta.21(@kinotic-ai/core@5.0.0-beta.7)
+        specifier: 5.0.0-beta.29
+        version: 5.0.0-beta.29(@kinotic-ai/core@5.0.0-beta.10)
       '@kinotic-ai/persistence':
-        specifier: 5.0.0-beta.7
-        version: 5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.7)
+        specifier: 5.0.0-beta.9
+        version: 5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)
       '@kinotic-ai/spawn':
         specifier: 5.0.0-beta.1
         version: 5.0.0-beta.1
@@ -449,21 +449,21 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@kinotic-ai/core@5.0.0-beta.7':
-    resolution: {integrity: sha512-pmqAzM3wb2TrAhZJGx47Dv7AxhxDNZupVkMoS4yQQtXRfgkHAu66+O1M3TqtIGdHJD7IKhrgfvbsAJ2erKKFCA==}
+  '@kinotic-ai/core@5.0.0-beta.10':
+    resolution: {integrity: sha512-4fxhVXXwxUh0BDFVDpQfBXanEgrRWJMI7gviSEkc+39xjV1IdBPctTJ7IOfEzilWXmArTwC7316BI8Q76O2mjQ==}
 
   '@kinotic-ai/idl@5.0.0-beta.1':
     resolution: {integrity: sha512-zM4NGbHQ5JMKYMh+SU/+Q4GL3UPZsJ5oQWbPAlzRvD9SiLzbnD9mVJpukRVbWnu7zxuk3Z6o3WNQ/7YAokEbDg==}
 
-  '@kinotic-ai/management-api@5.0.0-beta.21':
-    resolution: {integrity: sha512-UxHdcptEds5/MMwW4UseZ4MIjdIB+zfWHR7vYdoFQahLIUFq+l5Om7H2Tae3DPQBRsjbfhjegxrxxL9bIkQ1kg==}
+  '@kinotic-ai/management-api@5.0.0-beta.29':
+    resolution: {integrity: sha512-45Sv0MYzV3lLBiq/PZxPCXkLga8btv7ICIQOGENxFPkpX3Iqwsm8L/dvwHjBxU0d62Ab8uwt4+j9BFO3tUvQ7Q==}
     peerDependencies:
-      '@kinotic-ai/core': '>=5.0.0-beta.7'
+      '@kinotic-ai/core': ^5.0.0-beta.10
 
-  '@kinotic-ai/persistence@5.0.0-beta.7':
-    resolution: {integrity: sha512-SaHGPDpI/BNgd5In4B1hdbEcpiu4dRQESca3Q7UWZYlMZ7SVMQWF0oRKhyAyEmc/jg+N3ZCeByPHtsWwPtAReg==}
+  '@kinotic-ai/persistence@5.0.0-beta.9':
+    resolution: {integrity: sha512-dAxJ0V3m/U65DMPrHg5AfraXifEQIzNwOc7qGXDGkLiHM9kWs4j3iLdQWx1tIJ4dBLoQ8XTIPQNo3PUGjiD0MQ==}
     peerDependencies:
-      '@kinotic-ai/core': '>=5.0.0-beta.7'
+      '@kinotic-ai/core': '>=5.0.0-beta.9'
 
   '@kinotic-ai/spawn@5.0.0-beta.1':
     resolution: {integrity: sha512-54l4rcIo3Z6kYxWCqfpagNm4KZXvDbOdlK6D9Kg9XdImH731nEhiws6OJ/EDHFnEU0ykUJU0vekmaw2Khs/EDw==}
@@ -1837,7 +1837,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@kinotic-ai/core@5.0.0-beta.7':
+  '@kinotic-ai/core@5.0.0-beta.10':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
@@ -1856,16 +1856,16 @@ snapshots:
 
   '@kinotic-ai/idl@5.0.0-beta.1': {}
 
-  '@kinotic-ai/management-api@5.0.0-beta.21(@kinotic-ai/core@5.0.0-beta.7)':
+  '@kinotic-ai/management-api@5.0.0-beta.29(@kinotic-ai/core@5.0.0-beta.10)':
     dependencies:
-      '@kinotic-ai/core': 5.0.0-beta.7
+      '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1
-      '@kinotic-ai/persistence': 5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.7)
+      '@kinotic-ai/persistence': 5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)
       rxjs: 7.8.2
 
-  '@kinotic-ai/persistence@5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.7)':
+  '@kinotic-ai/persistence@5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)':
     dependencies:
-      '@kinotic-ai/core': 5.0.0-beta.7
+      '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1
       rxjs: 7.8.2
 

--- a/kinotic-js/workload-runner/bun.lock
+++ b/kinotic-js/workload-runner/bun.lock
@@ -6,7 +6,7 @@
       "name": "@kinotic-ai/workload-runner",
       "dependencies": {
         "@kinotic-ai/core": "^5.0.0-beta.10",
-        "@kinotic-ai/kinotic-cli": "5.2.0-beta.12",
+        "@kinotic-ai/kinotic-cli": "5.2.0-beta.13",
         "@kinotic-ai/management-api": "5.0.0-beta.28",
       },
       "devDependencies": {
@@ -52,11 +52,11 @@
 
     "@kinotic-ai/idl": ["@kinotic-ai/idl@5.0.0-beta.1", "", {}, "sha512-zM4NGbHQ5JMKYMh+SU/+Q4GL3UPZsJ5oQWbPAlzRvD9SiLzbnD9mVJpukRVbWnu7zxuk3Z6o3WNQ/7YAokEbDg=="],
 
-    "@kinotic-ai/kinotic-cli": ["@kinotic-ai/kinotic-cli@5.2.0-beta.12", "", { "dependencies": { "@inquirer/prompts": "^8.5.2", "@kinotic-ai/core": "5.0.0-beta.7", "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/management-api": "5.0.0-beta.21", "@kinotic-ai/persistence": "5.0.0-beta.7", "@kinotic-ai/spawn": "5.0.0-beta.1", "@oclif/core": "^4.13.3", "c12": "^3.3.4", "chalk": "^5.6.2", "liquidjs": "10.28.0", "open": "^11.0.0", "p-timeout": "^7.0.1", "radash": "^12.1.1", "simple-git": "3.36.0", "ts-morph": "^27.0.2" }, "bin": { "kinotic": "./bin/run.js" } }, "sha512-LxHgaUhD8vJZ567jEIjjmSSXRl/6qBwIneBRSuIYTlXIGTLJSnbgY144Y/zk92nKhify+objzI6Xhq6dHK9Tzw=="],
+    "@kinotic-ai/kinotic-cli": ["@kinotic-ai/kinotic-cli@5.2.0-beta.13", "", { "dependencies": { "@inquirer/prompts": "^8.5.2", "@kinotic-ai/core": "5.0.0-beta.10", "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/management-api": "5.0.0-beta.29", "@kinotic-ai/persistence": "5.0.0-beta.9", "@kinotic-ai/spawn": "5.0.0-beta.1", "@oclif/core": "^4.13.3", "c12": "^3.3.4", "chalk": "^5.6.2", "liquidjs": "10.28.0", "open": "^11.0.0", "p-timeout": "^7.0.1", "radash": "^12.1.1", "simple-git": "3.36.0", "ts-morph": "^27.0.2" }, "bin": { "kinotic": "bin/run.js" } }, "sha512-g0RJ8HBI8V+7DnzhpF9A2NeoHfbCWwVW+FtMrMMqdpgKbpdLoN16fNuIFBkVCS9dr/dan7OQ0bUUvpYFxS+jWw=="],
 
     "@kinotic-ai/management-api": ["@kinotic-ai/management-api@5.0.0-beta.28", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/persistence": "5.0.0-beta.9", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": "^5.0.0-beta.10" } }, "sha512-j5D4K83M4yhIWZr3KNoxErwQAH7jP6MCfuxqrnpF6JZESgwUFkk3XWhUb1KzaAV7NuFSzI89kZj1PIrqfMnPDQ=="],
 
-    "@kinotic-ai/persistence": ["@kinotic-ai/persistence@5.0.0-beta.7", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": ">=5.0.0-beta.7" } }, "sha512-SaHGPDpI/BNgd5In4B1hdbEcpiu4dRQESca3Q7UWZYlMZ7SVMQWF0oRKhyAyEmc/jg+N3ZCeByPHtsWwPtAReg=="],
+    "@kinotic-ai/persistence": ["@kinotic-ai/persistence@5.0.0-beta.9", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": ">=5.0.0-beta.9" } }, "sha512-dAxJ0V3m/U65DMPrHg5AfraXifEQIzNwOc7qGXDGkLiHM9kWs4j3iLdQWx1tIJ4dBLoQ8XTIPQNo3PUGjiD0MQ=="],
 
     "@kinotic-ai/spawn": ["@kinotic-ai/spawn@5.0.0-beta.1", "", { "dependencies": { "liquidjs": "10.28.0", "zod": "4.4.3" } }, "sha512-54l4rcIo3Z6kYxWCqfpagNm4KZXvDbOdlK6D9Kg9XdImH731nEhiws6OJ/EDHFnEU0ykUJU0vekmaw2Khs/EDw=="],
 
@@ -258,11 +258,7 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@kinotic-ai/kinotic-cli/@kinotic-ai/core": ["@kinotic-ai/core@5.0.0-beta.7", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@stomp/rx-stomp": "^2.4.0", "@stomp/stompjs": "^7.3.0", "debug": "^4.4.3", "p-tap": "^4.0.0", "rxjs": "^7.8.2", "typescript-optional": "3.0.0-alpha.3", "uuid": "^13.0.0", "ws": "^8.21.0" } }, "sha512-pmqAzM3wb2TrAhZJGx47Dv7AxhxDNZupVkMoS4yQQtXRfgkHAu66+O1M3TqtIGdHJD7IKhrgfvbsAJ2erKKFCA=="],
-
-    "@kinotic-ai/kinotic-cli/@kinotic-ai/management-api": ["@kinotic-ai/management-api@5.0.0-beta.21", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/persistence": "5.0.0-beta.7", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": ">=5.0.0-beta.7" } }, "sha512-UxHdcptEds5/MMwW4UseZ4MIjdIB+zfWHR7vYdoFQahLIUFq+l5Om7H2Tae3DPQBRsjbfhjegxrxxL9bIkQ1kg=="],
-
-    "@kinotic-ai/management-api/@kinotic-ai/persistence": ["@kinotic-ai/persistence@5.0.0-beta.9", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": ">=5.0.0-beta.9" } }, "sha512-dAxJ0V3m/U65DMPrHg5AfraXifEQIzNwOc7qGXDGkLiHM9kWs4j3iLdQWx1tIJ4dBLoQ8XTIPQNo3PUGjiD0MQ=="],
+    "@kinotic-ai/kinotic-cli/@kinotic-ai/management-api": ["@kinotic-ai/management-api@5.0.0-beta.29", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/persistence": "5.0.0-beta.9", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": "^5.0.0-beta.10" } }, "sha512-45Sv0MYzV3lLBiq/PZxPCXkLga8btv7ICIQOGENxFPkpX3Iqwsm8L/dvwHjBxU0d62Ab8uwt4+j9BFO3tUvQ7Q=="],
 
     "open/wsl-utils": ["wsl-utils@1.0.0", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA=="],
 

--- a/kinotic-js/workload-runner/package.json
+++ b/kinotic-js/workload-runner/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@kinotic-ai/core": "^5.0.0-beta.10",
-    "@kinotic-ai/kinotic-cli": "5.2.0-beta.12",
+    "@kinotic-ai/kinotic-cli": "5.2.0-beta.13",
     "@kinotic-ai/management-api": "5.0.0-beta.28"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

Every customer project sync fails since #535:

```
[workload-runner] found 1 microservice(s) and 1 UI(s)
    Error: Received too few json arguments, Expected: 3 Got: 2
[workload-runner] sync failed: bun .../@kinotic-ai/kinotic-cli/bin/run.js sync --publish ... exited with 1
```

#535 added `tenantPerUser` to `ApplicationService.createApplicationIfNotExist`. The argument decoder counts JSON tokens against method parameters (`AbstractJacksonSupport.java:143`), so a proxy that predates the change sends `[id, ""]` to a three-parameter method and the call is rejected before the first entity is synchronized. The workload-runner image pinned `@kinotic-ai/kinotic-cli` 5.2.0-beta.12, built against management-api beta.21.

## Change

- `kinotic-cli` → 5.2.0-beta.13, depending on management-api 5.0.0-beta.29 (whose proxy sends the third slot as `null`), plus the core beta.10 and persistence beta.9 that proxy requires as peers. Published to npm under the `beta` tag.
- `workload-runner` → pins kinotic-cli 5.2.0-beta.13, `bun.lock` refreshed.

Merging triggers `workload-runner-docker.yml`, which pushes `kinoticai/workload-runner:latest`. Nodes holding the old image need a re-pull, since `DeploymentProperties` references the tag only.

## Verified

- `pnpm build` and `pnpm test` in kinotic-cli (3 passing)
- `bun run type-check` in workload-runner
- installed `kinotic sync --help` loads under bun

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqQn5pPiauou7REvRDZZnR
