### PR TITLE
Phase 2: the acknowledgement names the node, and membership says when it is gone

### DIFF
--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -1,7 +1,7 @@
 # Node failure handling for service proxies — phase plan
 
 Plan of record for making a proxy call fail when the node serving it dies, instead of hanging
-forever. Phase 1 is in PR #476. Everything below was re-validated against `develop` at `3adf17d`
+forever. Phase 1 landed in PR #476; Phase 2 followed it. Everything below was re-validated against `develop` at `3adf17d`
 (2026-09-08); the adjustments that pass produced are folded in, and the phase numbering below
 supersedes the earlier chat numbering (mapping at the end).
 

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -1,7 +1,7 @@
 # Node failure handling for service proxies — phase plan
 
 Plan of record for making a proxy call fail when the node serving it dies, instead of hanging
-forever. Phase 1 landed in PR #476; Phase 2 followed it. Everything below was re-validated against `develop` at `3adf17d`
+forever. Phase 1 landed in PR #476; Phase 2 is PR #540. Everything below was re-validated against `develop` at `3adf17d`
 (2026-09-08); the adjustments that pass produced are folded in, and the phase numbering below
 supersedes the earlier chat numbering (mapping at the end).
 
@@ -101,19 +101,31 @@ if (message.replyAddress() != null) {
 // EventBusService — the ack's payload reaches the sender
 Future<String> sendWithAck(Event<byte[]> event);     // completes with the acking node id (was Future<Void>)
 
-// KinoticIgniteClusterManager — registration updates already carry RegistrationInfo.nodeId();
-// alongside statusFlux, emit the set of nodes holding a registration for the address
-Flux<Set<String>> registeredNodesFlux(String address);
-// exposed as EventBusService.monitorRegisteredNodes(CRI)
+// KinoticIgniteClusterManager — a NodeListener on the discovery events vertx-ignite already
+// subscribes to (EVT_NODE_JOINED, EVT_NODE_LEFT, EVT_NODE_FAILED) emits the cluster membership
+Flux<Set<String>> clusterNodesFlux();
+// exposed as EventBusService.monitorClusterNodes()
 ```
 
-Same cost profile as `statusFlux`: a map entry per monitored address, on registration events the
-cluster already delivers to every node.
+Membership, not the address's registration set, is what a pinned lease checks against. A JVM
+unregisters an address while it is still up — `ServiceRegistrationBeanPostProcessor` runs
+`ServiceInvocationSupervisor.stop()` on bean destruction, and an invocation already running there
+still replies — so the registration set fires a false failure on every rolling restart, at the
+exact moment Phase 3's drain wants callers to keep waiting. `nodeLeft` fires only when the node is
+gone: at once after a graceful leave, after a crash once Ignite's `failureDetectionTimeout` (10 s)
+expires. Cost is one N-sized snapshot per membership change per node, however many addresses have
+calls in flight; the registration set would have cost a k-sized set per monitored address, since
+every platform address is registered on all k nodes.
+
+Nothing watches the address before the ack. `sendWithAck` is a Vert.x `request`, which fails with
+`NO_HANDLERS` at once when nothing is registered and with `TIMEOUT` after `DeliveryOptions`'
+default 30 s when the ack never arrives — a bound on one network hop, since `DefaultEventConsumer`
+acks before dispatching, never on the invocation.
 
 Files: `DefaultEventConsumer`, `DefaultEventBusService`, `EventBusService`,
 `KinoticIgniteClusterManager`, the four `sendWithAck` call sites adapting to the new return type
 (`DefaultRpcServiceProxyHandle`, `McpToolInvoker`, `DefaultEventService`,
-`EndpointConnectionHandler`), `EventBusServiceTests` (node set tracks registration lifecycle;
+`EndpointConnectionHandler`), `EventBusServiceTests` (the membership names the local node;
 the ack names the local node).
 
 Why not `RegistrationInfo.seq()`: it exists, but a `MessageConsumer` never learns its own seq, so
@@ -131,38 +143,59 @@ interface RequestLivenessWatcher {
 }
 ```
 
-A lease passes through two states:
-
-- **Before the ack**: the address's `statusFlux` going INACTIVE fails the lease. This is the
-  single-registration case (every scoped call, every single-instance service) and it fires without
-  waiting for anything.
-- **After the ack** names a node: the lease is pinned to `(address, nodeId)` and fails when that
-  node leaves the address's `registeredNodesFlux` set. The address may stay ACTIVE on other
-  instances; this lease still fails, because the instance that took the request is gone.
+A lease starts at the ack. Until then Vert.x owns the outcome (`NO_HANDLERS` or `TIMEOUT` on the
+`request`, see Phase 2), and `KinoticUtil.mapSendFailure` maps `TIMEOUT` to
+`RpcServiceUnavailableException`, because an ack lost in flight cannot rule out that the handler
+ran. From the ack on, the lease is pinned to the node id it named and fails when that id leaves
+`monitorClusterNodes()`. The address may stay ACTIVE on other instances, and the node may already
+have unregistered the address to drain; the lease holds until the node is gone.
 
 Coverage of the round-robin cases:
 
 | Call | Ack names | Fails when |
 |---|---|---|
-| scoped `srv://<scope>@…` | the one node | either rule; immediate |
-| unscoped, N Java instances (one per JVM) — a service on N nodes, or `@ScopeOptional` methods | the JVM that took it | that JVM leaves the set |
+| scoped `srv://<scope>@…` | the one node | that node leaves the cluster |
+| unscoped, N Java instances (one per JVM) — a service on N nodes, or `@ScopeOptional` methods | the JVM that took it | that JVM leaves the cluster |
 | unscoped, N TS instances behind gateways | the **gateway** holding that instance's subscription | that gateway dies (this phase); the instance dies while its gateway lives (Phase 5) |
 
 Wired into `DefaultRpcServiceProxyHandle` (lease per correlationId, symmetric with the existing
 send-failure path — `onLost` calls `handler.processError(new RpcServiceUnavailableException(...))`)
 and `McpToolInvoker`. `onLost` only *dispatches* the failure to the request's own context, never
 runs continuations on the cluster manager's delivery context: under a death burst that loop must
-drain in queue submissions, not user code. Refcount monitors per address with a short linger so
-high-QPS bursts to one address do not churn subscribe/re-seed. Non-clustered guards are gone from
-`develop` (#496), so there is no fallback path.
+drain in queue submissions, not user code. One membership subscription per JVM, held for the
+watcher's lifetime, and leases keyed by the node id they are pinned to, so a membership change costs
+one lookup per pinned node. Non-clustered guards are gone from `develop` (#496), so there is no
+fallback path.
 
 Files: `RequestLivenessWatcher` + `Lease`, `RpcServiceUnavailableException`,
-`DefaultRpcServiceProxyHandle`, `McpToolInvoker`, Spring wiring, `RpcTests` (unregister a
-supervisor mid-call → `RpcServiceUnavailableException`; second instance still registered → the
-lease pinned to the dead node fails, the other's does not; unrelated churn → no false failure).
+`DefaultRpcServiceProxyHandle`, `McpToolInvoker`, Spring wiring, `RpcTests` (a second cluster
+node hosting the service leaves mid-call → `RpcServiceUnavailableException`, while a call pinned
+to the surviving node completes; the local node unregistering the service mid-call → the reply
+still arrives; unrelated churn → no false failure).
 
 The proxy constructor grows by one parameter, the way `develop` grew it for `TraceLogFilter`;
 it is not restructured.
+
+The callee side of the same phase: `ServiceInvocationSupervisor.stop()` drains instead of cutting.
+
+```java
+// ServiceInvocationSupervisor.stop() — Phase 3
+Future<Void> ret = methodInvocationEventConsumer.unregister()          // 1. stop accepting
+    .compose(v -> inFlight.drained());                                 // 2. single-value invocations reply first
+for(... : activeStreamingResults.entrySet()){
+    streamSubscribers.getValue().fail(new RpcServiceUnavailableException(...));   // 3. streams end with a terminal error
+}
+```
+
+Today `stop()` cancels streams with no terminal reply and returns before running invocations have
+replied; with membership as the post-ack signal a cut stream's caller would otherwise wait for the
+JVM to exit. The supervisor only tracks streams, so it gains an in-flight count for single-value
+invocations. The drain is bounded by a shutdown setting, the same kind of bound as Spring's
+lifecycle timeout, never a per-call one. To verify while building it: the drain only helps while
+Vert.x and Ignite are still up, and `ServiceRegistrationBeanPostProcessor.postProcessBeforeDestruction`
+runs on the service bean's destruction, where a published bean that injects nothing from kinotic
+has no dependency edge forcing that order. If the drain does not fit the phase's file budget it is
+Phase 3b, after the watcher.
 
 ## Phase 4 — gateway, caller side: session state, leases, session touch (~10 files)
 
@@ -241,7 +274,7 @@ vm-manager's overlapping heartbeat `setInterval`.
 Not in scope: failing in-flight calls on a sticky reconnect. That is what parking exists to
 avoid.
 
-## Phase 7 — parked reply sessions, same node (~9 files)
+## Phase 7 — parked reply sessions, same node (~13 files, split 7a gateway / 7b client)
 
 On `closed()` with a sticky session, `shutdown()` *parks* the `ReplySessionState` in a node-local
 `ParkedReplySessions` instead of disposing: the reply consumer keeps consuming into a bounded
@@ -261,19 +294,39 @@ Adjustments from the re-validation:
   heap-resident bodies up to `maxEventPayloadSize`, and the direct-memory-exhaustion scenario in
   NavidNotes parks many sessions on one node at once.
 
-Two exits. Window expiry: dispose, drop the buffer, close leases (streams then cancel through the
-existing INACTIVE path). Overflow: dispose and **rotate the `replyToId`** in the session's
-`ConnectedInfo`, so the next CONNECT mints a new reply CRI and the client's existing
+Two exits, one outcome. Window expiry: dispose, drop the buffer, close leases (streams then cancel
+through the existing INACTIVE path). Overflow: dispose. Both **rotate the `replyToId`** in the
+session's `ConnectedInfo`, so the next CONNECT mints a new reply CRI and the client's existing
 `replyToCriChangedHandler` → `resetRequestReplies` path fails its in-flight calls — continuity
-loss signals through a mechanism that already ships, and login is untouched.
+loss signals through a mechanism that already ships, and login is untouched. Expiry has to rotate
+too: a single-value reply produced during the gap is gone with the buffer, and a client that
+reconnects within the session but after the window would otherwise find its `replyToId` intact
+and wait forever for that reply.
+
+**The client half (7b).** A client whose socket stays down longer than the window has nothing left
+to wait for, so it fails its in-flight calls itself instead of holding them for a reconnect that
+may never come. One timer per connection, armed on `connectionState$` CLOSED and cleared on the
+next CONNECTED, never a per-call timeout; on expiry it runs `resetRequestReplies`. The window comes
+from the server: `ConnectedInfo` gains `replyBufferWindow` beside `replyToId`, mirrored in
+`ConnectedInfo.ts`, so it is configured once, on the gateway. Every ordering is consistent given
+the rotation above: a reconnect inside the window flushes; the client timer first, then a reconnect
+inside the server's window, flushes to correlations already failed, which `cancelIfUnexpected`
+already handles; the server first, then a reconnect, fails through the reply CRI change; no
+reconnect at all fails on the client timer. The client's first reconnect attempt comes
+`INITIAL_RECONNECT_DELAY` (2 s) after the drop, so the window's useful range starts there; five to
+ten seconds absorbs a spotty network, and past that the network is down and failing fast is
+cheaper than holding the calls.
 
 A client that reconnects through a fresh handshake without its session (the vm-manager's
 `reconnectOnFatalError` loop re-authenticates with credentials) gets a new `replyToId`; its old
 parked session is orphaned until the window expires. The window bounds a leak, not only a wait.
 
-Files: `ParkedReplySessions`, park/reattach in `EndpointConnectionHandler` + `ReplySessionState`,
-`replyToId` rotation, properties, tests (blip mid-stream on one gateway → stream continues;
-overflow → calls fail with the reset error).
+Files, 7a: `ParkedReplySessions`, park/reattach in `EndpointConnectionHandler` +
+`ReplySessionState`, `replyToId` rotation on both exits, `ApiGatewayProperties.replyBufferWindow`,
+`ConnectedInfo` (Java) carrying it, tests (blip mid-stream on one gateway → stream continues; a
+single-value reply during the blip → delivered on reattach; expiry and overflow → calls fail with
+the reset error). 7b: `ConnectedInfo.ts`, `StompConnectionManager.ts`, `EventBus.ts`, a TS test
+(blip shorter than the window → the call completes; longer → it fails).
 
 ## Phase 8 — cross-node handoff (~9 files)
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -170,7 +170,8 @@ public class EndpointConnectionHandler {
                                 }
                                 return Future.failedFuture(ex);
                             }
-                        });
+                        })
+                        .mapEmpty();
 
             } catch (Exception e) {
                 return Future.failedFuture(e);

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventBusService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventBusService.java
@@ -65,14 +65,12 @@ public interface EventBusService {
     Flux<ListenerStatus> monitorListenerStatus(CRI cri);
 
     /**
-     * Monitors which nodes hold a listener for the {@link CRI#baseResource()} of the given {@link CRI}.
-     * Node ids are the ones {@link #sendWithAck(Event)} completes with, so a sender can tell whether the
-     * node that took its event is still listening.
-     * @param cri to check for registered listeners
-     * @return a {@link Flux} that emits the current set of node ids on subscribe and every change after that;
-     *         an empty set means nothing is listening
+     * Monitors the membership of the cluster. Node ids are the ones {@link #sendWithAck(Event)} completes
+     * with, so a sender can tell whether the node that took its event is still part of the cluster.
+     * @return a {@link Flux} that emits the current set of node ids on subscribe and the resulting set
+     *         every time a node joins or leaves
      */
-    Flux<Set<String>> monitorRegisteredNodes(CRI cri);
+    Flux<Set<String>> monitorClusterNodes();
 
     /**
      * Monitors listener registration events across all service ({@code srv://}) addresses. A

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventBusService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventBusService.java
@@ -26,9 +26,10 @@ public interface EventBusService {
      * This is a special form of send that requires the receiver to acknowledge receipt of the message.
      * An exception will be signaled if no acknowledgement is sent.
      * @param event to send
-     * @return a {@link Future} that completes when the acknowledgement is received or fails on error
+     * @return a {@link Future} that completes with the id of the node whose consumer received the event,
+     *         or fails on error
      */
-    Future<Void> sendWithAck(Event<byte[]> event);
+    Future<String> sendWithAck(Event<byte[]> event);
 
     /**
      * Publishes an {@link Event} to every consumer registered on the {@link CRI#baseResource()} of the
@@ -62,6 +63,16 @@ public interface EventBusService {
      * @return a {@link Flux} that emits the current status on subscribe and every status transition after that
      */
     Flux<ListenerStatus> monitorListenerStatus(CRI cri);
+
+    /**
+     * Monitors which nodes hold a listener for the {@link CRI#baseResource()} of the given {@link CRI}.
+     * Node ids are the ones {@link #sendWithAck(Event)} completes with, so a sender can tell whether the
+     * node that took its event is still listening.
+     * @param cri to check for registered listeners
+     * @return a {@link Flux} that emits the current set of node ids on subscribe and every change after that;
+     *         an empty set means nothing is listening
+     */
+    Flux<Set<String>> monitorRegisteredNodes(CRI cri);
 
     /**
      * Monitors listener registration events across all service ({@code srv://}) addresses. A

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
@@ -34,6 +34,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * Monitoring an address therefore costs a local map entry, no matter how many addresses are monitored or
  * how often monitors come and go. All monitor signals are delivered on a vertx context, never on the
  * cluster threads that observe registration changes.
+ * <p>
+ * Vert.x high availability ({@code VertxOptions.setHAEnabled}) is not supported: {@link IgniteClusterManager}
+ * holds a single {@link NodeListener}, which the membership flux owns, and HA installs its own in that slot.
  *
  * Created by Navid on 7/13/26
  */

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
@@ -56,6 +56,7 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
     // Retains the latest membership snapshot for every clusterNodesFlux subscriber; never terminates
     private final Sinks.Many<Set<String>> clusterNodesSink = Sinks.many().replay().latest();
     private boolean clusterNodesEmitted; // touched only on the delivery context
+    private boolean nodeListenerInstalled;
     private volatile Vertx vertx;
     private volatile Context deliveryContext;
 
@@ -68,8 +69,6 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
     public void init(Vertx vertx) {
         super.init(vertx);
         this.vertx = vertx;
-        // IgniteClusterManager holds a single NodeListener and vertx core only installs one under HA,
-        // which KinoticVertxConfig does not enable, so this replaces nothing
         nodeListener(new NodeListener() {
             @Override
             public void nodeAdded(String nodeId) {
@@ -81,6 +80,17 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
                 emitClusterNodes(false);
             }
         });
+    }
+
+    @Override
+    public void nodeListener(NodeListener nodeListener) {
+        // IgniteClusterManager keeps one listener, so a second installer would silently take the slot
+        // from the membership flux. Vert.x HA is the only other installer, whichever of the two runs first.
+        if(nodeListenerInstalled){
+            throw new UnsupportedOperationException("KinoticIgniteClusterManager does not support Vert.x HA: its single NodeListener slot is owned by the cluster membership flux");
+        }
+        super.nodeListener(nodeListener);
+        nodeListenerInstalled = true;
     }
 
     // One shared context all monitors deliver on, so subscriber chains never run on the cluster

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
@@ -20,15 +20,18 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
 import javax.cache.Cache;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
- * An {@link IgniteClusterManager} that additionally provides a {@link Flux} of {@link ListenerStatus} for
- * any event bus address, fed by the registration updates it already receives for message routing.
+ * An {@link IgniteClusterManager} that additionally provides, for any event bus address, a {@link Flux} of
+ * the ids of the nodes holding a registration and a {@link Flux} of {@link ListenerStatus} derived from it,
+ * both fed by the registration updates it already receives for message routing.
  * Monitoring an address therefore costs a local map entry, no matter how many addresses are monitored or
  * how often monitors come and go. All monitor signals are delivered on a vertx context, never on the
  * cluster threads that observe registration changes.
@@ -99,7 +102,7 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
                 }
                 AddressMonitor monitor = monitors.get(event.address());
                 if(monitor != null){
-                    monitor.emit(statusOf(event.registrations()));
+                    monitor.emit(nodeIdsOf(event.registrations()));
                 }
                 if(event.address().startsWith(SERVICE_ADDRESS_PREFIX) && serviceListenerSink.currentSubscriberCount() > 0){
                     emitServiceListenerEvent(new ServiceListenerChange(event.address(), statusOf(event.registrations())));
@@ -120,13 +123,25 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
     }
 
     /**
-     * A {@link Flux} of {@link ListenerStatus} for the given address, shared between all subscribers
-     * for the same address. Emits the current status on subscribe and the resulting status of every
-     * registration change after that, so consecutive duplicates are possible.
+     * A {@link Flux} of {@link ListenerStatus} for the given address, derived from {@link #registeredNodesFlux}.
+     * Emits the current status on subscribe and the resulting status of every registration change after
+     * that, so consecutive duplicates are possible.
      * @param address the event bus address to monitor
      * @return the status flux
      */
     public Flux<ListenerStatus> statusFlux(String address) {
+        return registeredNodesFlux(address).map(KinoticIgniteClusterManager::statusOf);
+    }
+
+    /**
+     * A {@link Flux} of the ids of the nodes holding a registration for the given address, shared between
+     * all subscribers for the same address. Emits the current set on subscribe and the resulting set of
+     * every registration change after that, so consecutive duplicates are possible. Each emission is an
+     * immutable snapshot; an empty set means nothing is listening.
+     * @param address the event bus address to monitor
+     * @return the registered node ids flux
+     */
+    public Flux<Set<String>> registeredNodesFlux(String address) {
         return Flux.defer(() -> {
             Context context = deliveryContext();
             AddressMonitor monitor = monitors.compute(address, (a, existing) -> {
@@ -191,11 +206,11 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
                 return;
             }
             if(ar.succeeded()){
-                ListenerStatus status = statusOf(ar.result());
+                Set<String> nodeIds = nodeIdsOf(ar.result());
                 if(seed){
-                    monitor.seed(status);
+                    monitor.seed(nodeIds);
                 }else{
-                    monitor.emit(status);
+                    monitor.emit(nodeIds);
                 }
             }else{
                 log.error("Failed to query registrations for monitored address {}", address, ar.cause());
@@ -204,18 +219,25 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
         });
     }
 
-    private static ListenerStatus statusOf(List<RegistrationInfo> registrations) {
-        return registrations == null || registrations.isEmpty() ? ListenerStatus.INACTIVE : ListenerStatus.ACTIVE;
+    // Registrations and node id sets both mean ACTIVE exactly when non-empty
+    private static ListenerStatus statusOf(Collection<?> registrationsOrNodeIds) {
+        return registrationsOrNodeIds == null || registrationsOrNodeIds.isEmpty() ? ListenerStatus.INACTIVE : ListenerStatus.ACTIVE;
+    }
+
+    private static Set<String> nodeIdsOf(List<RegistrationInfo> registrations) {
+        return registrations == null
+                ? Set.of()
+                : registrations.stream().map(RegistrationInfo::nodeId).collect(Collectors.toUnmodifiableSet());
     }
 
     /**
      * Per-address sink plus the subscriber count used to remove idle entries. Emissions are serialized
      * on the delivery context; the emitted flag keeps a seed scheduled behind an update event from
-     * overwriting the newer status with a stale one.
+     * overwriting the newer node set with a stale one.
      */
     private static class AddressMonitor {
 
-        final Sinks.Many<ListenerStatus> sink = Sinks.many().replay().latest();
+        final Sinks.Many<Set<String>> sink = Sinks.many().replay().latest();
         int subscribers; // mutated only inside monitors.compute* blocks for this address
         private final Context deliveryContext;
         private boolean emitted; // touched only on the delivery context
@@ -224,18 +246,18 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
             this.deliveryContext = deliveryContext;
         }
 
-        void emit(ListenerStatus status) {
+        void emit(Set<String> nodeIds) {
             deliveryContext.runOnContext(v -> {
                 emitted = true;
-                tryEmit(status);
+                tryEmit(nodeIds);
             });
         }
 
-        void seed(ListenerStatus status) {
+        void seed(Set<String> nodeIds) {
             deliveryContext.runOnContext(v -> {
                 if(!emitted){
                     emitted = true;
-                    tryEmit(status);
+                    tryEmit(nodeIds);
                 }
             });
         }
@@ -244,10 +266,10 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
             deliveryContext.runOnContext(v -> sink.tryEmitError(throwable));
         }
 
-        private void tryEmit(ListenerStatus status) {
-            Sinks.EmitResult result = sink.tryEmitNext(status);
+        private void tryEmit(Set<String> nodeIds) {
+            Sinks.EmitResult result = sink.tryEmitNext(nodeIds);
             if(result.isFailure()){
-                log.warn("Failed to emit ListenerStatus {}: {}", status, result);
+                log.warn("Failed to emit registered nodes {}: {}", nodeIds, result);
             }
         }
     }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
@@ -3,6 +3,7 @@ package org.kinotic.core.internal;
 import io.vertx.core.Context;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.spi.cluster.NodeListener;
 import io.vertx.core.spi.cluster.RegistrationInfo;
 import io.vertx.core.spi.cluster.RegistrationListener;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
@@ -20,18 +21,16 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
 import javax.cache.Cache;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
- * An {@link IgniteClusterManager} that additionally provides, for any event bus address, a {@link Flux} of
- * the ids of the nodes holding a registration and a {@link Flux} of {@link ListenerStatus} derived from it,
- * both fed by the registration updates it already receives for message routing.
+ * An {@link IgniteClusterManager} that additionally provides a {@link Flux} of {@link ListenerStatus} for
+ * any event bus address, fed by the registration updates it already receives for message routing, and a
+ * {@link Flux} of the cluster membership, fed by the discovery events it already receives.
  * Monitoring an address therefore costs a local map entry, no matter how many addresses are monitored or
  * how often monitors come and go. All monitor signals are delivered on a vertx context, never on the
  * cluster threads that observe registration changes.
@@ -51,6 +50,9 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
     private final Map<String, AddressMonitor> monitors = new ConcurrentHashMap<>();
     // Hot sink shared by every serviceListenerEventsFlux subscriber; never terminates
     private final Sinks.Many<ServiceListenerEvent> serviceListenerSink = Sinks.many().multicast().directBestEffort();
+    // Retains the latest membership snapshot for every clusterNodesFlux subscriber; never terminates
+    private final Sinks.Many<Set<String>> clusterNodesSink = Sinks.many().replay().latest();
+    private boolean clusterNodesEmitted; // touched only on the delivery context
     private volatile Vertx vertx;
     private volatile Context deliveryContext;
 
@@ -63,6 +65,19 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
     public void init(Vertx vertx) {
         super.init(vertx);
         this.vertx = vertx;
+        // IgniteClusterManager holds a single NodeListener and vertx core only installs one under HA,
+        // which KinoticVertxConfig does not enable, so this replaces nothing
+        nodeListener(new NodeListener() {
+            @Override
+            public void nodeAdded(String nodeId) {
+                emitClusterNodes(false);
+            }
+
+            @Override
+            public void nodeLeft(String nodeId) {
+                emitClusterNodes(false);
+            }
+        });
     }
 
     // One shared context all monitors deliver on, so subscriber chains never run on the cluster
@@ -102,7 +117,7 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
                 }
                 AddressMonitor monitor = monitors.get(event.address());
                 if(monitor != null){
-                    monitor.emit(nodeIdsOf(event.registrations()));
+                    monitor.emit(statusOf(event.registrations()));
                 }
                 if(event.address().startsWith(SERVICE_ADDRESS_PREFIX) && serviceListenerSink.currentSubscriberCount() > 0){
                     emitServiceListenerEvent(new ServiceListenerChange(event.address(), statusOf(event.registrations())));
@@ -123,25 +138,13 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
     }
 
     /**
-     * A {@link Flux} of {@link ListenerStatus} for the given address, derived from {@link #registeredNodesFlux}.
-     * Emits the current status on subscribe and the resulting status of every registration change after
-     * that, so consecutive duplicates are possible.
+     * A {@link Flux} of {@link ListenerStatus} for the given address, shared between all subscribers
+     * for the same address. Emits the current status on subscribe and the resulting status of every
+     * registration change after that, so consecutive duplicates are possible.
      * @param address the event bus address to monitor
      * @return the status flux
      */
     public Flux<ListenerStatus> statusFlux(String address) {
-        return registeredNodesFlux(address).map(KinoticIgniteClusterManager::statusOf);
-    }
-
-    /**
-     * A {@link Flux} of the ids of the nodes holding a registration for the given address, shared between
-     * all subscribers for the same address. Emits the current set on subscribe and the resulting set of
-     * every registration change after that, so consecutive duplicates are possible. Each emission is an
-     * immutable snapshot; an empty set means nothing is listening.
-     * @param address the event bus address to monitor
-     * @return the registered node ids flux
-     */
-    public Flux<Set<String>> registeredNodesFlux(String address) {
         return Flux.defer(() -> {
             Context context = deliveryContext();
             AddressMonitor monitor = monitors.compute(address, (a, existing) -> {
@@ -154,6 +157,35 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
             refresh(address, true);
             return monitor.sink.asFlux()
                                .doFinally(signal -> monitors.computeIfPresent(address, (a, m) -> --m.subscribers == 0 ? null : m));
+        });
+    }
+
+    /**
+     * A {@link Flux} of the ids of every node in the cluster, shared between all subscribers. Emits the
+     * current membership on subscribe and the resulting membership every time a node joins or leaves.
+     * Each emission is an immutable snapshot, and the ids are the ones {@link #getNodeId()} reports on
+     * each node.
+     * @return the cluster nodes flux
+     */
+    public Flux<Set<String>> clusterNodesFlux() {
+        return Flux.defer(() -> {
+            emitClusterNodes(true);
+            return clusterNodesSink.asFlux();
+        });
+    }
+
+    // The snapshot is taken on the calling thread and emitted on the delivery context; a seed queued
+    // behind a membership event must not overwrite that event's newer snapshot with its stale one
+    private void emitClusterNodes(boolean seed) {
+        Set<String> nodes = Set.copyOf(getNodes());
+        deliveryContext().runOnContext(v -> {
+            if(!seed || !clusterNodesEmitted){
+                clusterNodesEmitted = true;
+                Sinks.EmitResult result = clusterNodesSink.tryEmitNext(nodes);
+                if(result.isFailure()){
+                    log.warn("Failed to emit cluster nodes {}: {}", nodes, result);
+                }
+            }
         });
     }
 
@@ -206,11 +238,11 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
                 return;
             }
             if(ar.succeeded()){
-                Set<String> nodeIds = nodeIdsOf(ar.result());
+                ListenerStatus status = statusOf(ar.result());
                 if(seed){
-                    monitor.seed(nodeIds);
+                    monitor.seed(status);
                 }else{
-                    monitor.emit(nodeIds);
+                    monitor.emit(status);
                 }
             }else{
                 log.error("Failed to query registrations for monitored address {}", address, ar.cause());
@@ -219,25 +251,18 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
         });
     }
 
-    // Registrations and node id sets both mean ACTIVE exactly when non-empty
-    private static ListenerStatus statusOf(Collection<?> registrationsOrNodeIds) {
-        return registrationsOrNodeIds == null || registrationsOrNodeIds.isEmpty() ? ListenerStatus.INACTIVE : ListenerStatus.ACTIVE;
-    }
-
-    private static Set<String> nodeIdsOf(List<RegistrationInfo> registrations) {
-        return registrations == null
-                ? Set.of()
-                : registrations.stream().map(RegistrationInfo::nodeId).collect(Collectors.toUnmodifiableSet());
+    private static ListenerStatus statusOf(List<RegistrationInfo> registrations) {
+        return registrations == null || registrations.isEmpty() ? ListenerStatus.INACTIVE : ListenerStatus.ACTIVE;
     }
 
     /**
      * Per-address sink plus the subscriber count used to remove idle entries. Emissions are serialized
      * on the delivery context; the emitted flag keeps a seed scheduled behind an update event from
-     * overwriting the newer node set with a stale one.
+     * overwriting the newer status with a stale one.
      */
     private static class AddressMonitor {
 
-        final Sinks.Many<Set<String>> sink = Sinks.many().replay().latest();
+        final Sinks.Many<ListenerStatus> sink = Sinks.many().replay().latest();
         int subscribers; // mutated only inside monitors.compute* blocks for this address
         private final Context deliveryContext;
         private boolean emitted; // touched only on the delivery context
@@ -246,18 +271,18 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
             this.deliveryContext = deliveryContext;
         }
 
-        void emit(Set<String> nodeIds) {
+        void emit(ListenerStatus status) {
             deliveryContext.runOnContext(v -> {
                 emitted = true;
-                tryEmit(nodeIds);
+                tryEmit(status);
             });
         }
 
-        void seed(Set<String> nodeIds) {
+        void seed(ListenerStatus status) {
             deliveryContext.runOnContext(v -> {
                 if(!emitted){
                     emitted = true;
-                    tryEmit(nodeIds);
+                    tryEmit(status);
                 }
             });
         }
@@ -266,10 +291,10 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
             deliveryContext.runOnContext(v -> sink.tryEmitError(throwable));
         }
 
-        private void tryEmit(Set<String> nodeIds) {
-            Sinks.EmitResult result = sink.tryEmitNext(nodeIds);
+        private void tryEmit(ListenerStatus status) {
+            Sinks.EmitResult result = sink.tryEmitNext(status);
             if(result.isFailure()){
-                log.warn("Failed to emit registered nodes {}: {}", nodeIds, result);
+                log.warn("Failed to emit ListenerStatus {}: {}", status, result);
             }
         }
     }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventBusService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventBusService.java
@@ -70,10 +70,8 @@ public class DefaultEventBusService implements EventBusService {
     }
 
     @Override
-    public Flux<Set<String>> monitorRegisteredNodes(CRI cri) {
-        // Every registration change on the address emits its resulting node set, dedupe to changes
-        return clusterManager.registeredNodesFlux(cri.baseResource())
-                             .distinctUntilChanged();
+    public Flux<Set<String>> monitorClusterNodes() {
+        return clusterManager.clusterNodesFlux();
     }
 
     @Override

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventBusService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventBusService.java
@@ -6,6 +6,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.spi.cluster.RegistrationInfo;
 import io.vertx.core.tracing.TracingPolicy;
@@ -57,6 +58,7 @@ public class DefaultEventBusService implements EventBusService {
         MessageConsumer<Event<byte[]>> consumer = vertx.eventBus().consumer(address);
         localListenerCounts.merge(address, 1, Integer::sum);
         return new DefaultEventConsumer(consumer,
+                                        clusterManager.getNodeId(),
                                         () -> localListenerCounts.computeIfPresent(address, (k, count) -> count == 1 ? null : count - 1));
     }
 
@@ -64,6 +66,13 @@ public class DefaultEventBusService implements EventBusService {
     public Flux<ListenerStatus> monitorListenerStatus(CRI cri) {
         // Every registration change on the address emits its resulting status, dedupe to transitions
         return clusterManager.statusFlux(cri.baseResource())
+                             .distinctUntilChanged();
+    }
+
+    @Override
+    public Flux<Set<String>> monitorRegisteredNodes(CRI cri) {
+        // Every registration change on the address emits its resulting node set, dedupe to changes
+        return clusterManager.registeredNodesFlux(cri.baseResource())
                              .distinctUntilChanged();
     }
 
@@ -99,15 +108,16 @@ public class DefaultEventBusService implements EventBusService {
     }
 
     @Override
-    public Future<Void> sendWithAck(Event<byte[]> event) {
+    public Future<String> sendWithAck(Event<byte[]> event) {
         Validate.notNull(event, "Event must not be null");
         String baseResource = event.cri().baseResource();
         DeliveryOptions deliveryOptions = createDeliveryOptions(event, baseResource);
+        // the acknowledgement body is the id of the node whose consumer took the event
         return vertx.eventBus()
-                    .request(baseResource,
-                             event,
-                             deliveryOptions)
-                    .mapEmpty();
+                    .<String>request(baseResource,
+                                     event,
+                                     deliveryOptions)
+                    .map(Message::body);
     }
 
     DeliveryOptions createDeliveryOptions(Event<?> event, String baseResource){

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventConsumer.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventConsumer.java
@@ -14,35 +14,36 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Default implementation of {@link EventConsumer} that wraps a Vert.x {@link MessageConsumer}.
  * The message body is already an {@link Event} (produced by the registered event codec), so it is
- * handed straight to the handler.
+ * handed straight to the handler. A sender that asked for an acknowledgement receives the id of the
+ * node this consumer runs on, so it knows which node took the event.
  *
  * Created by Navid Mitchell on 2024-01-01.
  */
 public class DefaultEventConsumer implements EventConsumer {
 
     private final MessageConsumer<Event<byte[]>> delegate;
+    private final String nodeId;
     private final Runnable onUnregister;
     private final AtomicBoolean unregistered = new AtomicBoolean(false);
 
-    public DefaultEventConsumer(MessageConsumer<Event<byte[]>> delegate) {
-        this(delegate, null);
-    }
-
     /**
      * @param delegate the Vert.x consumer to wrap
+     * @param nodeId the id of the node this consumer runs on, sent as the acknowledgement
      * @param onUnregister run once when this consumer is first unregistered; may be null
      */
-    public DefaultEventConsumer(MessageConsumer<Event<byte[]>> delegate, Runnable onUnregister) {
+    public DefaultEventConsumer(MessageConsumer<Event<byte[]>> delegate, String nodeId, Runnable onUnregister) {
         this.delegate = delegate;
+        this.nodeId = nodeId;
         this.onUnregister = onUnregister;
     }
 
     @Override
     public EventConsumer handler(Handler<Event<byte[]>> handler) {
         this.delegate.handler(message -> {
-            // ack that we received the message if desired by sender
+            // ack receipt if the sender asked for it; naming this node lets the sender tie the
+            // request to the one registration that took it when the address has several
             if (message.replyAddress() != null) {
-                message.reply(null);
+                message.reply(nodeId);
             }
             handler.handle(message.body());
         });

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/event/DefaultEventService.java
@@ -33,7 +33,7 @@ public class DefaultEventService implements EventService {
     public Future<Void> send(Event<byte[]> event) {
         Future<Void> ret;
         if(event.cri().scheme().equals(EventConstants.SERVICE_DESTINATION_SCHEME)){
-            ret = eventBusService.sendWithAck(event);
+            ret = eventBusService.sendWithAck(event).mapEmpty();
         }else if(event.cri().scheme().equals(EventConstants.STREAM_DESTINATION_SCHEME)){
             ret = eventStreamService.send(event);
         }else{

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/EventFabricTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/EventFabricTests.java
@@ -31,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Behavioral tests for {@link EventFabric} and {@link EventFabricBeanPostProcessor}: events emitted
@@ -52,7 +54,10 @@ public class EventFabricTests {
         // Same codec wiring KinoticVertxConfig applies, so events cross the bus exactly as in production
         vertx.eventBus().registerCodec(new EventMessageCodec(jsonMapper));
         vertx.eventBus().codecSelector(body -> body instanceof Event ? EventMessageCodec.NAME : null);
-        eventFabric = new EventFabric(new DefaultEventBusService(null, vertx),
+        // A plain Vert.x has no node id; a consumer's acknowledgement names the one the cluster manager reports
+        KinoticIgniteClusterManager clusterManager = mock(KinoticIgniteClusterManager.class);
+        when(clusterManager.getNodeId()).thenReturn("test-node");
+        eventFabric = new EventFabric(new DefaultEventBusService(clusterManager, vertx),
                                       jsonMapper,
                                       ReactiveAdapterRegistry.getSharedInstance());
         postProcessor = new EventFabricBeanPostProcessor(new ObjectProvider<>() {

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/EventBusServiceTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/EventBusServiceTests.java
@@ -72,45 +72,18 @@ public class EventBusServiceTests {
     }
 
     /**
-     * Pins the monitorRegisteredNodes contract, the node-level counterpart of the status monitor: the set
-     * names the nodes holding a listener, so a sender can tell whether the node that acknowledged its event
-     * is still among them. On one node the set is either this node or empty.
+     * Pins the monitorClusterNodes contract: the set names every cluster member by the id an acknowledgement
+     * carries, so a sender can tell whether the node that acknowledged its event is still among them.
      */
     @Test
-    public void testMonitorRegisteredNodesTracksListenerLifecycle() throws Exception {
-        CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "org.kinotic.tests.RegisteredNodesProbe");
-        Set<String> thisNode = Set.of(kinotic.serverInfo().getNodeId());
-
-        EventConsumer consumer = eventBusService.listen(cri);
-        consumer.handler(event -> {});
-        consumer.completion().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
-
-        AtomicReference<EventConsumer> relistened = new AtomicReference<>();
-        try {
-            StepVerifier.create(eventBusService.monitorRegisteredNodes(cri))
-                        .expectNext(thisNode)
-                        .then(consumer::unregister)
-                        .expectNext(Set.of())
-                        .then(() -> {
-                            EventConsumer ec = eventBusService.listen(cri);
-                            ec.handler(event -> {});
-                            relistened.set(ec);
-                        })
-                        .expectNext(thisNode)
-                        .thenCancel()
-                        .verify(Duration.ofSeconds(15));
-        } finally {
-            EventConsumer ec = relistened.get();
-            if(ec != null){
-                ec.unregister();
-            }
-        }
+    public void testMonitorClusterNodesNamesThisNode() {
+        // the test cluster is a single node, so the membership is exactly this node
+        StepVerifier.create(eventBusService.monitorClusterNodes())
+                    .expectNext(Set.of(kinotic.serverInfo().getNodeId()))
+                    .thenCancel()
+                    .verify(Duration.ofSeconds(15));
     }
 
-    /**
-     * The acknowledgement names the node whose consumer took the event, in the same id space
-     * monitorRegisteredNodes reports, which is what lets a sender pin a request to one registration.
-     */
     @Test
     public void testSendWithAckNamesTheReceivingNode() throws Exception {
         CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "org.kinotic.tests.AckProbe");

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/EventBusServiceTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/EventBusServiceTests.java
@@ -1,5 +1,6 @@
 package org.kinotic.core.internal.api;
 
+import io.vertx.core.spi.cluster.NodeListener;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.api.Kinotic;
@@ -10,6 +11,7 @@ import org.kinotic.core.api.event.EventConstants;
 import org.kinotic.core.api.event.EventConsumer;
 import org.kinotic.core.api.event.ListenerStatus;
 import org.kinotic.core.api.event.Metadata;
+import org.kinotic.core.internal.KinoticIgniteClusterManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -32,6 +34,8 @@ public class EventBusServiceTests {
     private EventBusService eventBusService;
     @Autowired
     private Kinotic kinotic;
+    @Autowired
+    private KinoticIgniteClusterManager clusterManager;
 
     /**
      * Pins the monitorListenerStatus contract: the initial status reflects existing listeners, removing
@@ -100,4 +104,21 @@ public class EventBusServiceTests {
             consumer.unregister();
         }
     }
+
+    /**
+     * Pins that the cluster manager's single NodeListener slot belongs to the membership flux: installing
+     * another listener, which is what Vert.x HA does, fails instead of silently ending membership updates.
+     */
+    @Test
+    public void testSecondNodeListenerIsRejected() {
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                                () -> clusterManager.nodeListener(new NodeListener() {
+                                    @Override
+                                    public void nodeAdded(String nodeId) {}
+
+                                    @Override
+                                    public void nodeLeft(String nodeId) {}
+                                }));
+    }
+
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/EventBusServiceTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/EventBusServiceTests.java
@@ -1,17 +1,22 @@
 package org.kinotic.core.internal.api;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.kinotic.core.api.Kinotic;
 import org.kinotic.core.api.event.CRI;
+import org.kinotic.core.api.event.Event;
 import org.kinotic.core.api.event.EventBusService;
 import org.kinotic.core.api.event.EventConstants;
 import org.kinotic.core.api.event.EventConsumer;
 import org.kinotic.core.api.event.ListenerStatus;
+import org.kinotic.core.api.event.Metadata;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -25,6 +30,8 @@ public class EventBusServiceTests {
 
     @Autowired
     private EventBusService eventBusService;
+    @Autowired
+    private Kinotic kinotic;
 
     /**
      * Pins the monitorListenerStatus contract: the initial status reflects existing listeners, removing
@@ -61,6 +68,63 @@ public class EventBusServiceTests {
             if(ec != null){
                 ec.unregister();
             }
+        }
+    }
+
+    /**
+     * Pins the monitorRegisteredNodes contract, the node-level counterpart of the status monitor: the set
+     * names the nodes holding a listener, so a sender can tell whether the node that acknowledged its event
+     * is still among them. On one node the set is either this node or empty.
+     */
+    @Test
+    public void testMonitorRegisteredNodesTracksListenerLifecycle() throws Exception {
+        CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "org.kinotic.tests.RegisteredNodesProbe");
+        Set<String> thisNode = Set.of(kinotic.serverInfo().getNodeId());
+
+        EventConsumer consumer = eventBusService.listen(cri);
+        consumer.handler(event -> {});
+        consumer.completion().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        AtomicReference<EventConsumer> relistened = new AtomicReference<>();
+        try {
+            StepVerifier.create(eventBusService.monitorRegisteredNodes(cri))
+                        .expectNext(thisNode)
+                        .then(consumer::unregister)
+                        .expectNext(Set.of())
+                        .then(() -> {
+                            EventConsumer ec = eventBusService.listen(cri);
+                            ec.handler(event -> {});
+                            relistened.set(ec);
+                        })
+                        .expectNext(thisNode)
+                        .thenCancel()
+                        .verify(Duration.ofSeconds(15));
+        } finally {
+            EventConsumer ec = relistened.get();
+            if(ec != null){
+                ec.unregister();
+            }
+        }
+    }
+
+    /**
+     * The acknowledgement names the node whose consumer took the event, in the same id space
+     * monitorRegisteredNodes reports, which is what lets a sender pin a request to one registration.
+     */
+    @Test
+    public void testSendWithAckNamesTheReceivingNode() throws Exception {
+        CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "org.kinotic.tests.AckProbe");
+
+        EventConsumer consumer = eventBusService.listen(cri);
+        consumer.handler(event -> {});
+        consumer.completion().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+        try {
+            String ackingNode = eventBusService.sendWithAck(Event.create(cri, Metadata.create(), new byte[0]))
+                                               .toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+            Assertions.assertEquals(kinotic.serverInfo().getNodeId(), ackingNode);
+        } finally {
+            consumer.unregister();
         }
     }
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/event/DefaultEventBusServiceTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/event/DefaultEventBusServiceTests.java
@@ -11,9 +11,12 @@ import org.kinotic.core.api.event.Event;
 import org.kinotic.core.api.event.EventConstants;
 import org.kinotic.core.api.event.EventConsumer;
 import org.kinotic.core.api.event.Metadata;
+import org.kinotic.core.internal.KinoticIgniteClusterManager;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link DefaultEventBusService} local-delivery preference.
@@ -29,7 +32,10 @@ public class DefaultEventBusServiceTests {
     @BeforeEach
     public void setUp() {
         vertx = Vertx.vertx();
-        eventBusService = new DefaultEventBusService(null, vertx);
+        // A plain Vert.x has no node id; a consumer's acknowledgement names the one the cluster manager reports
+        KinoticIgniteClusterManager clusterManager = mock(KinoticIgniteClusterManager.class);
+        when(clusterManager.getNodeId()).thenReturn("test-node");
+        eventBusService = new DefaultEventBusService(clusterManager, vertx);
     }
 
     @AfterEach

--- a/website/app/components/content/RpcLivenessDiagram.vue
+++ b/website/app/components/content/RpcLivenessDiagram.vue
@@ -7,7 +7,7 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
   <div class="rpc-diagram-wrap">
 
     <!-- ═══════════════════════════ OVERVIEW: registration is liveness ═══════════════════════════ -->
-    <svg v-if="!view || view === 'overview'" class="rpc-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1140 664" role="img" aria-label="Every hop that holds a pending request watches the callee's event bus registration: Java proxies and the MCP invoker through the request liveness watcher, TS clients through the gateway on their behalf. A dead node's registrations leave the replicated subscription cache, and every lease pinned to that node fails with RpcServiceUnavailableException.">
+    <svg v-if="!view || view === 'overview'" class="rpc-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1140 664" role="img" aria-label="Every hop that holds a pending request holds a lease pinned to the node the acknowledgement named: Java proxies and the MCP invoker through the request liveness watcher, TS clients through the gateway on their behalf. When that node leaves the cluster, every lease pinned to it fails with RpcServiceUnavailableException.">
       <defs>
         <marker id="rk-ink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon class="mk-ink" points="0,0 10,5 0,10"/></marker>
         <marker id="rk-ind" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon class="mk-ind" points="0,0 10,5 0,10"/></marker>
@@ -65,17 +65,17 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
       <text class="t-name" x="530" y="468" text-anchor="middle">KinoticIgniteClusterManager</text>
       <line class="sep" x1="396" y1="476" x2="664" y2="476"/>
       <text class="t-mono" x="530" y="493" text-anchor="middle">statusFlux(address) · ACTIVE / INACTIVE</text>
-      <text class="t-mono" x="530" y="508" text-anchor="middle">registeredNodesFlux(address) · { nodeId }</text>
-      <text class="t-tiny" x="530" y="525" text-anchor="middle">fed by registration updates the bus already delivers</text>
+      <text class="t-mono" x="530" y="508" text-anchor="middle">clusterNodesFlux() · membership { nodeId }</text>
+      <text class="t-tiny" x="530" y="525" text-anchor="middle">fed by registration updates and discovery events</text>
 
       <rect class="watch" x="380" y="206" width="300" height="150" rx="8"/>
       <text class="t-name" x="530" y="228" text-anchor="middle">RequestLivenessWatcher</text>
       <line class="sep" x1="396" y1="236" x2="664" y2="236"/>
-      <text class="t-mono" x="530" y="254" text-anchor="middle">lease = (address, correlationId)</text>
-      <text class="t-mono" x="530" y="269" text-anchor="middle">before ack: address INACTIVE → onLost</text>
+      <text class="t-mono" x="530" y="254" text-anchor="middle">lease = (correlationId, nodeId from the ack)</text>
+      <text class="t-mono" x="530" y="269" text-anchor="middle">before ack: Vert.x fails the request itself</text>
       <text class="t-mono" x="530" y="284" text-anchor="middle">after ack: pinned to nodeId</text>
-      <text class="t-mono" x="530" y="299" text-anchor="middle">nodeId leaves the set → onLost</text>
-      <text class="t-mono" x="530" y="320" text-anchor="middle">one monitor per address, refcounted</text>
+      <text class="t-mono" x="530" y="299" text-anchor="middle">nodeId leaves the cluster → onLost</text>
+      <text class="t-mono" x="530" y="320" text-anchor="middle">one membership subscription per JVM</text>
       <text class="t-mono" x="530" y="335" text-anchor="middle">pendingCount() → node metric</text>
 
       <!-- callers use the watcher -->
@@ -85,7 +85,7 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
 
       <!-- signals cluster manager → watcher -->
       <line class="flow-red" x1="530" y1="446" x2="530" y2="356" marker-end="url(#rk-red)"/>
-      <text class="t-tiny" x="540" y="432">status · node set</text>
+      <text class="t-tiny" x="540" y="432">status · membership</text>
       <line class="flow-red" x1="640" y1="446" x2="760" y2="356" marker-end="url(#rk-red)"/>
       <text class="t-tiny" x="700" y="432">to gateway leases</text>
 
@@ -117,7 +117,7 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
     </svg>
 
     <!-- ═══════════════════════════ FAILURE: a call in flight when its node dies ═══════════════════════════ -->
-    <svg v-else-if="view === 'failure'" class="rpc-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1140 780" role="img" aria-label="Sequence: the caller sends a request and takes a lease; the ack names node N2 and the lease pins to it; N2 dies; Ignite removes N2's registrations; the watcher sees N2 leave the address's node set and fails the lease with RpcServiceUnavailableException even though another instance keeps the address active. Below, a TS instance dying behind a live gateway: the gateway synthesizes the error for every invocation outstanding on that socket.">
+    <svg v-else-if="view === 'failure'" class="rpc-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1140 780" role="img" aria-label="Sequence: the caller sends a request and takes a lease; the ack names node N2 and the lease pins to it; N2 dies; Ignite detects the failure and N2 leaves the cluster membership; the watcher fails the lease with RpcServiceUnavailableException even though another instance keeps the address active. Below, a TS instance dying behind a live gateway: the gateway synthesizes the error for every invocation outstanding on that socket.">
       <defs>
         <marker id="rf-ink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon class="mk-ink" points="0,0 10,5 0,10"/></marker>
         <marker id="rf-ind" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon class="mk-ind" points="0,0 10,5 0,10"/></marker>
@@ -167,17 +167,17 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
       <!-- 5 registrations removed -->
       <circle class="step" cx="40" cy="346" r="11"/><text class="t-step" x="40" y="350" text-anchor="middle">4</text>
       <rect class="note-red" x="420" y="330" width="240" height="46" rx="6"/>
-      <text class="t-mono-red" x="540" y="349" text-anchor="middle">N2's registrations removed</text>
+      <text class="t-mono-red" x="540" y="349" text-anchor="middle">N2 leaves the membership</text>
       <text class="t-mono-red" x="540" y="364" text-anchor="middle">address → { N1 }   still ACTIVE</text>
       <line class="flow-red" x1="420" y1="353" x2="190" y2="353" marker-end="url(#rf-red)"/>
-      <text class="t-tiny" x="300" y="345" text-anchor="middle">registeredNodesFlux emits { N1 }</text>
+      <text class="t-tiny" x="300" y="345" text-anchor="middle">clusterNodesFlux emits { N1, … }</text>
 
       <!-- 6 lease fails -->
       <circle class="step" cx="40" cy="400" r="11"/><text class="t-step" x="40" y="404" text-anchor="middle">5</text>
       <rect class="note-red" x="80" y="384" width="410" height="32" rx="6"/>
-      <text class="t-mono-red" x="285" y="404" text-anchor="middle">N2 ∉ { N1 } → onLost → RpcServiceUnavailableException</text>
+      <text class="t-mono-red" x="285" y="404" text-anchor="middle">N2 ∉ membership → onLost → RpcServiceUnavailableException</text>
       <text class="t-tiny" x="80" y="438">The address never went INACTIVE — N1 still serves it. The lease fails anyway, because it was pinned to the node that took the request.</text>
-      <text class="t-tiny" x="80" y="452">Before the ack arrives, the lease instead fails on the address going INACTIVE — the single-registration case, every scoped call.</text>
+      <text class="t-tiny" x="80" y="452">Had N2 only unregistered the address to drain before shutting down, the lease would hold: it fails on the node leaving the cluster, not the address.</text>
 
       <!-- ─────────── B ─────────── -->
       <line class="sep" x1="24" y1="478" x2="1116" y2="478"/>
@@ -216,7 +216,7 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
     </svg>
 
     <!-- ═══════════════════════════ RECONNECT: parked reply session and cross-node handoff ═══════════════════════════ -->
-    <svg v-else class="rpc-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1140 720" role="img" aria-label="Sequence: a TS client mid-stream loses its socket; the gateway parks the connection's reply session, keeping the reply registration so the server stream keeps running and replies buffer. On reconnect to the same node the parked session reattaches and flushes. On a node rollover the client lands on gateway B, which publishes a reply-session-release; gateway A flushes its buffer to the reply address and B forwards from then on. The parking window and buffer are bounded; overflow rotates the replyToId so the client fails its in-flight calls through its existing reset path.">
+    <svg v-else class="rpc-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1140 720" role="img" aria-label="Sequence: a TS client mid-stream loses its socket; the gateway parks the connection's reply session, keeping the reply registration so the server stream keeps running and replies buffer. On reconnect to the same node the parked session reattaches and flushes. On a node rollover the client lands on gateway B, which publishes a reply-session-release; gateway A flushes its buffer to the reply address and B forwards from then on. The parking window and buffer are bounded; expiry and overflow both rotate the replyToId so the client fails its in-flight calls through its existing reset path, and a client whose socket stays down past the window fails them itself.">
       <defs>
         <marker id="rr-ink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon class="mk-ink" points="0,0 10,5 0,10"/></marker>
         <marker id="rr-ind" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon class="mk-ind" points="0,0 10,5 0,10"/></marker>
@@ -297,8 +297,8 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
 
       <!-- exits -->
       <rect class="note-red" x="60" y="664" width="1030" height="40" rx="6"/>
-      <text class="t-mono-red" x="575" y="681" text-anchor="middle">Exits: window expiry → dispose, streams cancel through the reply-listener INACTIVE path already in place.</text>
-      <text class="t-mono-red" x="575" y="696" text-anchor="middle">Buffer overflow → dispose and rotate replyToId; the next CONNECT hands the client a new reply CRI and its existing reset path fails the in-flight calls.</text>
+      <text class="t-mono-red" x="575" y="681" text-anchor="middle">Exits: window expiry → dispose and rotate replyToId; streams cancel through the reply-listener INACTIVE path already in place.</text>
+      <text class="t-mono-red" x="575" y="696" text-anchor="middle">Overflow → the same. The next CONNECT hands the client a new reply CRI and its reset path fails the in-flight calls; down past the window, the client fails them itself.</text>
     </svg>
   </div>
 </template>

--- a/website/content/02.platform/11.service-call-liveness.md
+++ b/website/content/02.platform/11.service-call-liveness.md
@@ -12,7 +12,7 @@ A [service proxy](/apps/services/service-proxies) call travels over the OS bus t
 The reason to prefer this over a timeout is that a timeout encodes a guess about how long work takes, and no number is right for a service the platform does not own. Liveness observes whether the worker still exists. A legitimate ten-hour call is never cut short; a dead node fails its pending calls within seconds.
 
 ::callout{type="info"}
-**Implementation status.** The terminal reply marker every part of this design reads is in place. The watcher, the gateway leases, the ack that names the node, reply session parking and the cross-node handoff land in successive releases; sections describing them say so. The wire contract and error types below are the ones callers will see.
+**Implementation status.** The terminal reply marker every part of this design reads is in place, and so is the acknowledgement that names the node. The watcher, the gateway leases, reply session parking and the cross-node handoff land in successive releases; sections describing them say so. The wire contract and error types below are the ones callers will see.
 ::
 
 ## Registration is liveness

--- a/website/content/02.platform/11.service-call-liveness.md
+++ b/website/content/02.platform/11.service-call-liveness.md
@@ -12,7 +12,7 @@ A [service proxy](/apps/services/service-proxies) call travels over the OS bus t
 The reason to prefer this over a timeout is that a timeout encodes a guess about how long work takes, and no number is right for a service the platform does not own. Liveness observes whether the worker still exists. A legitimate ten-hour call is never cut short; a dead node fails its pending calls within seconds.
 
 ::callout{type="info"}
-**Implementation status.** The terminal reply marker every part of this design reads is in place, and so is the acknowledgement that names the node. The watcher, the gateway leases, reply session parking and the cross-node handoff land in successive releases; sections describing them say so. The wire contract and error types below are the ones callers will see.
+**Implementation status.** The terminal reply marker every part of this design reads is in place, and so are the acknowledgement that names the node and the cluster membership signal a pinned lease checks it against. The watcher, the gateway leases, reply session parking and the cross-node handoff land in successive releases; sections describing them say so. The wire contract and error types below are the ones callers will see.
 ::
 
 ## Registration is liveness
@@ -33,7 +33,7 @@ The ack that confirms receipt of a request names the node whose consumer took it
 ::rpc-liveness-diagram{view="failure"}
 ::
 
-A lease has two states. Before the ack, it fails if the address goes inactive — the single-registration case, which is every scoped call and every single-instance service. After the ack, it is pinned to the node that answered and fails when that node leaves the address's registration set, even while other instances keep the address active.
+A lease starts at the ack. Before it, Vert.x itself bounds the send: the request fails at once when nothing is registered, and after its delivery timeout when the ack never arrives — a bound on one network hop, not on the call, since the consumer acks before it dispatches. From the ack on, the lease is pinned to the node that answered and fails when that node leaves the cluster, even while other instances keep the address active, and even after that node has unregistered the address to drain before shutting down. A node that finishes a call before it leaves never fails it.
 
 For a TS service the ack names the gateway holding the instance's subscription, which cannot tell two TS instances on the same gateway apart. The gateway can: it forwarded the invocation to one specific socket and sees the terminal reply come back through the same connection, so it tracks each outstanding invocation per socket and synthesizes the failure for all of them when that socket closes. Server-side STOMP heartbeats make a socket close deterministic even when a VM vanishes without closing it, so this path is bounded by the heartbeat interval — ahead of Ignite's own detection window.
 
@@ -55,7 +55,7 @@ A TS client's reply destination is stable across reconnects: the gateway mints i
 
 When a sticky-session connection closes, the gateway *parks* the connection's reply state instead of tearing it down: the reply registration stays, so the service's stream keeps running, and replies buffer against a byte budget while its leases stay armed. A reconnect to the same node reattaches and flushes in order. A reconnect that lands on a different gateway — the normal case during a rolling update — finds the session in the clustered store, registers a reply consumer there, and publishes a release to the reply address; the old gateway flushes its buffer to that address and steps aside, and the new one forwards from then on with per-call ordering intact. The client observes a reconnect and nothing else.
 
-A parked session is bounded in two ways, both gateway properties. When its window expires, it is disposed and the streams it was holding cancel through the existing reply-listener path. When its buffer overflows, it is disposed and the session's `replyToId` is rotated, so the client's next connect receives a new reply destination and its in-flight calls fail through the reset path it already has. Continuity loss is signalled by a mechanism that exists today; nothing new is required of the client.
+A parked session is bounded in two ways, both gateway properties. When its window expires, it is disposed and the streams it was holding cancel through the existing reply-listener path. When its buffer overflows, it is disposed. Either way the session's `replyToId` is rotated, so the client's next connect receives a new reply destination and its in-flight calls fail through the reset path it already has; without the rotation on expiry, a single-value reply lost with the buffer would leave a reconnecting client waiting for it forever. The client learns the window from the connect handshake and holds its own timer against it: a socket that stays down past the window fails the in-flight calls on the client, so nothing waits on a reconnect that may never come. The timer is per connection, not per call, and it is the only thing the client adds.
 
 ## What this does not cover
 


### PR DESCRIPTION
Phase 2 of the node-failure / proxy-hang series (plan: `docs/future-prompts/Node failure handling for service proxies.md`). The event-bus layer only: nothing consumes the new signals yet — Phase 3 builds the request liveness watcher on them.

## The ack names the node

```java
// DefaultEventConsumer — was message.reply(null)
if (message.replyAddress() != null) {
    message.reply(nodeId);          // clusterManager.getNodeId(), the id DefaultKinotic.serverInfo already uses
}
```

```java
// EventBusService
Future<String> sendWithAck(Event<byte[]> event);      // completes with the acking node id (was Future<Void>)
Flux<Set<String>> monitorClusterNodes();              // every node in the cluster, in the same id space
```

A sender that gets `"N2"` back can watch the membership and know the moment N2 is no longer part of the cluster — even while other instances keep the address ACTIVE. That is the case address-level liveness cannot see: a service published on several nodes, several TS instances of one service, or the shared unscoped address a scoped service joins for its `@ScopeOptional` methods. All of them round-robin, and all of them behave the same way here.

## Why membership and not the address's registration set

The first revision of this PR emitted the set of nodes registered on the address. That set changes when a JVM unregisters, and a JVM unregisters while it is still up:

```java
// ServiceRegistrationBeanPostProcessor.postProcessBeforeDestruction → ServiceInvocationSupervisor.stop()
Future<Void> ret = methodInvocationEventConsumer.unregister();   // address drops this node; invocations already running still reply
```

A lease keyed on that set fails every in-flight call on every rolling restart, at the exact moment Phase 3's graceful drain wants callers to keep waiting. `nodeLeft` fires only when the node is actually gone: at once after a graceful leave, after `failureDetectionTimeout` (10 s) on a crash. It is also cheaper — one N-sized snapshot per membership change per node, however many addresses have calls in flight, where the registration set costs a k-sized set per monitored address because every platform address is registered on all k nodes.

Nothing watches the address before the ack: `sendWithAck` is a Vert.x `request`, which fails with `NO_HANDLERS` at once and with `TIMEOUT` after the 30 s default when the ack never comes — a bound on one hop, since the consumer acks before dispatching, never on the invocation.

## Cluster manager

```java
// KinoticIgniteClusterManager.init — a NodeListener on the discovery events vertx-ignite already
// subscribes to (EVT_NODE_JOINED, EVT_NODE_LEFT, EVT_NODE_FAILED). Vert.x core installs one only
// under HA, which KinoticVertxConfig does not enable, so nothing is replaced.
nodeListener(new NodeListener() {
    public void nodeAdded(String nodeId) { emitClusterNodes(false); }
    public void nodeLeft(String nodeId)  { emitClusterNodes(false); }
});

public Flux<Set<String>> clusterNodesFlux()   // replay-latest snapshot of getNodes(), seeded on first subscribe
```

Snapshots are emitted on the same delivery context as the address monitors, with the same seed/emit ordering guard. The per-address `AddressMonitor` is back to `ListenerStatus`, which is all `statusFlux` needs.

## Call sites

`sendWithAck`'s four callers: the proxy and MCP invoker only attach failure handlers, so they compile unchanged; `DefaultEventService.send` and the gateway's `EndpointConnectionHandler.send` add `.mapEmpty()` to keep returning `Future<Void>`. The gateway will read the node id in Phase 4.

## Tests

- `EventBusServiceTests` (real clustered Vert.x on Ignite): `testSendWithAckNamesTheReceivingNode` — the ack equals `kinotic.serverInfo().getNodeId()`; `testMonitorClusterNodesNamesThisNode` — the membership is exactly `{thisNode}`. A departure is not observable on a single-node test cluster; Phase 3's two-node test covers it with the first caller that acts on one.
- `DefaultEventBusServiceTests` and `EventFabricTests` construct `DefaultEventBusService` on a plain non-clustered Vert.x and previously passed a `null` cluster manager; `listen()` now asks it for the node id, so they hand it a Mockito stub answering `getNodeId()`. Their assertions are unchanged.
- `kinotic-api-gateway` and `kinotic-domain` compile against the new interface.

## Docs and plan

The platform liveness page and its diagrams describe the lease as starting at the ack and failing on membership. The plan doc records the same, plus what the discussion settled for later phases: Phase 3 gains the supervisor drain (single-value invocations reply before the consumer leaves, cut streams get a terminal error, `TIMEOUT` maps to `RpcServiceUnavailableException`); Phase 7 rotates the `replyToId` on window expiry as well as overflow, and the client fails its in-flight calls itself when a socket stays down past the window it learns from the connect handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY