### PR TITLE
Update e2e-tests dependencies and workspace config

### DIFF
--- a/kinotic-js/e2e-tests/package.json
+++ b/kinotic-js/e2e-tests/package.json
@@ -10,9 +10,9 @@
     "ui-test": "vitest --ui --mode development"
   },
   "dependencies": {
-    "@kinotic-ai/core": "^5.0.0-beta.4",
-    "@kinotic-ai/management-api": "^5.0.0-beta.17",
-    "@kinotic-ai/persistence": "^5.0.0-beta.4",
+    "@kinotic-ai/core": "^5.0.0-beta.10",
+    "@kinotic-ai/management-api": "^5.0.0-beta.30",
+    "@kinotic-ai/persistence": "^5.0.0-beta.9",
     "vue": "^3.5.41"
   },
   "devDependencies": {

--- a/kinotic-js/e2e-tests/pnpm-lock.yaml
+++ b/kinotic-js/e2e-tests/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
   .:
     dependencies:
       '@kinotic-ai/core':
-        specifier: ^5.0.0-beta.4
-        version: 5.0.0-beta.4(supports-color@8.1.1)
+        specifier: ^5.0.0-beta.10
+        version: 5.0.0-beta.10
       '@kinotic-ai/management-api':
-        specifier: ^5.0.0-beta.17
-        version: 5.0.0-beta.17(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))
+        specifier: ^5.0.0-beta.30
+        version: 5.0.0-beta.30(@kinotic-ai/core@5.0.0-beta.10)
       '@kinotic-ai/persistence':
-        specifier: ^5.0.0-beta.4
-        version: 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))
+        specifier: ^5.0.0-beta.9
+        version: 5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)
       vue:
         specifier: ^3.5.41
         version: 3.5.41(typescript@5.9.3)
@@ -35,10 +35,10 @@ importers:
         version: 5.0.0-beta.1
       '@kinotic-ai/kinotic-cli':
         specifier: ^5.2.0-beta.2
-        version: 5.2.0-beta.2(@types/node@25.9.5)(magicast@0.5.4)(supports-color@8.1.1)
+        version: 5.2.0-beta.2(@types/node@25.9.5)(magicast@0.5.4)
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
-        version: 1.30.0(supports-color@8.1.1)(zod@4.4.3)
+        version: 1.30.0(zod@4.4.3)
       '@types/node':
         specifier: ^25.9.5
         version: 25.9.5
@@ -68,10 +68,10 @@ importers:
         version: 3.10.2(@vitest/runner@4.1.10)(vitest@4.1.10)
       axios:
         specifier: 1.18.0
-        version: 1.18.0(supports-color@8.1.1)
+        version: 1.18.0
       testcontainers:
         specifier: ^11.14.0
-        version: 11.14.0(supports-color@8.1.1)
+        version: 11.14.0
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -448,8 +448,8 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@kinotic-ai/core@5.0.0-beta.4':
-    resolution: {integrity: sha512-loAF90XFnlFRxHWtsgM2lR7FXXQ1O/WBYrELu+m7kNqRayWauQhikgXbwTf+OIUze8lLypBDanaRl80Crqzd0g==}
+  '@kinotic-ai/core@5.0.0-beta.10':
+    resolution: {integrity: sha512-4fxhVXXwxUh0BDFVDpQfBXanEgrRWJMI7gviSEkc+39xjV1IdBPctTJ7IOfEzilWXmArTwC7316BI8Q76O2mjQ==}
 
   '@kinotic-ai/idl@5.0.0-beta.1':
     resolution: {integrity: sha512-zM4NGbHQ5JMKYMh+SU/+Q4GL3UPZsJ5oQWbPAlzRvD9SiLzbnD9mVJpukRVbWnu7zxuk3Z6o3WNQ/7YAokEbDg==}
@@ -459,10 +459,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@kinotic-ai/management-api@5.0.0-beta.17':
-    resolution: {integrity: sha512-P3VZMOcZMcileQUJOdnehgujZdjh+4pzcFPPLitsArcs71kE5hyKjSGRkB4RDlA9M4+CbH2SiQWFfzVF/59+uA==}
+  '@kinotic-ai/management-api@5.0.0-beta.30':
+    resolution: {integrity: sha512-YUCdXAGL1CSwMnZAHH7Q2dv2TQdcobvCQ94uNVEnEDHZNC4Jjp7LjranlfbOBQR/DnsTzOXG5LEZxolgrR78tw==}
     peerDependencies:
-      '@kinotic-ai/core': '>=5.0.0-beta.5'
+      '@kinotic-ai/core': ^5.0.0-beta.10
 
   '@kinotic-ai/os-api@5.0.0-beta.5':
     resolution: {integrity: sha512-irDD3OHLTOv2L0BOI2DWbd+RDgFAoWbLlgjgLi+GFTC3QeuyBGBYZAylFjPRCo6VSRZSdMxN/MFmFbMTP8qzWA==}
@@ -474,10 +474,10 @@ packages:
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.4'
 
-  '@kinotic-ai/persistence@5.0.0-beta.5':
-    resolution: {integrity: sha512-OhpkJbOvb1gcDHrbAi5F+OhXs9HzLOocTForm9J77HiryY7n3Dwr38A2ukm9MYsiO0mRdXGr7m20880iUzKQZQ==}
+  '@kinotic-ai/persistence@5.0.0-beta.9':
+    resolution: {integrity: sha512-dAxJ0V3m/U65DMPrHg5AfraXifEQIzNwOc7qGXDGkLiHM9kWs4j3iLdQWx1tIJ4dBLoQ8XTIPQNo3PUGjiD0MQ==}
     peerDependencies:
-      '@kinotic-ai/core': '>=5.0.0-beta.5'
+      '@kinotic-ai/core': '>=5.0.0-beta.9'
 
   '@kinotic-ai/spawn@5.0.0-beta.1':
     resolution: {integrity: sha512-54l4rcIo3Z6kYxWCqfpagNm4KZXvDbOdlK6D9Kg9XdImH731nEhiws6OJ/EDHFnEU0ykUJU0vekmaw2Khs/EDw==}
@@ -2538,7 +2538,7 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1)':
+  '@kinotic-ai/core@5.0.0-beta.10':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
@@ -2557,13 +2557,13 @@ snapshots:
 
   '@kinotic-ai/idl@5.0.0-beta.1': {}
 
-  '@kinotic-ai/kinotic-cli@5.2.0-beta.2(@types/node@25.9.5)(magicast@0.5.4)(supports-color@8.1.1)':
+  '@kinotic-ai/kinotic-cli@5.2.0-beta.2(@types/node@25.9.5)(magicast@0.5.4)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@25.9.5)
-      '@kinotic-ai/core': 5.0.0-beta.4(supports-color@8.1.1)
+      '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1
-      '@kinotic-ai/os-api': 5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))
-      '@kinotic-ai/persistence': 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))
+      '@kinotic-ai/os-api': 5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.10)
+      '@kinotic-ai/persistence': 5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)
       '@kinotic-ai/spawn': 5.0.0-beta.1
       '@oclif/core': 4.13.3
       c12: 3.3.4(magicast@0.5.4)
@@ -2572,7 +2572,7 @@ snapshots:
       open: 11.0.0
       p-timeout: 7.0.1
       radash: 12.1.1
-      simple-git: 3.36.0(supports-color@8.1.1)
+      simple-git: 3.36.0
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - '@types/node'
@@ -2581,29 +2581,29 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@kinotic-ai/management-api@5.0.0-beta.17(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))':
+  '@kinotic-ai/management-api@5.0.0-beta.30(@kinotic-ai/core@5.0.0-beta.10)':
     dependencies:
-      '@kinotic-ai/core': 5.0.0-beta.4(supports-color@8.1.1)
+      '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1
-      '@kinotic-ai/persistence': 5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))
+      '@kinotic-ai/persistence': 5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)
       rxjs: 7.8.2
 
-  '@kinotic-ai/os-api@5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))':
+  '@kinotic-ai/os-api@5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.10)':
     dependencies:
-      '@kinotic-ai/core': 5.0.0-beta.4(supports-color@8.1.1)
+      '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1
-      '@kinotic-ai/persistence': 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))
+      '@kinotic-ai/persistence': 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.10)
       rxjs: 7.8.2
 
-  '@kinotic-ai/persistence@5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))':
+  '@kinotic-ai/persistence@5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.10)':
     dependencies:
-      '@kinotic-ai/core': 5.0.0-beta.4(supports-color@8.1.1)
+      '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1
       rxjs: 7.8.2
 
-  '@kinotic-ai/persistence@5.0.0-beta.5(@kinotic-ai/core@5.0.0-beta.4(supports-color@8.1.1))':
+  '@kinotic-ai/persistence@5.0.0-beta.9(@kinotic-ai/core@5.0.0-beta.10)':
     dependencies:
