### PR TITLE
Phase 6: typed RPC errors in TypeScript, NONE sessions end with the connection

### DIFF
--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -1,7 +1,7 @@
 # Node failure handling for service proxies — phase plan
 
 Plan of record for making a proxy call fail when the node serving it dies, instead of hanging
-forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545. Everything below was re-validated against `develop` at `3adf17d`
+forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545; Phase 6 is PR #547, based on #546. Everything below was re-validated against `develop` at `3adf17d`
 (2026-09-08); the adjustments that pass produced are folded in, and the phase numbering below
 supersedes the earlier chat numbering (mapping at the end).
 

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -327,6 +327,18 @@ vm-manager's overlapping heartbeat `setInterval`.
 Not in scope: failing in-flight calls on a sticky reconnect. That is what parking exists to
 avoid.
 
+As built: `RpcError` (`api/event`, exported) carries `exceptionName` and `exceptionClass` parsed
+from the `ServiceExceptionWrapper` body of an error reply, falling back to the error header;
+`EventBus.requestStream` rejects with it. The `NONE` edge was a gateway defect, not a client one:
+`removeSession()` only marked the session destroyed, and nothing flushes a destroyed session on
+the WebSocket path, so the store entry and its `replyToId` survived until the timeout; it now
+deletes the entry from the store, and `shutdown()` does the same, so a NONE session ends with its
+connection however the connection ended. The vm-manager heartbeat is a self-rescheduling
+`setTimeout`, so a beat that outlives its interval never overlaps the next. Files: `RpcError.ts`,
+`EventBus.ts`, `index.ts`, `RpcError.test.ts`, vm-manager `index.ts`, `EndpointConnectionHandler`,
+`EndpointConnectionHandlerTests` (a NONE session is gone from the store once the connection
+closes). `@kinotic-ai/core` moves to 5.0.0-beta.11 for the new export.
+
 ## Phase 7 — parked reply sessions, same node (~13 files, split 7a gateway / 7b client)
 
 On `closed()` with a sticky session, `shutdown()` *parks* the `ReplySessionState` in a node-local

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -136,6 +136,10 @@ public class EndpointConnectionHandler {
 
     public void removeSession() {
         if (sessionKeepAliveMode == SessionKeepAliveMode.NONE && session != null) {
+            // nothing flushes a destroyed session on the WebSocket path, so the store entry is removed
+            // here; a reconnect within the timeout would otherwise resume the session and its replyToId
+            services.sessionStore.delete(session.id())
+                                 .onFailure(throwable -> log.warn("Session {} could not be removed from the store", session.id(), throwable));
             session.destroy();
         }
     }
@@ -214,6 +218,8 @@ public class EndpointConnectionHandler {
         subscriptions.clear();
         replySessionState.dispose();
         serviceSessionState.dispose();
+        // a NONE session ends with its connection however the connection ended
+        removeSession();
         session = null;
         connectedInfo = null;
         stompAuthorizer = null;

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -136,10 +136,9 @@ public class EndpointConnectionHandler {
 
     public void removeSession() {
         if (sessionKeepAliveMode == SessionKeepAliveMode.NONE && session != null) {
-            // destroy() only removes the session from the store inside the Vert.x SessionHandler call
-            // chain, which flushes at response end. A WebSocket's response ended at the upgrade, so the
-            // store entry is removed here; a reconnect within the timeout would otherwise resume the
-            // session and its replyToId.
+            // The Vert.x SessionHandler deletes a destroyed session from the store when the response
+            // ends. A WebSocket's response ended at the upgrade, so the store entry is removed here,
+            // which keeps a reconnect within the timeout from resuming the session and its replyToId.
             services.sessionStore.delete(session.id())
                                  .onFailure(throwable -> log.warn("Session {} could not be removed from the store", session.id(), throwable));
             session.destroy();

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -136,8 +136,10 @@ public class EndpointConnectionHandler {
 
     public void removeSession() {
         if (sessionKeepAliveMode == SessionKeepAliveMode.NONE && session != null) {
-            // nothing flushes a destroyed session on the WebSocket path, so the store entry is removed
-            // here; a reconnect within the timeout would otherwise resume the session and its replyToId
+            // destroy() only removes the session from the store inside the Vert.x SessionHandler call
+            // chain, which flushes at response end. A WebSocket's response ended at the upgrade, so the
+            // store entry is removed here; a reconnect within the timeout would otherwise resume the
+            // session and its replyToId.
             services.sessionStore.delete(session.id())
                                  .onFailure(throwable -> log.warn("Session {} could not be removed from the store", session.id(), throwable));
             session.destroy();

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandlerTests.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandlerTests.java
@@ -229,6 +229,23 @@ public class EndpointConnectionHandlerTests {
         Assertions.assertFalse(sent.getValue().metadata().contains(EventConstants.ERROR_HEADER));
     }
 
+    @Test
+    public void testNoneKeepAliveSessionEndsWithTheConnection() throws Exception {
+        Session session = services.sessionStore.createSession(SESSION_TIMEOUT_MS * 10);
+        services.sessionStore.put(session).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        EndpointConnectionHandler handler = connect(session, Map.of(EventConstants.SESSION_KEEP_ALIVE_HEADER, "NONE"));
+        Assertions.assertNotNull(storedSession(session.id()));
+
+        // a network close, not a DISCONNECT frame: the session must not outlive the connection either way
+        handler.shutdown();
+        long deadline = System.currentTimeMillis() + 5000;
+        while (storedSession(session.id()) != null && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        Assertions.assertNull(storedSession(session.id()), "a NONE session survived its connection");
+    }
+
     // Subscribes the connection to a service address it publishes and delivers one invocation to it
     private void deliverInvocation(EndpointConnectionHandler handler, String replyTo, String correlationId) {
         handler.subscribe(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0"), "svc-1", new StompSubscriptionHandler() {

--- a/kinotic-js/workspace/packages/core/package.json
+++ b/kinotic-js/workspace/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/core",
-  "version": "5.0.0-beta.10",
+  "version": "5.0.0-beta.11",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
@@ -9,6 +9,7 @@ import {filter, map, multicast, tap} from 'rxjs/operators'
 import {Optional} from 'typescript-optional'
 import {v4 as uuidv4} from 'uuid'
 import {EventConstants, type IEvent, type IEventBus} from './IEventBus'
+import {RpcError} from './RpcError'
 
 /**
  * Default IEvent implementation
@@ -229,9 +230,8 @@ export class EventBus implements IEventBus {
 
                                                       } else if (value.hasHeader(EventConstants.ERROR_HEADER)) {
 
-                                                          // TODO: add custom error type that contains error detail as well if provided by server, this would be the event body
                                                           serverSignaledCompletion = true
-                                                          subscriber.error(new Error(value.getHeader(EventConstants.ERROR_HEADER)))
+                                                          subscriber.error(RpcError.fromEvent(value))
 
                                                       } else {
 

--- a/kinotic-js/workspace/packages/core/src/api/event/RpcError.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/RpcError.ts
@@ -1,0 +1,68 @@
+import {EventConstants, type IEvent} from './IEventBus'
+
+/**
+ * The error a service call fails with when the server answered it with an error reply. The reply body
+ * describes the exception the server caught, so a caller can branch on which exception it was rather than
+ * on a message written for people: a call that failed because the node serving it left the cluster carries
+ * `RpcServiceUnavailableException`, one rejected because nothing served its address
+ * `RpcMissingServiceException`.
+ */
+export class RpcError extends Error {
+
+    /**
+     * The simple name of the exception the server caught, such as `RpcServiceUnavailableException`.
+     */
+    public readonly exceptionName: string
+
+    /**
+     * The fully qualified class name of the exception the server caught.
+     */
+    public readonly exceptionClass: string
+
+    constructor(message: string, exceptionName: string, exceptionClass: string) {
+        super(message)
+        this.name = 'RpcError'
+        this.exceptionName = exceptionName
+        this.exceptionClass = exceptionClass
+    }
+
+    /**
+     * Builds the error an error reply carries. The body is the server's description of the exception when
+     * it is JSON; otherwise the error header alone names the failure.
+     * @param reply the error reply, which carries the error header
+     */
+    public static fromEvent(reply: IEvent): RpcError {
+        const message = reply.getHeader(EventConstants.ERROR_HEADER) ?? ''
+        let ret: RpcError
+        const detail = describedException(reply)
+        if (detail !== undefined) {
+            ret = new RpcError(detail.errorMessage ?? message, detail.exceptionName ?? '', detail.exceptionClass ?? '')
+        } else {
+            ret = new RpcError(message, '', '')
+        }
+        return ret
+    }
+}
+
+interface ServiceExceptionWrapper {
+    exceptionName?: string
+    exceptionClass?: string
+    errorMessage?: string
+}
+
+// The body is a ServiceExceptionWrapper when the reply is JSON; anything else, or a body that does not
+// parse, describes nothing beyond the header
+function describedException(reply: IEvent): ServiceExceptionWrapper | undefined {
+    let ret: ServiceExceptionWrapper | undefined = undefined
+    if (reply.data.isPresent() && reply.getHeader(EventConstants.CONTENT_TYPE_HEADER)?.startsWith('application/json')) {
+        try {
+            const parsed = JSON.parse(reply.getDataString())
+            if (parsed !== null && typeof parsed === 'object') {
+                ret = parsed as ServiceExceptionWrapper
+            }
+        } catch {
+            // not a description of the exception, the header is all there is
+        }
+    }
+    return ret
+}

--- a/kinotic-js/workspace/packages/core/src/index.ts
+++ b/kinotic-js/workspace/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export * from './api/event/CRI'
 export * from './api/event/DefaultCRI'
 export * from './api/event/EventBus'
 export * from './api/event/IEventBus'
+export * from './api/event/RpcError'
 
 export * from './api/security/BasicCredentialsResolver'
 export * from './api/security/BearerCredentialsResolver'

--- a/kinotic-js/workspace/packages/core/test/RpcError.test.ts
+++ b/kinotic-js/workspace/packages/core/test/RpcError.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from 'vitest'
+import {Event, EventConstants, RpcError} from '../src'
+
+// What a caller can branch on when a service call fails: the exception the server caught, read off the
+// error reply the way EventBus reads it, rather than the message alone.
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('RpcError', () => {
+
+        const errorReply = (headers: [string, string][], body?: string): Event => {
+            const event = new Event('reply://r:1@kinotic.js.EventBus/replyHandler', new Map(headers))
+            if (body !== undefined) {
+                event.setDataString(body)
+            }
+            return event
+        }
+
+        it('carries the exception the server describes in a JSON body', () => {
+            const error = RpcError.fromEvent(errorReply([
+                [EventConstants.ERROR_HEADER, 'Node n2 left the cluster while serving the request to srv://x'],
+                [EventConstants.CONTENT_TYPE_HEADER, 'application/json'],
+            ], JSON.stringify({
+                exceptionName: 'RpcServiceUnavailableException',
+                exceptionClass: 'org.kinotic.core.api.exceptions.RpcServiceUnavailableException',
+                errorMessage: 'Node n2 left the cluster while serving the request to srv://x',
+            })))
+            expect(error).toBeInstanceOf(RpcError)
+            expect(error).toBeInstanceOf(Error)
+            expect(error.exceptionName).toBe('RpcServiceUnavailableException')
+            expect(error.exceptionClass).toBe('org.kinotic.core.api.exceptions.RpcServiceUnavailableException')
+            expect(error.message).toBe('Node n2 left the cluster while serving the request to srv://x')
+        })
+
+        it('falls back to the error header when the reply carries no description', () => {
+            const error = RpcError.fromEvent(errorReply([[EventConstants.ERROR_HEADER, 'boom']]))
+            expect(error.message).toBe('boom')
+            expect(error.exceptionName).toBe('')
+        })
+
+        it('falls back to the error header when the body is not the description', () => {
+            const error = RpcError.fromEvent(errorReply([
+                [EventConstants.ERROR_HEADER, 'boom'],
+                [EventConstants.CONTENT_TYPE_HEADER, 'application/json'],
+            ], 'not json'))
+            expect(error.message).toBe('boom')
+            expect(error.exceptionClass).toBe('')
+        })
+    })
+  })
+})

--- a/kinotic-js/workspace/packages/vm-manager/src/index.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/index.ts
@@ -149,7 +149,9 @@ function reconnectOnFatalError() {
 function startHeartbeat(nodeOrchestrator: VmNodeOrchestrationServiceProxy,
                         vmManager: DefaultVmManager,
                         provider: IVmProvider) {
-    heartbeatTimer = setInterval(async () => {
+    // The next beat is scheduled once this one has finished, so a heartbeat that outlives its
+    // interval while the server is slow or unreachable never overlaps the one after it
+    const beat = async () => {
         try {
             // A node that stopped enforcing something keeps its workloads but takes no more
             await nodeOrchestrator.heartbeat(nodeId!, [...await provider.checkNodeHealth(),
@@ -162,8 +164,13 @@ function startHeartbeat(nodeOrchestrator: VmNodeOrchestrationServiceProxy,
             }
         } catch (error) {
             console.error('Heartbeat failed:', error)
+        } finally {
+            if (!shuttingDown) {
+                heartbeatTimer = setTimeout(beat, config.heartbeatIntervalMs)
+            }
         }
-    }, config.heartbeatIntervalMs)
+    }
+    heartbeatTimer = setTimeout(beat, config.heartbeatIntervalMs)
 }
 
 async function start() {
@@ -226,7 +233,7 @@ async function shutdown() {
     console.log('Shutting down VM Manager...')
     shuttingDown = true
     if (heartbeatTimer) {
-        clearInterval(heartbeatTimer)
+        clearTimeout(heartbeatTimer)
     }
     await alloyManager?.stop()
     await Kinotic.disconnect()

--- a/website/content/02.platform/11.service-call-liveness.md
+++ b/website/content/02.platform/11.service-call-liveness.md
@@ -44,7 +44,7 @@ What the caller receives, in every runtime:
 | `RpcMissingServiceException` | rejected at send, no registration for the address | never executed |
 | `RpcServiceUnavailableException` | the node that took the call left the cluster while it was in flight, its acknowledgement never arrived, or the service stopped while producing a stream | may or may not have executed |
 
-Callers of non-idempotent operations should treat the second as ambiguous and check before retrying.
+Callers of non-idempotent operations should treat the second as ambiguous and check before retrying. In TypeScript a failed call rejects with an `RpcError`, whose `exceptionName` and `exceptionClass` name the exception the server caught, so a caller branches on `exceptionName === 'RpcServiceUnavailableException'` rather than on the message.
 
 A service that stops, on a rolling update or any other graceful shutdown, stops accepting calls first, then answers every call it already has before its node leaves the cluster, so those calls complete normally and no lease fails. Streams it was producing cannot be finished; each one ends with `RpcServiceUnavailableException` at its subscriber the moment the service stops. The wait for the in-flight calls is bounded, so a call that never finishes cannot hold the shutdown.
 


### PR DESCRIPTION
Phase 6 of the node-failure / proxy-hang series (plan: `docs/future-prompts/Node failure handling for service proxies.md`). Based on the Phase 5 branch (#546) so the diff is Phase 6 only; GitHub retargets it when #546 merges.

## `RpcError`: the exception the server caught, in TypeScript

```ts
// api/event/RpcError.ts — exported from @kinotic-ai/core
export class RpcError extends Error {
    public readonly exceptionName: string    // e.g. RpcServiceUnavailableException
    public readonly exceptionClass: string   // e.g. org.kinotic.core.api.exceptions.RpcServiceUnavailableException
    public static fromEvent(reply: IEvent): RpcError
}

// EventBus.requestStream — was subscriber.error(new Error(value.getHeader(ERROR_HEADER)))
subscriber.error(RpcError.fromEvent(value))
```

`fromEvent` parses the `ServiceExceptionWrapper` body the server's exception converter writes when the reply is JSON, and falls back to the error header otherwise. A caller now branches on `error.exceptionName === 'RpcServiceUnavailableException'` rather than on the message. `@kinotic-ai/core` moves to 5.0.0-beta.11 for the new export.

## The NONE keep-alive edge was a gateway defect

```java
// EndpointConnectionHandler.removeSession — before
session.destroy();      // marks it; SessionHandler flushes destroyed sessions at response end, which never comes on a WebSocket

// after
services.sessionStore.delete(session.id());
session.destroy();
```

The store entry, and the `replyToId` in it, survived until the session timeout, so a reconnect within it resumed a session that NONE says ends with the connection. `shutdown()` now calls `removeSession()` too, so a network close ends a NONE session the same way a DISCONNECT frame does.

## vm-manager heartbeat

`setInterval` could start a beat while the previous one was still awaiting a slow or unreachable server. The loop is now a self-rescheduling `setTimeout`: the next beat is scheduled in `finally`, after the current one has finished, and stops when the manager is shutting down.

## Tests

- `RpcError.test.ts` (vitest, no container): the JSON description is carried; the header is the fallback when there is no body or the body is not the description.
- `EndpointConnectionHandlerTests` (+1): a NONE session is gone from the store once its connection closes.

`bunx tsc --noEmit` on core is clean; `:kinotic-api-gateway:test` green (22 tests).

## Docs and plan

The platform liveness page describes `RpcError` under what the caller receives; the plan's Phase 6 section records what was built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY)_