### PR TITLE
Phase 1: one wildcard domain, certificate and sites account for every published UI

### DIFF
--- a/deployment/terraform/azure/cluster/frontdoor.tf
+++ b/deployment/terraform/azure/cluster/frontdoor.tf
@@ -1,41 +1,49 @@
 # ── UI sites on Front Door ────────────────────────────────────────────────────
-# Every published UI is served at <label>.apps.<zone> through this one Front Door Standard
-# profile and endpoint, and the profile's identity, which reads every organization's storage
-# account. kinotic-server (FrontDoorUiDeploymentProvisioner) creates the rest at runtime:
-# per organization an origin group authenticating as that identity, with an origin on its
-# storage account; once, the rule set that serves a single-page application's routes; per
-# site a custom domain with a managed certificate, a route, and the CNAME and validation
-# TXT records in the platform zone.
+# Every published UI is served at <label>.apps.<zone>. The sites module owns everything a
+# site needs and nothing changes on Front Door or in DNS when a UI is published: the profile
+# and endpoint, the sites storage account, the wildcard certificate and domain, the wildcard
+# DNS record, and the origin, rules and route that serve sites/<hostname>/ from the account.
 
 locals {
-  sites_domain = "apps.${local.global.dns_zone_name}"
+  sites_label  = "apps"
+  sites_domain = module.sites.sites_domain
 }
 