-      '@kinotic-ai/core': 5.0.0-beta.4(supports-color@8.1.1)
+      '@kinotic-ai/core': 5.0.0-beta.10
       '@kinotic-ai/idl': 5.0.0-beta.1
       rxjs: 7.8.2
 
@@ -2612,7 +2612,7 @@ snapshots:
       liquidjs: 10.28.0
       zod: 4.4.3
 
-  '@kwsites/file-exists@1.1.1(supports-color@8.1.1)':
+  '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -2620,7 +2620,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.1.0(hono@4.13.0)
       ajv: 8.20.0
@@ -2630,8 +2630,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
       hono: 4.13.0
       jose: 6.2.8
       json-schema-typed: 8.0.2
@@ -3001,7 +3001,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agent-base@6.0.2(supports-color@8.1.1):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -3090,11 +3090,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.18.0(supports-color@8.1.1):
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -3147,7 +3147,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.3.0(supports-color@8.1.1):
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -3340,7 +3340,7 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  docker-modem@5.0.7(supports-color@8.1.1):
+  docker-modem@5.0.7:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       readable-stream: 3.6.2
@@ -3349,12 +3349,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@4.0.12(supports-color@8.1.1):
+  dockerode@4.0.12:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7(supports-color@8.1.1)
+      docker-modem: 5.0.7
       protobufjs: 7.6.5
       tar-fs: 2.1.5
       uuid: 10.0.0
@@ -3467,18 +3467,18 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express-rate-limit@8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
+  express-rate-limit@8.6.2(express@5.2.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      express: 5.2.1(supports-color@8.1.1)
+      express: 5.2.1
       ip-address: 10.4.0
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@8.1.1):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0(supports-color@8.1.1)
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -3488,7 +3488,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@8.1.1)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -3499,8 +3499,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0(supports-color@8.1.1)
-      send: 1.2.1(supports-color@8.1.1)
+      router: 2.2.0
+      send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -3536,7 +3536,7 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
-  finalhandler@2.1.1(supports-color@8.1.1):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -3638,9 +3638,9 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -3895,7 +3895,7 @@ snapshots:
 
   properties-reader@3.0.1:
     dependencies:
-      '@kwsites/file-exists': 1.1.1(supports-color@8.1.1)
+      '@kwsites/file-exists': 1.1.1
       mkdirp: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -4015,7 +4015,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
-  router@2.2.0(supports-color@8.1.1):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -4039,7 +4039,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@8.1.1):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -4060,7 +4060,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4106,9 +4106,9 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-git@3.36.0(supports-color@8.1.1):
+  simple-git@3.36.0:
     dependencies:
-      '@kwsites/file-exists': 1.1.1(supports-color@8.1.1)
+      '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
@@ -4235,7 +4235,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  testcontainers@11.14.0(supports-color@8.1.1):
+  testcontainers@11.14.0:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@types/dockerode': 4.0.1
@@ -4244,7 +4244,7 @@ snapshots:
       byline: 5.0.0
       debug: 4.4.3(supports-color@8.1.1)
       docker-compose: 1.4.2
-      dockerode: 4.0.12(supports-color@8.1.1)
+      dockerode: 4.0.12
       get-port: 7.2.0
       proper-lockfile: 4.1.2
       properties-reader: 3.0.1

--- a/kinotic-js/e2e-tests/pnpm-workspace.yaml
+++ b/kinotic-js/e2e-tests/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ minimumReleaseAgeExclude:
   - '@kinotic-ai/core'
   - '@kinotic-ai/idl'
   - '@kinotic-ai/kinotic-cli'
+  - '@kinotic-ai/management-api'
   - '@kinotic-ai/os-api'
   - '@kinotic-ai/persistence'
   - '@kinotic-ai/spawn'


### PR DESCRIPTION
Updates the e2e-tests package dependencies to newer beta versions and adds `@kinotic-ai/management-api` to the pnpm workspace minimum release age exclusion list.

**Changes:**
- Bump `@kinotic-ai/core` from `^5.0.0-beta.4` to `^5.0.0-beta.10`
- Bump `@kinotic-ai/management-api` from `^5.0.0-beta.17` to `^5.0.0-beta.30`
- Bump `@kinotic-ai/persistence` from `^5.0.0-beta.4` to `^5.0.0-beta.9`
- Add `@kinotic-ai/management-api` to `minimumReleaseAgeExclude` in pnpm-workspace.yaml to align with other core packages

These updates bring the e2e-tests environment in sync with the latest beta releases of the core dependencies.

https://claude.ai/code/session_01DvzeqsNuDnV71dXVzqsrek