### PR TITLE
Move the workload-runner to kinotic-cli beta.14

### DIFF
--- a/kinotic-js/kinotic-cli/pnpm-lock.yaml
+++ b/kinotic-js/kinotic-cli/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: 5.0.0-beta.1
         version: 5.0.0-beta.1
       '@kinotic-ai/management-api':
-        specifier: 5.0.0-beta.29
-        version: 5.0.0-beta.29(@kinotic-ai/core@5.0.0-beta.10)
+        specifier: 5.0.0-beta.30
+        version: 5.0.0-beta.30(@kinotic-ai/core@5.0.0-beta.10)
       '@kinotic-ai/persistence':
         specifier: 5.0.0-beta.9
         version: 5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)
@@ -455,8 +455,8 @@ packages:
   '@kinotic-ai/idl@5.0.0-beta.1':
     resolution: {integrity: sha512-zM4NGbHQ5JMKYMh+SU/+Q4GL3UPZsJ5oQWbPAlzRvD9SiLzbnD9mVJpukRVbWnu7zxuk3Z6o3WNQ/7YAokEbDg==}
 
-  '@kinotic-ai/management-api@5.0.0-beta.29':
-    resolution: {integrity: sha512-45Sv0MYzV3lLBiq/PZxPCXkLga8btv7ICIQOGENxFPkpX3Iqwsm8L/dvwHjBxU0d62Ab8uwt4+j9BFO3tUvQ7Q==}
+  '@kinotic-ai/management-api@5.0.0-beta.30':
+    resolution: {integrity: sha512-YUCdXAGL1CSwMnZAHH7Q2dv2TQdcobvCQ94uNVEnEDHZNC4Jjp7LjranlfbOBQR/DnsTzOXG5LEZxolgrR78tw==}
     peerDependencies:
       '@kinotic-ai/core': ^5.0.0-beta.10
 
@@ -1856,7 +1856,7 @@ snapshots:
 
   '@kinotic-ai/idl@5.0.0-beta.1': {}
 
-  '@kinotic-ai/management-api@5.0.0-beta.29(@kinotic-ai/core@5.0.0-beta.10)':
+  '@kinotic-ai/management-api@5.0.0-beta.30(@kinotic-ai/core@5.0.0-beta.10)':
     dependencies:
       '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1

