### PR TITLE
Sync into the project named by the config instead of deriving one

### DIFF
--- a/kinotic-js/kinotic-cli/package.json
+++ b/kinotic-js/kinotic-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kinotic-ai/kinotic-cli",
-    "version": "5.2.0-beta.13",
+    "version": "5.2.0-beta.14",
     "description": "Kinotic CLI provides the ability to build, deploy, and manage Kinotic applications that run on the Kinotic OS.",
     "author": "Kinotic Developers",
     "bin": {
@@ -24,7 +24,7 @@
         "@inquirer/prompts": "^8.5.2",
         "@kinotic-ai/core": "5.0.0-beta.10",
         "@kinotic-ai/idl": "5.0.0-beta.1",
-        "@kinotic-ai/management-api": "5.0.0-beta.29",
+        "@kinotic-ai/management-api": "5.0.0-beta.30",
         "@kinotic-ai/persistence": "5.0.0-beta.9",
         "@kinotic-ai/spawn": "5.0.0-beta.1",
         "@oclif/core": "^4.13.3",

--- a/kinotic-js/kinotic-cli/src/commands/initialize.ts
+++ b/kinotic-js/kinotic-cli/src/commands/initialize.ts
@@ -43,6 +43,7 @@ export class Initialize extends Command {
 
     static flags = {
         application:  Flags.string({char: 'a', description: 'The name of the application you want to use', required: false}),
+        project:      Flags.string({char: 'p', description: 'The id of the project in Kinotic OS, defaults to <application>-main', required: false}),
         entities:   Flags.string({char: 'e', description: 'Path to the directory containing the Entity definitions', required: false}),
         repository: Flags.string({char: 'r', description: 'Path to the directory to write generated Repository classes', required: false}),
         mirror:     Flags.boolean({char: 'm', description: 'Mirror the entity folder structure under the repository path', default: true}),
@@ -74,6 +75,15 @@ export class Initialize extends Command {
             if (validation !== true) {
                 this.error(validation)
             }
+        }
+
+        let project = flags.project
+        if (!project) {
+            project = await input({
+                message: 'What is the id of the project in Kinotic OS?',
+                default: `${application}-main`,
+                validate: (input: string) => input.trim() !== '' || 'Project id is required'
+            })
         }
 
         let entitiesPath = flags.entities
@@ -109,6 +119,7 @@ export class Initialize extends Command {
         const configObj = new KinoticProjectConfig()
         // Don't set name - it will be loaded from package.json
         configObj.applicationId = application
+        configObj.projectId = project
         configObj.entitiesPaths = [{
             path: entitiesPath,
             repositoryPath: repositoryPath,

--- a/kinotic-js/kinotic-cli/src/commands/synchronize.ts
+++ b/kinotic-js/kinotic-cli/src/commands/synchronize.ts
@@ -6,8 +6,7 @@ import {EntityDefinition,
         INamedQueriesDefinitionService,
         NamedQueriesDefinition,
         ManagementApiPlugin,
-        Project,
-        ProjectType} from '@kinotic-ai/management-api'
+        Project} from '@kinotic-ai/management-api'
 import {Command, Flags} from '@oclif/core'
 import chalk from 'chalk'
 import {EntityCodeGenerationService} from '@/internal/EntityCodeGenerationService'
@@ -62,14 +61,11 @@ export class Synchronize extends Command {
 
             let project: Project | null = null
             if(!flags.dryRun) {
-                await Kinotic.applications.createApplicationIfNotExist(kinoticProjectConfig.applicationId, '')
-                project = new Project(null,
-                                      kinoticProjectConfig.applicationId,
-                                      kinoticProjectConfig.name as string,
-                                      kinoticProjectConfig.description)
-                project.organizationId = kinoticProjectConfig.organizationId
-                project.sourceOfTruth = ProjectType.TYPESCRIPT
-                project = await Kinotic.projects.createProjectIfNotExist(project)
+                project = await Kinotic.projects.findById(kinoticProjectConfig.projectId)
+                if(!project) {
+                    this.error(`Project ${kinoticProjectConfig.projectId} does not exist on ${serverUrl}. `
+                               + 'Create it in Kinotic OS first, then set projectId in .config/kinotic.config.ts to its id.')
+                }
             }
 
             const codeGenerationService = new EntityCodeGenerationService(kinoticProjectConfig.applicationId,

--- a/kinotic-js/workspace/bun.lock
+++ b/kinotic-js/workspace/bun.lock
@@ -59,7 +59,7 @@
     },
     "packages/management-api": {
       "name": "@kinotic-ai/management-api",
-      "version": "5.0.0-beta.29",
+      "version": "5.0.0-beta.30",
       "dependencies": {
         "@kinotic-ai/idl": "workspace:*",
         "@kinotic-ai/persistence": "workspace:*",

--- a/kinotic-js/workspace/packages/management-api/package.json
+++ b/kinotic-js/workspace/packages/management-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/management-api",
-  "version": "5.0.0-beta.29",
+  "version": "5.0.0-beta.30",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/management-api/src/api/model/KinoticProjectConfig.ts
+++ b/kinotic-js/workspace/packages/management-api/src/api/model/KinoticProjectConfig.ts
@@ -49,6 +49,13 @@ export class KinoticProjectConfig {
     public applicationId!: string
 
     /**
+     * The id of the Kinotic Project this configuration belongs to. Every server interaction the CLI
+     * makes on the project's behalf, such as `kinotic sync`, addresses this project; it must already
+     * exist in Kinotic OS.
+     */
+    public projectId!: string
+
+    /**
      * The paths to search for classes decorated with @Entity that Kinotic will be created for.
      * Each entry can be a string (simple path) or an {@link EntitiesPathConfig} object for full control
      * over where repository classes are generated.

--- a/kinotic-management-api/src/main/java/org/kinotic/management/internal/api/services/github/GitHubProjectRepoProvisioner.java
+++ b/kinotic-management-api/src/main/java/org/kinotic/management/internal/api/services/github/GitHubProjectRepoProvisioner.java
@@ -232,6 +232,7 @@ public class GitHubProjectRepoProvisioner implements ProjectRepoProvisioner {
         ret.put("projectSlug", SLUGIFY.slugify(project.getName()));
         ret.put("organizationId", project.getOrganizationId());
         ret.put("applicationId", project.getApplicationId());
+        ret.put("projectId", project.getId());
         return ret;
     }
 

--- a/kinotic-management-api/src/test/java/org/kinotic/management/internal/api/services/github/GitHubProjectRepoProvisionerTest.java
+++ b/kinotic-management-api/src/test/java/org/kinotic/management/internal/api/services/github/GitHubProjectRepoProvisionerTest.java
@@ -106,7 +106,7 @@ class GitHubProjectRepoProvisionerTest {
 
         // .liquid content rendered with the project context, suffix stripped;
         // projectSlug carries the repo-name slug, projectName the raw name
-        assertEquals("{\"name\": \"demo\", \"display\": \"demo\", \"org\": \"org-1\", \"app\": \"app-1\"}",
+        assertEquals("{\"name\": \"demo\", \"display\": \"demo\", \"org\": \"org-1\", \"app\": \"app-1\", \"project\": \"app-1-demo\"}",
                      tree.get("package.json").content());
         // liquid in paths rendered
         assertTrue(tree.containsKey("src/Demo.ts"));
@@ -180,6 +180,7 @@ class GitHubProjectRepoProvisionerTest {
 
     private static Project project() {
         Project project = new Project();
+        project.setId("app-1-demo");
         project.setName("demo");
         project.setOrganizationId("org-1");
         project.setApplicationId("app-1");
@@ -197,7 +198,7 @@ class GitHubProjectRepoProvisionerTest {
             addEntry(tar, "root/versions.txt.liquid",
                      "{{ kinoticCoreVersion }}\n{{ kinoticCliVersion }}\n".getBytes(StandardCharsets.UTF_8), false);
             addEntry(tar, "root/package.json.liquid",
-                     "{\"name\": \"{{projectSlug}}\", \"display\": \"{{projectName}}\", \"org\": \"{{organizationId}}\", \"app\": \"{{applicationId}}\"}"
+                     "{\"name\": \"{{projectSlug}}\", \"display\": \"{{projectName}}\", \"org\": \"{{organizationId}}\", \"app\": \"{{applicationId}}\", \"project\": \"{{projectId}}\"}"
                              .getBytes(StandardCharsets.UTF_8), false);
             addEntry(tar, "root/src/{{ projectName | camelCase | upperFirst }}.ts.liquid",
                      "export class {{ projectName | camelCase | upperFirst }} {}".getBytes(StandardCharsets.UTF_8), false);

--- a/website/content/01.apps/02.quick-start.md
+++ b/website/content/01.apps/02.quick-start.md
@@ -31,7 +31,7 @@ git clone <your-provisioned-repo> && cd <your-repo>
 bun install
 ```
 
-The repository comes with a `.config/kinotic.config.ts` already wired to your organization and application, pointing entity discovery at `packages/domain/model` and repository generation at `packages/domain/repositories`.
+The repository comes with a `.config/kinotic.config.ts` already wired to your organization, application, and project, pointing entity discovery at `packages/domain/model` and repository generation at `packages/domain/repositories`.
 
 ## Define an Entity
 

--- a/website/content/01.apps/03.application-structure/02.applications-and-projects.md
+++ b/website/content/01.apps/03.application-structure/02.applications-and-projects.md
@@ -31,6 +31,7 @@ import type { KinoticProjectConfig } from '@kinotic-ai/management-api'
 const config: KinoticProjectConfig = {
   organizationId: "my-org",
   applicationId: "my-app",
+  projectId: "my-app-main",
   entitiesPaths: [
     {
       path: "packages/domain/model",
@@ -54,6 +55,7 @@ is loaded the same way.
 | --- | --- |
 | `organizationId` | **Required.** The id of the Kinotic organization this project belongs to. |
 | `applicationId` | **Required.** The application id this project belongs to. Must match the application id registered with Kinotic OS: lowercase letters, digits, and interior dashes. |
+| `projectId` | **Required.** The id of this project in Kinotic OS. Provisioned repositories carry the id of the project that created them; `kinotic sync` addresses this project and fails when it does not exist. |
 | `name` | Optional project name. When omitted, the `name` from the project's `package.json` is used. |
 | `description` | Optional project description. When omitted, the `description` from the project's `package.json` is used. |
 | `entitiesPaths` | **Required.** An array whose entries are either a plain path string or an `EntitiesPathConfig` object with `path` (the directory containing entity definitions), `repositoryPath` (where the CLI writes generated repository classes), and `mirrorFolderStructure` (whether to replicate the entity directory structure in the output, default `true`). The CLI scans these paths when you run `kinotic sync`. |

--- a/website/content/01.apps/08.cli-reference.md
+++ b/website/content/01.apps/08.cli-reference.md
@@ -59,7 +59,7 @@ kinotic gen --force
 
 ### `kinotic sync` / `kinotic synchronize`
 
-Synchronize local entity definitions with the Kinotic server. This uploads your entity classes so the server can set up the backing data stores and register the entity services, and applies any pending [migrations](/apps/persistence/migrations) from the `./migrations` directory. It runs the same generation as `kinotic generate`, so the repository classes and `.config/c3` are refreshed as well. Requires a prior `kinotic login` against the target server.
+Synchronize local entity definitions with the Kinotic server. This uploads your entity classes so the server can set up the backing data stores and register the entity services, and applies any pending [migrations](/apps/persistence/migrations) from the `./migrations` directory. The entities are synchronized into the project named by `projectId` in `.config/kinotic.config.ts`, which must already exist in Kinotic OS. It runs the same generation as `kinotic generate`, so the repository classes and `.config/c3` are refreshed as well. Requires a prior `kinotic login` against the target server.
 
 ```bash
 kinotic sync -p


### PR DESCRIPTION
## Problem

With the argument-count error out of the way (#536), every deploy sync fails one call later:

```
[workload-runner] found 1 microservice(s) and 1 UI(s)
    Error: createRepoFromTemplate failed: HTTP 422 — {"message":"Could not clone: Name already exists on this account", ...}
```

`kinotic sync` built a `Project` with a null id from the config's application id and the package name and passed it to `createProjectIfNotExist`. `DefaultProjectService` derives `<applicationId>-<slug(name)>` from that, which never matches the `<applicationId>-main` id the create-app workflow assigns, so the project looked new and the provisioner tried to create a second repo under the same name.

## Change

- `KinoticProjectConfig.projectId` (management-api → 5.0.0-beta.30)
- `GitHubProjectRepoProvisioner` puts `projectId` in the render context, so a scaffolded config names the project that provisioned it
- `kinotic sync` looks the project up by that id and fails with a pointer to the config when it does not exist. An entity sync no longer creates applications or projects.
- `kinotic initialize` asks for the project id (`--project`, defaulting to `<application>-main`)
- Docs: config field table, quick start, CLI reference

Companion PRs, merged **after** this is deployed since the renderer rejects undeclared variables:
- kinotic-ai/kinotic-tpl-isomorphic-ts#10 renders `projectId` into `.config/kinotic.config.ts`
- kinotic-ai/claude-plugin#12 shows the field in the scaffold reference and checks it in Step 4

Publish order once merged: management-api beta.30, then kinotic-cli 5.2.0-beta.14, then a workload-runner bump (follow-up commit on this branch once the CLI is on npm).

## Verified

- `GitHubProjectRepoProvisionerTest` (4 passing)
- `@kinotic-ai/management-api` type-check
- kinotic-cli `tsc --noEmit` and mocha against the locally built management-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqQn5pPiauou7REvRDZZnR