-resource "azurerm_cdn_frontdoor_profile" "sites" {
-  name                = "afd-${local.name_prefix}-sites"
-  resource_group_name = azurerm_resource_group.main.name
-  sku_name            = "Standard_AzureFrontDoor"
-  tags                = local.common_tags
+module "sites" {
+  source = "../modules/sites"
 
-  identity {
-    type = "SystemAssigned"
-  }
+  name_prefix                   = local.name_prefix
+  location                      = var.location
+  resource_group_name           = azurerm_resource_group.main.name
+  tags                          = local.common_tags
+  dns_zone_name                 = local.global.dns_zone_name
+  dns_zone_id                   = local.global.dns_zone_id
+  dns_zone_resource_group_name  = local.global.resource_group_name
+  dns_zone_subscription_id      = local.global.subscription_id
+  sites_label                   = local.sites_label
+  key_vault_id                  = azurerm_key_vault.main.id
+  certificate_officer_object_id = var.terraform_principal_object_id
+  lets_encrypt_email            = var.lets_encrypt_email
+  server_principal_id           = azurerm_user_assigned_identity.kinotic_server.principal_id
 }
 
-# Every organization's account is created in the org storage group, so one assignment
-# covers them all. The provider cannot read a new identity's principal id in the plan that
-# creates it, so a fresh root applies the profile first:
-#   terraform apply -target=azurerm_cdn_frontdoor_profile.sites && terraform apply
+# The profile and endpoint predate the module and keep their identity
+moved {
+  from = azurerm_cdn_frontdoor_profile.sites
+  to   = module.sites.azurerm_cdn_frontdoor_profile.sites
+}
+
+moved {
+  from = azurerm_cdn_frontdoor_endpoint.sites
+  to   = module.sites.azurerm_cdn_frontdoor_endpoint.sites
+}
+
+# Sites published before the sites account still live in organization storage accounts,
+# which the profile reads through this assignment until they are gone
 resource "azurerm_role_assignment" "sites_blob_reader" {
   scope                = azurerm_resource_group.org_storage.id
   role_definition_name = "Storage Blob Data Reader"
-  principal_id         = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
-}
-
-resource "azurerm_cdn_frontdoor_endpoint" "sites" {
-  name                     = "sites-${local.name_prefix}"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.sites.id
-  tags                     = local.common_tags
+  principal_id         = module.sites.profile_principal_id
 }
 
 output "sites_domain" {
@@ -44,6 +52,11 @@ output "sites_domain" {
 }
 
 output "frontdoor_endpoint_host_name" {
-  description = "The Front Door endpoint every site's CNAME points at"
-  value       = azurerm_cdn_frontdoor_endpoint.sites.host_name
+  description = "The Front Door endpoint the wildcard record points at"
+  value       = module.sites.endpoint_host_name
+}
+
+output "sites_storage_blob_endpoint" {
+  description = "The blob endpoint kinotic-server publishes sites into"
+  value       = module.sites.storage_blob_endpoint
 }

--- a/deployment/terraform/azure/cluster/keyvault.tf
+++ b/deployment/terraform/azure/cluster/keyvault.tf
@@ -11,7 +11,7 @@ resource "azurerm_key_vault" "main" {
   tenant_id                  = data.azurerm_client_config.keyvault.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
-  purge_protection_enabled   = false  # set true for production
+  purge_protection_enabled   = false # set true for production
 
   # Use RBAC for access control (not access policies)
   rbac_authorization_enabled = true
@@ -37,11 +37,11 @@ resource "azurerm_role_assignment" "kinotic_server_kv_secrets" {
 
 # Federated credential so kinotic-server pods authenticate via workload identity
 resource "azurerm_federated_identity_credential" "kinotic_server" {
-  name                  = "kinotic-server-federated"
+  name                      = "kinotic-server-federated"
   user_assigned_identity_id = azurerm_user_assigned_identity.kinotic_server.id
-  audience              = ["api://AzureADTokenExchange"]
-  issuer                = data.azurerm_kubernetes_cluster.main.oidc_issuer_url
-  subject               = "system:serviceaccount:kinotic:kinotic-server"
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = data.azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject                   = "system:serviceaccount:kinotic:kinotic-server"
 }
 
 # ── Platform Key Vault access ─────────────────────────────────────────────────
@@ -100,7 +100,7 @@ resource "azurerm_role_assignment" "kinotic_server_blob_private_dns" {
 # the platform DNS zone.
 
 resource "azurerm_role_assignment" "kinotic_server_frontdoor" {
-  scope                = azurerm_cdn_frontdoor_profile.sites.id
+  scope                = module.sites.profile_id
   role_definition_name = "CDN Profile Contributor"
   principal_id         = azurerm_user_assigned_identity.kinotic_server.principal_id
 }

--- a/deployment/terraform/azure/cluster/kinotic.tf
+++ b/deployment/terraform/azure/cluster/kinotic.tf
@@ -51,8 +51,9 @@ resource "helm_release" "kinotic_server" {
     # UI sites — the Front Door profile and DNS zone kinotic-server serves published UIs from
     { name = "extraEnv.KINOTIC_SYSTEMAPI_UIDEPLOYMENT_SITESDOMAIN", value = local.sites_domain },
     { name = "extraEnv.KINOTIC_SYSTEMAPI_UIDEPLOYMENT_DNSZONEID", value = local.global.dns_zone_id },
-    { name = "extraEnv.KINOTIC_SYSTEMAPI_UIDEPLOYMENT_FRONTDOORPROFILEID", value = azurerm_cdn_frontdoor_profile.sites.id },
-    { name = "extraEnv.KINOTIC_SYSTEMAPI_UIDEPLOYMENT_FRONTDOORENDPOINTHOSTNAME", value = azurerm_cdn_frontdoor_endpoint.sites.host_name },
+    { name = "extraEnv.KINOTIC_SYSTEMAPI_UIDEPLOYMENT_FRONTDOORPROFILEID", value = module.sites.profile_id },
+    { name = "extraEnv.KINOTIC_SYSTEMAPI_UIDEPLOYMENT_FRONTDOORENDPOINTHOSTNAME", value = module.sites.endpoint_host_name },
+    { name = "extraEnv.KINOTIC_SYSTEMAPI_UIDEPLOYMENT_SITESSTORAGEENDPOINT", value = module.sites.storage_blob_endpoint },
     # Email (Azure Communication Services) — shared service from global terraform
     { name = "extraEnv.KINOTIC_EMAIL_BACKEND", value = "azure" },
     { name = "extraEnv.KINOTIC_EMAIL_AZURE_ENDPOINT", value = local.global.email_service_endpoint },

--- a/deployment/terraform/azure/cluster/main.tf
+++ b/deployment/terraform/azure/cluster/main.tf
@@ -26,6 +26,16 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 2.0"
     }
+    # The sites module: origin authentication at an API version azurerm lacks, and the
+    # wildcard certificate's issuance
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    acme = {
+      source  = "vancluever/acme"
+      version = "~> 2.0"
+    }
   }
 
   backend "azurerm" {
@@ -34,6 +44,12 @@ terraform {
     container_name       = "tfstate"
     key                  = "cluster/terraform.tfstate"
   }
+}
+
+provider "azapi" {}
+
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
 }
 
 provider "azurerm" {
@@ -115,16 +131,16 @@ module "networking" {
 module "aks" {
   source = "../modules/aks"
 
-  name_prefix            = local.name_prefix
-  location               = var.location
-  resource_group_name    = azurerm_resource_group.main.name
-  kubernetes_version     = var.kubernetes_version
-  dns_prefix             = "${local.name_prefix}-aks"
+  name_prefix         = local.name_prefix
+  location            = var.location
+  resource_group_name = azurerm_resource_group.main.name
+  kubernetes_version  = var.kubernetes_version
+  dns_prefix          = "${local.name_prefix}-aks"
 
-  control_plane_identity_id   = module.identity.control_plane_identity_id
-  kubelet_identity_id         = module.identity.kubelet_identity_id
-  kubelet_identity_client_id  = module.identity.kubelet_identity_client_id
-  kubelet_identity_object_id  = module.identity.kubelet_identity_object_id
+  control_plane_identity_id  = module.identity.control_plane_identity_id
+  kubelet_identity_id        = module.identity.kubelet_identity_id
+  kubelet_identity_client_id = module.identity.kubelet_identity_client_id
+  kubelet_identity_object_id = module.identity.kubelet_identity_object_id
 
   aks_subnet_id  = module.networking.aks_subnet_id
   pod_cidr       = var.pod_cidr

--- a/deployment/terraform/azure/dev/README.md
+++ b/deployment/terraform/azure/dev/README.md
@@ -7,7 +7,9 @@ uses. One apply creates:
 | Resource | Name | Purpose |
 |---|---|---|
 | Resource group | `rg-kinotic-<environment>` | Holds the Front Door profile and, created by the server at runtime, one storage account per organization |
-| Front Door Standard profile + endpoint | `afd-kinotic-<environment>-sites` | Serves every published UI at `<label>.apps-<environment>.kinotic.ai`; its system identity holds Storage Blob Data Reader on the group, and the server adds origin groups, the rule set, domains and routes at runtime |
+| Front Door Standard profile + endpoint | `afd-kinotic-<environment>-sites` | Serves every published UI at `<label>.apps-<environment>.kinotic.ai` through one wildcard domain, one wildcard DNS record and one route; nothing on Front Door changes when a UI is published (`modules/sites`) |
+| Sites storage account | `stkinotic<environment>sites` | Holds every site's files under `sites/<hostname>/`, read by the profile's identity and written by the server |
+| Key vault | `kv-kinotic-<environment>-sites` | Holds the Let's Encrypt wildcard certificate for `*.apps-<environment>.kinotic.ai`, issued by the apply through a DNS challenge and renewed by an apply within 30 days of expiry |
 | Service principal | `kinotic-<environment>-server` | The identity the server runs as, with Contributor and Storage Blob Data Contributor on the group, DNS Zone Contributor on `kinotic.ai`, and Contributor on the email service |
 | `.env.local` at the repository root | | The principal's `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`, written by the apply |
 
@@ -41,9 +43,14 @@ profile in all of Azure, so two developers sharing one would collide:
 environment = "local"   # e.g. your first name
 ```
 
+```hcl
+# local.auto.tfvars (gitignored)
+lets_encrypt_email = "you@example.com"   # the Let's Encrypt account the wildcard certificate is issued under
+```
+
 ```bash
 terraform init
-terraform apply -target=azurerm_cdn_frontdoor_profile.sites   # the profile first: the role below needs its identity's principal id
+terraform apply -target=module.sites.azurerm_cdn_frontdoor_profile.sites   # the profile first: the roles need its identity's principal id
 terraform apply
 terraform output -raw application_local_yml > ../../../../kinotic-server/src/main/resources/application-local.yml
 ```

--- a/deployment/terraform/azure/dev/main.tf
+++ b/deployment/terraform/azure/dev/main.tf
@@ -23,6 +23,16 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~> 3.0"
     }
+    # The sites module: origin authentication at an API version azurerm lacks, and the
+    # wildcard certificate's issuance
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    acme = {
+      source  = "vancluever/acme"
+      version = "~> 2.0"
+    }
   }
 }
 
@@ -37,6 +47,12 @@ provider "azurerm" {
 }
 
 provider "azuread" {}
+
+provider "azapi" {}
+
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+}
 
 # ── Read global state ─────────────────────────────────────────────────────────
 
@@ -55,7 +71,7 @@ data "azurerm_client_config" "current" {}
 locals {
   name_prefix  = "${var.project}-${var.environment}"
   global       = data.terraform_remote_state.global.outputs
-  sites_domain = "apps-${var.environment}.${local.global.dns_zone_name}"
+  sites_domain = module.sites.sites_domain
   env_local    = "${path.module}/../../../../.env.local"
 
   common_tags = {
@@ -75,33 +91,57 @@ resource "azurerm_resource_group" "main" {
 }
 
 # ── UI sites on Front Door ────────────────────────────────────────────────────
+# The sites module owns everything a site needs, so nothing changes on Front Door or in
+# DNS when a UI is published; this root adds the key vault the wildcard certificate is
+# issued into, which the cluster root has already.
 
-resource "azurerm_cdn_frontdoor_profile" "sites" {
-  name                = "afd-${local.name_prefix}-sites"
-  resource_group_name = azurerm_resource_group.main.name
-  sku_name            = "Standard_AzureFrontDoor"
-  tags                = local.common_tags
-
-  # The profile reads each organization's storage account as this identity: the server
-  # sets origin authentication on every origin group it creates
-  identity {
-    type = "SystemAssigned"
-  }
+resource "azurerm_key_vault" "sites" {
+  name                       = "kv-${local.name_prefix}-sites"
+  location                   = var.location
+  resource_group_name        = azurerm_resource_group.main.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  rbac_authorization_enabled = true
+  tags                       = local.common_tags
 }
 
-# The accounts live in the group above, so one assignment covers every organization. The
-# provider cannot read a new identity's principal id in the plan that creates it, so a fresh
-# root applies the profile first, as the README says
+module "sites" {
+  source = "../modules/sites"
+
+  name_prefix                     = local.name_prefix
+  location                        = var.location
+  resource_group_name             = azurerm_resource_group.main.name
+  tags                            = local.common_tags
+  dns_zone_name                   = local.global.dns_zone_name
+  dns_zone_id                     = local.global.dns_zone_id
+  dns_zone_resource_group_name    = local.global.resource_group_name
+  dns_zone_subscription_id        = local.global.subscription_id
+  sites_label                     = "apps-${var.environment}"
+  key_vault_id                    = azurerm_key_vault.sites.id
+  certificate_officer_object_id   = data.azurerm_client_config.current.object_id
+  lets_encrypt_email              = var.lets_encrypt_email
+  server_principal_id             = azuread_service_principal.server.object_id
+  server_principal_skip_aad_check = true
+}
+
+# The profile and endpoint predate the module and keep their identity
+moved {
+  from = azurerm_cdn_frontdoor_profile.sites
+  to   = module.sites.azurerm_cdn_frontdoor_profile.sites
+}
+
+moved {
+  from = azurerm_cdn_frontdoor_endpoint.sites
+  to   = module.sites.azurerm_cdn_frontdoor_endpoint.sites
+}
+
+# Sites published before the sites account still live in organization storage accounts in
+# this group, which the profile reads through this assignment until they are gone
 resource "azurerm_role_assignment" "sites_blob_reader" {
   scope                = azurerm_resource_group.main.id
   role_definition_name = "Storage Blob Data Reader"
-  principal_id         = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
-}
-
-resource "azurerm_cdn_frontdoor_endpoint" "sites" {
-  name                     = "sites-${local.name_prefix}"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.sites.id
-  tags                     = local.common_tags
+  principal_id         = module.sites.profile_principal_id
 }
 
 # ── Service principal for kinotic-server ──────────────────────────────────────
@@ -226,6 +266,11 @@ variable "location" {
   default     = "centralus"
 }
 
+variable "lets_encrypt_email" {
+  description = "Account email for the Let's Encrypt registration that issues the sites wildcard certificate; set it in local.auto.tfvars"
+  type        = string
+}
+
 # ── Outputs ───────────────────────────────────────────────────────────────────
 
 output "sites_domain" {
@@ -252,7 +297,8 @@ output "application_local_yml" {
           disableProvisioner: false
           sitesDomain: ${local.sites_domain}
           dnsZoneId: ${local.global.dns_zone_id}
-          frontDoorProfileId: ${azurerm_cdn_frontdoor_profile.sites.id}
-          frontDoorEndpointHostName: ${azurerm_cdn_frontdoor_endpoint.sites.host_name}
+          frontDoorProfileId: ${module.sites.profile_id}
+          frontDoorEndpointHostName: ${module.sites.endpoint_host_name}
+          sitesStorageEndpoint: ${module.sites.storage_blob_endpoint}
   EOT
 }

--- a/deployment/terraform/azure/modules/sites/main.tf
+++ b/deployment/terraform/azure/modules/sites/main.tf
@@ -1,0 +1,347 @@
+# ── Published UI sites ────────────────────────────────────────────────────────
+# Every published UI is served at <label>.<sites_label>.<zone> through one Front Door
+# Standard profile, and nothing on Front Door or in DNS changes when a UI is published:
+# one wildcard domain *.<sites_label>.<zone> on a wildcard certificate, one wildcard DNS
+# record, one route, and a rule set that derives the file's location in the sites storage
+# account from the request's host name. A UI is live as soon as its files are under
+# sites/<hostname>/ in the account, which the profile reads as its managed identity.
+#
+# The wildcard certificate is a Let's Encrypt certificate issued here by a DNS challenge on
+# the platform zone and kept in the key vault, from which Front Door takes its latest
+# version; a terraform apply within min_days_remaining of expiry renews it.
+
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    azapi = {
+      source = "Azure/azapi"
+    }
+    acme = {
+      source = "vancluever/acme"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+locals {
+  sites_domain = "${var.sites_label}.${var.dns_zone_name}"
+  # Storage account names allow 3 to 24 lowercase letters and digits
+  storage_account_name = substr("st${replace(var.name_prefix, "-", "")}sites", 0, 24)
+  # the types the provider admits; wasm and web manifests are not among them
+  compressed_content_types = [
+    "text/html", "text/css", "text/plain", "text/xml", "text/javascript", "application/javascript",
+    "application/x-javascript", "application/json", "application/xml", "image/svg+xml",
+  ]
+}
+
+# ── Profile and endpoint ──────────────────────────────────────────────────────
+
+resource "azurerm_cdn_frontdoor_profile" "sites" {
+  name                = "afd-${var.name_prefix}-sites"
+  resource_group_name = var.resource_group_name
+  sku_name            = "Standard_AzureFrontDoor"
+  tags                = var.tags
+
+  # The profile reads the sites storage account and the certificate's vault as this identity
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_endpoint" "sites" {
+  name                     = "sites-${var.name_prefix}"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.sites.id
+  tags                     = var.tags
+}
+
+# ── Sites storage ─────────────────────────────────────────────────────────────
+# One account for every site of the environment: sites/<hostname>/... Anonymous access is
+# off; Front Door reads as the profile's identity and kinotic-server writes as its own.
+
+resource "azurerm_storage_account" "sites" {
+  name                            = local.storage_account_name
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  account_kind                    = "StorageV2"
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  is_hns_enabled                  = true
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  tags                            = var.tags
+}
+
+resource "azurerm_storage_container" "sites" {
+  name                  = "sites"
+  storage_account_id    = azurerm_storage_account.sites.id
+  container_access_type = "private"
+}
+
+resource "azurerm_role_assignment" "frontdoor_reads_sites" {
+  scope                = azurerm_storage_account.sites.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "server_writes_sites" {
+  scope                            = azurerm_storage_account.sites.id
+  role_definition_name             = "Storage Blob Data Contributor"
+  principal_id                     = var.server_principal_id
+  skip_service_principal_aad_check = var.server_principal_skip_aad_check
+}
+
+# ── Wildcard certificate ──────────────────────────────────────────────────────
+
+resource "tls_private_key" "acme_account" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "acme_registration" "sites" {
+  account_key_pem = tls_private_key.acme_account.private_key_pem
+  email_address   = var.lets_encrypt_email
+}
+
+resource "random_password" "certificate" {
+  length  = 32
+  special = false
+}
+
+resource "acme_certificate" "sites" {
+  account_key_pem = acme_registration.sites.account_key_pem
+  common_name     = "*.${local.sites_domain}"
+  # Front Door rejects elliptic-curve keys
+  key_type                 = "2048"
+  min_days_remaining       = 30
+  certificate_p12_password = random_password.certificate.result
+
+  dns_challenge {
+    provider = "azuredns"
+    config = {
+      # The roots are applied by a signed-in operator; the challenge writes its TXT record as them
+      AZURE_AUTH_METHOD     = "cli"
+      AZURE_SUBSCRIPTION_ID = var.dns_zone_subscription_id
+      AZURE_RESOURCE_GROUP  = var.dns_zone_resource_group_name
+      AZURE_ZONE_NAME       = var.dns_zone_name
+    }
+  }
+}
+
+resource "azurerm_role_assignment" "certificate_officer" {
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = var.certificate_officer_object_id
+}
+
+# Role assignments reach the vault's data plane a minute or so after they are written
+resource "terraform_data" "wait_for_certificate_officer" {
+  input = azurerm_role_assignment.certificate_officer.id
+  provisioner "local-exec" {
+    command = "sleep 60"
+  }
+}
+
+resource "azurerm_key_vault_certificate" "sites" {
+  name         = "sites-wildcard"
+  key_vault_id = var.key_vault_id
+
+  certificate {
+    contents = acme_certificate.sites.certificate_p12
+    password = random_password.certificate.result
+  }
+
+  depends_on = [terraform_data.wait_for_certificate_officer]
+}
+
+# Front Door takes the certificate from the vault as the profile's identity
+resource "azurerm_role_assignment" "frontdoor_reads_certificate" {
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Certificate User"
+  principal_id         = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "frontdoor_reads_secret" {
+  scope                = var.key_vault_id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
+}
+
+resource "azurerm_cdn_frontdoor_secret" "sites" {
+  name                     = "sites-wildcard"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.sites.id
+
+  secret {
+    customer_certificate {
+      # the versionless id follows renewals
+      key_vault_certificate_id = azurerm_key_vault_certificate.sites.versionless_id
+    }
+  }
+
+  depends_on = [azurerm_role_assignment.frontdoor_reads_certificate, azurerm_role_assignment.frontdoor_reads_secret]
+}
+
+# ── Wildcard domain and DNS ───────────────────────────────────────────────────
+
+resource "azurerm_cdn_frontdoor_custom_domain" "sites" {
+  name                     = "sites-wildcard"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.sites.id
+  dns_zone_id              = var.dns_zone_id
+  host_name                = "*.${local.sites_domain}"
+
+  tls {
+    certificate_type        = "CustomerCertificate"
+    cdn_frontdoor_secret_id = azurerm_cdn_frontdoor_secret.sites.id
+    minimum_tls_version     = "TLS12"
+  }
+}
+
+resource "azurerm_dns_txt_record" "sites_validation" {
+  name                = "_dnsauth.${var.sites_label}"
+  zone_name           = var.dns_zone_name
+  resource_group_name = var.dns_zone_resource_group_name
+  ttl                 = 300
+
+  record {
+    value = azurerm_cdn_frontdoor_custom_domain.sites.validation_token
+  }
+}
+
+resource "azurerm_dns_cname_record" "sites_wildcard" {
+  name                = "*.${var.sites_label}"
+  zone_name           = var.dns_zone_name
+  resource_group_name = var.dns_zone_resource_group_name
+  ttl                 = 300
+  record              = azurerm_cdn_frontdoor_endpoint.sites.host_name
+}
+
+# ── Origin, rules and route ───────────────────────────────────────────────────
+# Origin authentication (the profile's identity presenting a bearer token to the account)
+# exists from API version 2025-06-01, which the azurerm provider does not expose yet, so the
+# origin group is written as the API's resource. It requires HTTPS health probes; the
+# container's properties answer the identity's token with 200.
+
+resource "azapi_resource" "sites_origin_group" {
+  type      = "Microsoft.Cdn/profiles/originGroups@2025-06-01"
+  name      = "sites"
+  parent_id = azurerm_cdn_frontdoor_profile.sites.id
+
+  body = {
+    properties = {
+      loadBalancingSettings = {
+        sampleSize                      = 4
+        successfulSamplesRequired       = 3
+        additionalLatencyInMilliseconds = 50
+      }
+      healthProbeSettings = {
+        probePath              = "/sites?restype=container"
+        probeRequestType       = "HEAD"
+        probeProtocol          = "Https"
+        probeIntervalInSeconds = 240
+      }
+      sessionAffinityState = "Disabled"
+      authentication = {
+        type  = "SystemAssignedIdentity"
+        scope = "https://storage.azure.com/.default"
+      }
+    }
+  }
+
+  # the provider's schema predates the authentication property
+  schema_validation_enabled = false
+
+  depends_on = [azurerm_role_assignment.frontdoor_reads_sites]
+}
+
+resource "azurerm_cdn_frontdoor_origin" "sites" {
+  name                           = "blob"
+  cdn_frontdoor_origin_group_id  = azapi_resource.sites_origin_group.id
+  enabled                        = true
+  host_name                      = azurerm_storage_account.sites.primary_blob_host
+  origin_host_header             = azurerm_storage_account.sites.primary_blob_host
+  http_port                      = 80
+  https_port                     = 443
+  priority                       = 1
+  weight                         = 1000
+  certificate_name_check_enabled = true
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "sites" {
+  name                     = "sites"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.sites.id
+}
+
+# A request naming a file (an extension longer than zero; "Any" also matches a path with no
+# extension) is served from the site's directory; url_path expands without its leading slash
+resource "azurerm_cdn_frontdoor_rule" "asset" {
+  name                      = "asset"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.sites.id
+  order                     = 1
+  behavior_on_match         = "Stop"
+
+  conditions {
+    url_file_extension_condition {
+      operator     = "GreaterThan"
+      match_values = ["0"]
+    }
+  }
+
+  actions {
+    url_rewrite_action {
+      source_pattern          = "/"
+      destination             = "/sites/{hostname}/{url_path}"
+      preserve_unmatched_path = false
+    }
+  }
+}
+
+# A request naming no file is a route of the single-page application: its index
+resource "azurerm_cdn_frontdoor_rule" "spa" {
+  name                      = "spa"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.sites.id
+  order                     = 2
+  behavior_on_match         = "Stop"
+
+  conditions {
+    url_file_extension_condition {
+      operator     = "LessThanOrEqual"
+      match_values = ["0"]
+    }
+  }
+
+  actions {
+    url_rewrite_action {
+      source_pattern          = "/"
+      destination             = "/sites/{hostname}/index.html"
+      preserve_unmatched_path = false
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_route" "sites" {
+  name                            = "sites"
+  cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.sites.id
+  cdn_frontdoor_origin_group_id   = azapi_resource.sites_origin_group.id
+  cdn_frontdoor_origin_ids        = [azurerm_cdn_frontdoor_origin.sites.id]
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.sites.id]
+  cdn_frontdoor_rule_set_ids      = [azurerm_cdn_frontdoor_rule_set.sites.id]
+  supported_protocols             = ["Http", "Https"]
+  patterns_to_match               = ["/*"]
+  # origin authentication requires HTTPS to the origin
+  forwarding_protocol    = "HttpsOnly"
+  link_to_default_domain = false
+  https_redirect_enabled = true
+  enabled                = true
+
+  cache {
+    query_string_caching_behavior = "IgnoreQueryString"
+    compression_enabled           = true
+    content_types_to_compress     = local.compressed_content_types
+  }
+}

--- a/deployment/terraform/azure/modules/sites/outputs.tf
+++ b/deployment/terraform/azure/modules/sites/outputs.tf
@@ -1,0 +1,27 @@
+output "sites_domain" {
+  description = "The domain every published UI is a label under"
+  value       = local.sites_domain
+}
+
+output "profile_id" {
+  value = azurerm_cdn_frontdoor_profile.sites.id
+}
+
+output "profile_principal_id" {
+  description = "The profile's managed identity, which reads every site's files"
+  value       = azurerm_cdn_frontdoor_profile.sites.identity[0].principal_id
+}
+
+output "endpoint_host_name" {
+  description = "The Front Door endpoint the wildcard record points at"
+  value       = azurerm_cdn_frontdoor_endpoint.sites.host_name
+}
+
+output "storage_account_id" {
+  value = azurerm_storage_account.sites.id
+}
+
+output "storage_blob_endpoint" {
+  description = "The blob endpoint kinotic-server publishes sites into"
+  value       = azurerm_storage_account.sites.primary_blob_endpoint
+}

--- a/deployment/terraform/azure/modules/sites/variables.tf
+++ b/deployment/terraform/azure/modules/sites/variables.tf
@@ -1,0 +1,67 @@
+variable "name_prefix" {
+  description = "Prefix every resource is named under, e.g. kinotic-production"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region of the storage account and the key vault certificate"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group holding the profile and the sites storage account"
+  type        = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "dns_zone_name" {
+  description = "The platform zone, e.g. kinotic.ai"
+  type        = string
+}
+
+variable "dns_zone_id" {
+  type = string
+}
+
+variable "dns_zone_resource_group_name" {
+  type = string
+}
+
+variable "dns_zone_subscription_id" {
+  type = string
+}
+
+variable "sites_label" {
+  description = "The label of the sites domain within the zone: apps for apps.kinotic.ai, apps-local for a developer's apps-local.kinotic.ai"
+  type        = string
+}
+
+variable "key_vault_id" {
+  description = "RBAC-enabled key vault the wildcard certificate is issued into; must be in the profile's subscription"
+  type        = string
+}
+
+variable "certificate_officer_object_id" {
+  description = "Object id of the principal running terraform, which imports the certificate into the vault"
+  type        = string
+}
+
+variable "lets_encrypt_email" {
+  description = "Account email for the Let's Encrypt registration that issues the wildcard certificate"
+  type        = string
+}
+
+variable "server_principal_id" {
+  description = "Principal id of kinotic-server, which publishes sites into the storage account"
+  type        = string
+}
+
+variable "server_principal_skip_aad_check" {
+  description = "True for a service principal created in the same apply, which may not have replicated to the RBAC lookup yet"
+  type        = bool
+  default     = false
+}

--- a/docs/future-prompts/Customer managed domains.md
+++ b/docs/future-prompts/Customer managed domains.md
@@ -1,0 +1,43 @@
+We serve every published UI at `<org>-<app>-<ui>.apps.kinotic.ai` through one Front Door
+wildcard domain, and the API at `api.kinotic.ai` on the cluster's load balancer. I want a
+customer to be able to bring their own domain: `ui.mydomain.com` for a published UI and
+`api.mydomain.com` for the API, so the session cookie stays same-site. A customer domain may
+take up to half an hour to come live; that is fine. The platform hostname must keep serving
+throughout, and nothing about a customer domain may slow down publishing to the platform
+hostname, which is an upload and nothing else.
+
+What I already know, so you don't re-derive it:
+
+- Front Door is the UI CDN only. Its WebSocket limits (3,000 concurrent connections per
+  profile, 4-hour maximum, 5-minute idle) rule it out for the STOMP gateway, so
+  `api.mydomain.com` never goes through Front Door.
+- On the UI side a customer domain is a Front Door custom domain of its own, the non-wildcard
+  case: a managed certificate works, the customer proves ownership with the TXT record Front
+  Door issues plus a CNAME to the endpoint. The wildcard rewrite keys storage by the platform
+  hostname (`/sites/{hostname}/…`), so one rule per customer domain maps
+  `HostName equals ui.mydomain.com` onto the site's directory. Both are Front Door writes,
+  15 to 30 minutes to propagate. Front Door caps custom domains per profile in the hundreds;
+  the platform hostnames under the wildcard don't count, but a second profile is needed
+  eventually.
+- On the API side, TLS for a hostname we don't own. Preferred: Caddy 2 in front of the
+  gateway with on-demand TLS, its `ask` endpoint hitting the gateway, which answers whether
+  the hostname is a registered, validated domain of an application; certificates issued at
+  the first handshake, stored in shared storage when Caddy has replicas. Alternative: Vert.x
+  serving certificates by SNI with `HttpServer.updateSSLOptions`, which means owning the
+  ACME client, challenges, storage and renewal ourselves.
+- The cookie needs nothing: `__Host-kinotic-session` carries no `Domain`, so it belongs to
+  `api.mydomain.com`, and `SameSite=Lax` sends it from `ui.mydomain.com` because both share
+  the site `mydomain.com`. `SameSite=None` stays a developer-profile setting only.
+- What the platform has to learn: a record on the application of its domains and their
+  validation state (the Front Door validation token for the UI domain, and how the API
+  domain is validated); a CORS check that consults that record instead of the static
+  `allowedOriginPattern`; OIDC and social-login redirect URIs built from the request's host
+  when it arrived on a customer domain (`AuthEndpointSupport`, which today builds them from
+  `appBaseUrl` / `apiBaseUrl`); and a console flow where the customer adds the domain, sees
+  the records to create, and watches validation.
+
+Design the domain record, the validation flow for both hostnames, the Caddy `ask` contract,
+the CORS and redirect-URI changes, and the console pages, as a series of phases of about ten
+files each, with a review after each phase. Start with the UI domain; the API domain and
+Caddy come after, since a customer UI on its own domain talking to `api.kinotic.ai` works
+already with `SameSite=None` off the table only once the API domain exists.

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -36,6 +36,7 @@ kinotic:
       dnsZoneId: "-"
       frontDoorProfileId: "-"
       frontDoorEndpointHostName: "-"
+      sitesStorageEndpoint: "-"
     deployment:
       # A workload runs inside a micro VM, so "localhost" there is the guest, not this machine.
       # Local development runs the BOXLITE provider, whose guests reach the host on the

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/config/UiDeploymentProperties.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/config/UiDeploymentProperties.java
@@ -52,6 +52,13 @@ public class UiDeploymentProperties {
     private String frontDoorEndpointHostName;
 
     /**
+     * Blob endpoint of the sites storage account every published UI is written to, under
+     * {@code sites/<hostname>/}, from which Front Door serves it.
+     */
+    @NotBlank
+    private String sitesStorageEndpoint;
+
+    /**
      * The hostname a site with the given label is served at.
      */
     public String resolveHostname(String label) {

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -196,6 +196,7 @@ Azure Front Door, configured under `kinotic.systemApi.uiDeployment.*`:
 | `dnsZoneId` | — | Id of the Azure DNS zone holding `sitesDomain`, where each site's CNAME and validation TXT are written. Required |
 | `frontDoorProfileId` | — | Id of the Front Door Standard profile every site is served through. Required |
 | `frontDoorEndpointHostName` | — | Host name of the profile's endpoint, the target of every site's CNAME. Required |
+| `sitesStorageEndpoint` | — | Blob endpoint of the sites storage account terraform creates, where every published UI is written under `sites/<hostname>/`. Required |
 
 Like organization storage, the required settings are validated at boot, and an environment
 that disables the provisioner sets them to placeholders. In the Azure deployment terraform creates the profile and endpoint and passes them to the


### PR DESCRIPTION
Phase 1 of 4 of the Option A serving design: nothing on Front Door or in DNS changes when a UI is published. This phase is the platform plumbing only; publishing into it is phase 2 and 3, retiring per-organization storage is phase 4. Nothing here changes what runs today: the roots keep the profile and endpoint (moved into the module), and the reader assignment on the organization storage groups stays while sites published there still serve.

## What the module creates, once per environment (`modules/sites`)

```
storage account   st<env>sites          HNS, TLS 1.2, anonymous off; container sites/, one directory per hostname
                                        Storage Blob Data Reader → the profile's identity; Contributor → kinotic-server
certificate       *.<label>.<zone>       Let's Encrypt via a DNS challenge on the platform zone (azuredns, az login),
                                        RSA 2048 (Front Door rejects EC), imported into the vault; renewed by an apply
                                        within 30 days of expiry; Front Door follows the vault's latest version
domain            *.<label>.<zone>       CustomerCertificate on that secret; validated by _dnsauth.<label> TXT
dns               *.<label>  CNAME → endpoint
origin group      sites                  authentication SystemAssignedIdentity / storage scope; HTTPS probe on the
                                        container's properties. Written with azapi at 2025-06-01: azurerm has no
                                        origin authentication yet
rules             asset  extension > 0    → /sites/{hostname}/{url_path}
                  spa    extension <= 0   → /sites/{hostname}/index.html
route             sites                  the wildcard domain, /*, HTTPS only, query strings ignored, compression
```

Why a wildcard and BYOC: Front Door propagates a configuration change over 15 to 45 minutes, so per-site domains, certificates and routes cannot meet a two-minute target. Managed certificates now cover wildcards but are not rotated, hence the ACME issuance.

## Roots

- `cluster`: `frontdoor.tf` becomes the module call plus `moved` blocks for the profile and endpoint; `keyvault.tf` and `kinotic.tf` reference the module; the server gets `KINOTIC_SYSTEMAPI_UIDEPLOYMENT_SITESSTORAGEENDPOINT`.
- `dev`: adds a small RBAC vault for the certificate, the module, the `lets_encrypt_email` variable (set in `local.auto.tfvars`), and `sitesStorageEndpoint` in the generated `application-local.yml`. The first apply still targets the profile first, for its identity's principal id.

The dev root plans as 2 moves, 24 adds, 0 changes, 0 destroys. Both roots validate.

## Server

`kinotic.systemApi.uiDeployment.sitesStorageEndpoint`, required, with the development placeholder and the configuration doc row. Nothing reads it yet; phase 2 does.

Also carried: `docs/future-prompts/Customer managed domains.md`, the design notes for customer domains this layout leaves room for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD5Xz2gy6UZ9wyzF8sVWdN