--- a/kinotic-js/workload-runner/bun.lock
+++ b/kinotic-js/workload-runner/bun.lock
@@ -6,7 +6,7 @@
       "name": "@kinotic-ai/workload-runner",
       "dependencies": {
         "@kinotic-ai/core": "^5.0.0-beta.10",
-        "@kinotic-ai/kinotic-cli": "5.2.0-beta.13",
+        "@kinotic-ai/kinotic-cli": "5.2.0-beta.14",
         "@kinotic-ai/management-api": "5.0.0-beta.28",
       },
       "devDependencies": {
@@ -52,7 +52,7 @@
 
     "@kinotic-ai/idl": ["@kinotic-ai/idl@5.0.0-beta.1", "", {}, "sha512-zM4NGbHQ5JMKYMh+SU/+Q4GL3UPZsJ5oQWbPAlzRvD9SiLzbnD9mVJpukRVbWnu7zxuk3Z6o3WNQ/7YAokEbDg=="],
 
-    "@kinotic-ai/kinotic-cli": ["@kinotic-ai/kinotic-cli@5.2.0-beta.13", "", { "dependencies": { "@inquirer/prompts": "^8.5.2", "@kinotic-ai/core": "5.0.0-beta.10", "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/management-api": "5.0.0-beta.29", "@kinotic-ai/persistence": "5.0.0-beta.9", "@kinotic-ai/spawn": "5.0.0-beta.1", "@oclif/core": "^4.13.3", "c12": "^3.3.4", "chalk": "^5.6.2", "liquidjs": "10.28.0", "open": "^11.0.0", "p-timeout": "^7.0.1", "radash": "^12.1.1", "simple-git": "3.36.0", "ts-morph": "^27.0.2" }, "bin": { "kinotic": "bin/run.js" } }, "sha512-g0RJ8HBI8V+7DnzhpF9A2NeoHfbCWwVW+FtMrMMqdpgKbpdLoN16fNuIFBkVCS9dr/dan7OQ0bUUvpYFxS+jWw=="],
+    "@kinotic-ai/kinotic-cli": ["@kinotic-ai/kinotic-cli@5.2.0-beta.14", "", { "dependencies": { "@inquirer/prompts": "^8.5.2", "@kinotic-ai/core": "5.0.0-beta.10", "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/management-api": "5.0.0-beta.30", "@kinotic-ai/persistence": "5.0.0-beta.9", "@kinotic-ai/spawn": "5.0.0-beta.1", "@oclif/core": "^4.13.3", "c12": "^3.3.4", "chalk": "^5.6.2", "liquidjs": "10.28.0", "open": "^11.0.0", "p-timeout": "^7.0.1", "radash": "^12.1.1", "simple-git": "3.36.0", "ts-morph": "^27.0.2" }, "bin": { "kinotic": "bin/run.js" } }, "sha512-4GvX1s84WRHkUaaEpwDg85t7XbrkLJVn271OkCMsc4JZErD196EI/SX0hnCKWRZwYVPvUM19YF6ckVDfyzkgmQ=="],
 
     "@kinotic-ai/management-api": ["@kinotic-ai/management-api@5.0.0-beta.28", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/persistence": "5.0.0-beta.9", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": "^5.0.0-beta.10" } }, "sha512-j5D4K83M4yhIWZr3KNoxErwQAH7jP6MCfuxqrnpF6JZESgwUFkk3XWhUb1KzaAV7NuFSzI89kZj1PIrqfMnPDQ=="],
 
@@ -258,7 +258,7 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@kinotic-ai/kinotic-cli/@kinotic-ai/management-api": ["@kinotic-ai/management-api@5.0.0-beta.29", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/persistence": "5.0.0-beta.9", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": "^5.0.0-beta.10" } }, "sha512-45Sv0MYzV3lLBiq/PZxPCXkLga8btv7ICIQOGENxFPkpX3Iqwsm8L/dvwHjBxU0d62Ab8uwt4+j9BFO3tUvQ7Q=="],
+    "@kinotic-ai/kinotic-cli/@kinotic-ai/management-api": ["@kinotic-ai/management-api@5.0.0-beta.30", "", { "dependencies": { "@kinotic-ai/idl": "5.0.0-beta.1", "@kinotic-ai/persistence": "5.0.0-beta.9", "rxjs": "^7.8.2" }, "peerDependencies": { "@kinotic-ai/core": "^5.0.0-beta.10" } }, "sha512-YUCdXAGL1CSwMnZAHH7Q2dv2TQdcobvCQ94uNVEnEDHZNC4Jjp7LjranlfbOBQR/DnsTzOXG5LEZxolgrR78tw=="],
 
     "open/wsl-utils": ["wsl-utils@1.0.0", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA=="],
 

--- a/kinotic-js/workload-runner/package.json
+++ b/kinotic-js/workload-runner/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@kinotic-ai/core": "^5.0.0-beta.10",
-    "@kinotic-ai/kinotic-cli": "5.2.0-beta.13",
+    "@kinotic-ai/kinotic-cli": "5.2.0-beta.14",
     "@kinotic-ai/management-api": "5.0.0-beta.28"
   },
   "devDependencies": {


### PR DESCRIPTION
Follow-up to #537. `@kinotic-ai/kinotic-cli` 5.2.0-beta.14 is on npm with management-api beta.30, so the workload-runner pins it and the CLI lockfile is refreshed to match its package.json. Merging rebuilds `kinoticai/workload-runner:latest`.

Verified: workload-runner `bun run type-check`, and the installed `kinotic sync --help` loads under bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqQn5pPiauou7REvRDZZnR
