### PR TITLE
Phase 9: an unreachable vm-manager marks its node at once, and a silent node goes offline whatever it reported

### DIFF
--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -1,7 +1,7 @@
 # Node failure handling for service proxies — phase plan
 
 Plan of record for making a proxy call fail when the node serving it dies, instead of hanging
-forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545; Phase 6 in #547; Phases 7 and 8 were built as #548 and #549 and dropped, see their section; the fail-on-disconnect rule that replaces them is PR #551; Phase 9 is PR #550, based on #551. Everything below was re-validated against `develop` at `3adf17d`
+forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545; Phase 6 in #547; Phases 7 and 8 were built as #548 and #549 and dropped, see their section; the fail-on-disconnect rule that replaces them is PR #551; Phase 9 is PR #552, based on #551 (#550 was closed with the dropped Phase 8 base). Everything below was re-validated against `develop` at `3adf17d`
 (2026-09-08); the adjustments that pass produced are folded in, and the phase numbering below
 supersedes the earlier chat numbering (mapping at the end).
 

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -395,6 +395,25 @@ if (node.getStatus().getType() == VmNodeStatusType.ONLINE      // DRAINING never
 This matters more now: the vm-manager reports telemetry-shipping problems as DRAINING, so a node
 that loses Loki/Tempo and then dies keeps its workloads RUNNING forever.
 
+As built. `VmNodeOrchestrationService.verifyNode(nodeId)` is the invalidation trigger:
+`DefaultWorkloadOrchestrationService` calls it when a `VmManagerProxy` call fails with
+`RpcMissingServiceException` or `RpcServiceUnavailableException`. Verification reads the
+vm-manager's registration for the node (`monitorListenerStatus` on the scoped address, first
+emission); absent, the node becomes `UNREACHABLE`, a new `VmNodeStatusType`, so placement stops
+at once. Its workloads are left to the heartbeat reaper: a vm-manager reconnecting after a blip
+is registration-less for a few seconds, and failing workloads on that would be a false positive.
+The reaper now marks any non-OFFLINE node with a stale `lastSeen` OFFLINE and fails its
+workloads, which covers DRAINING and UNREACHABLE alike. The next heartbeat brings an UNREACHABLE
+node back to ONLINE through the existing status comparison. `KinoticUtil.serviceIdentifierOf`
+carries the proxy-to-identifier derivation `DefaultServiceRegistry` had inline, so the orchestrator
+builds the scoped address the same way the proxy does.
+
+Files: `KinoticUtil`, `DefaultServiceRegistry`, `VmNodeStatusType` (Java and TS),
+`VmNodeOrchestrationService`, `DefaultVmNodeOrchestrationService`,
+`DefaultWorkloadOrchestrationService`, `WorkloadOrchestrationTest` (+ `StubVmNodeService.findAll`):
+an unreachable vm-manager with no registration marks its node UNREACHABLE; one still registered
+leaves it ONLINE; a silent DRAINING node goes OFFLINE with its workload FAILED.
+
 ## Numbering
 
 | Earlier chat numbering | This document |

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -1,7 +1,7 @@
 # Node failure handling for service proxies — phase plan
 
 Plan of record for making a proxy call fail when the node serving it dies, instead of hanging
-forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545; Phase 6 in #547; Phases 7 and 8 were built as #548 and #549 and dropped, see their section; the fail-on-disconnect rule that replaces them is PR #551. Everything below was re-validated against `develop` at `3adf17d`
+forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545; Phase 6 in #547; Phases 7 and 8 were built as #548 and #549 and dropped, see their section; the fail-on-disconnect rule that replaces them is PR #551; Phase 9 is PR #550, based on #551. Everything below was re-validated against `develop` at `3adf17d`
 (2026-09-08); the adjustments that pass produced are folded in, and the phase numbering below
 supersedes the earlier chat numbering (mapping at the end).
 

--- a/docs/future-prompts/Typed heartbeat option for vertx-stomp-lite.md
+++ b/docs/future-prompts/Typed heartbeat option for vertx-stomp-lite.md
@@ -1,0 +1,54 @@
+`StompServerOptions.setHeartbeat` in vertx-stomp-lite takes a `JsonObject` with two integer keys,
+`x` and `y`, and the gateway builds one by hand:
+
+```java
+// ApiGatewayVertcleFactory.createApiGatewayVerticle
+long heartbeat = properties.getApiGateway().getStompHeartbeat();
+StompServerOptions stompServerOptions = new StompServerOptions()
+        .setWebsocketPath(STOMP_WEBSOCKET_PATH)
+        .setHeartbeat(new JsonObject().put("x", heartbeat).put("y", heartbeat))
+```
+
+A JSON object for two ints is Primitive Obsession on the library's own API: nothing checks the
+key names at compile time, a `long` is silently narrowed through `getInteger`, and the reader has
+to know the STOMP spec's `x,y` convention to tell which direction is which. I want the option to
+be a record.
+
+What I already know, so you don't re-derive it:
+
+- vertx-stomp-lite is our library (`org.kinotic:vertx-stomp-lite`, pinned by
+  `vertxStompLiteVersion` in `gradle.properties`, 6.0.0 today). The change is made there and
+  released before the gateway picks it up; never work around an unpublished version.
+- The library already has the type, nested and package-private in spirit: `Frame.Heartbeat`
+  holds `final int x; final int y`, with `parse(String)` for the `heart-beat` header,
+  `create(JsonObject)` for the option, `toString()` for the CONNECTED header, and the two
+  `compute*HeartbeatPeriod` functions. `StompServerOptions.DEFAULT_STOMP_HEARTBEAT` is a
+  `JsonObject` of `x=30000, y=30000`, and `DefaultStompServerConnection` calls
+  `Heartbeat.create(options.getHeartbeat())` on every CONNECT.
+- The semantics to preserve, from the STOMP 1.2 spec and the library's code: `x` is what the
+  server can send, `y` what it wants to receive, both in milliseconds, `0` meaning none; the
+  negotiated client period is `max(client.x, server.y)` and the server period
+  `max(server.x, client.y)`, each `0` if either side offered `0`; a connection silent for more
+  than twice the client period is closed through `handler.closed()`.
+- The gateway offers the same value both ways, from `kinotic.apiGateway.stompHeartbeat`, and
+  `StompHeartbeatTests` in `kinotic-api-gateway` builds the options the same way the factory
+  does and pins the close on a real socket. Both are the only call sites of `setHeartbeat`.
+
+Do this:
+
+1. In vertx-stomp-lite, promote the heartbeat to a top-level record, `StompHeartbeat(int x, int y)`
+   or a clearer pair of names if the spec's letters are not worth keeping, in the options
+   package, with `parse(String)` and the header rendering on it. `StompServerOptions`
+   gets `setHeartbeat(StompHeartbeat)` and `getHeartbeat()` returning it, with the default as a
+   record constant; `Frame.Heartbeat` and `create(JsonObject)` go away, and
+   `DefaultStompServerConnection` and the period functions use the record. If the options class
+   has a `JsonObject` constructor or `toJson()` for Vert.x-style configuration, the record maps
+   to and from `{x, y}` there so a JSON-configured server keeps working. Release the library.
+2. In kinotic, bump `vertxStompLiteVersion`, replace the `JsonObject` construction in
+   `ApiGatewayVertcleFactory` and `StompHeartbeatTests` with the record, and keep
+   `ApiGatewayProperties.stompHeartbeat` a single `long` unless a deployment ever needs the two
+   directions apart.
+
+Validate step 2 with `dependencyInsight` on `:kinotic-api-gateway:compileClasspath` for the new
+library version, `:kinotic-api-gateway:test`, and a grep for `"x"` under `kinotic-api-gateway`
+to confirm no key names survive.

--- a/kinotic-core/src/main/java/org/kinotic/core/api/utils/KinoticUtil.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/utils/KinoticUtil.java
@@ -5,6 +5,10 @@ import io.vertx.core.eventbus.ReplyFailure;
 import lombok.extern.slf4j.Slf4j;
 import net.openhft.hashing.LongTupleHashFunction;
 import org.kinotic.core.api.directory.ServiceDirectory;
+import org.kinotic.core.internal.utils.MetaUtil;
+import org.kinotic.core.api.service.ServiceIdentifier;
+import org.kinotic.core.api.annotations.Proxy;
+import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.event.CRI;
 import org.kinotic.core.api.exceptions.RpcMissingServiceException;
 import org.kinotic.core.api.exceptions.RpcServiceUnavailableException;
@@ -38,6 +42,25 @@ public class KinoticUtil {
      * @param serviceDirectory the directory to report unreachability to, or null when none is configured
      * @return the throwable to propagate to the caller
      */
+    /**
+     * The identity a {@link org.kinotic.core.api.annotations.Proxy} interface addresses: its zone, namespace,
+     * name and version as declared on the interface, with no scope. A scoped call adds the scope per invocation.
+     * @param proxyInterface an interface annotated with {@link org.kinotic.core.api.annotations.Proxy}
+     * @return the identifier the interface's calls are routed by
+     */
+    public static ServiceIdentifier serviceIdentifierOf(Class<?> proxyInterface) {
+        Proxy proxyAnnotation = proxyInterface.getAnnotation(Proxy.class);
+        Validate.notNull(proxyAnnotation, "The Class provided must be annotated with @Proxy");
+        String namespace = proxyAnnotation.namespace().isEmpty() ? safeEncodeURI(proxyInterface.getPackageName()) : safeEncodeURI(proxyAnnotation.namespace());
+        String name = proxyAnnotation.name().isEmpty() ? proxyInterface.getSimpleName() : proxyAnnotation.name();
+        // A proxy targets one address; with no declaration it targets the un-zoned address
+        return new ServiceIdentifier(MetaUtil.getZone(proxyInterface),
+                                     namespace,
+                                     name,
+                                     null,
+                                     MetaUtil.getVersion(proxyInterface));
+    }
+
     public static Throwable mapSendFailure(Throwable throwable, CRI destination, ServiceDirectory serviceDirectory) {
         Throwable ret = throwable;
         if (throwable instanceof ReplyException replyException) {

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.Kinotic;
 import org.kinotic.core.api.RpcServiceProxyHandle;
 import org.kinotic.core.api.ServiceRegistry;
-import org.kinotic.core.api.annotations.Proxy;
 import org.kinotic.core.api.directory.ServiceDirectory;
 import org.kinotic.core.api.event.EventBusService;
 import org.kinotic.core.api.event.TraceLogFilter;
@@ -26,7 +25,6 @@ import org.kinotic.core.internal.api.service.rpc.RpcArgumentConverter;
 import org.kinotic.core.internal.api.service.rpc.RpcArgumentConverterResolver;
 import org.kinotic.core.internal.api.service.rpc.RpcReturnValueHandlerFactory;
 import org.kinotic.core.api.utils.KinoticUtil;
-import org.kinotic.core.internal.utils.MetaUtil;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ReactiveAdapterRegistry;
@@ -165,23 +163,7 @@ public class DefaultServiceRegistry implements ServiceRegistry {
 
     @Override
     public <T> RpcServiceProxyHandle<T> serviceProxy(Class<T> serviceInterface) {
-        Proxy proxyAnnotation = serviceInterface.getAnnotation(Proxy.class);
-        Validate.notNull(proxyAnnotation, "The Class provided must be annotated with @Proxy");
-
-        String namespace = proxyAnnotation.namespace().isEmpty() ? KinoticUtil.safeEncodeURI(serviceInterface.getPackageName()) : KinoticUtil.safeEncodeURI(proxyAnnotation.namespace());
-        String name = proxyAnnotation.name().isEmpty() ? serviceInterface.getSimpleName() : proxyAnnotation.name();
-        String version = MetaUtil.getVersion(serviceInterface);
-
-        // A proxy targets one address; with no declaration it targets the un-zoned address
-        String zone = MetaUtil.getZone(serviceInterface);
-
-        ServiceIdentifier serviceIdentifier = new ServiceIdentifier(zone,
-                                                                    namespace,
-                                                                    name,
-                                                                    null,
-                                                                    version);
-
-        return serviceProxy(serviceIdentifier, serviceInterface, MimeTypeUtils.APPLICATION_JSON_VALUE);
+        return serviceProxy(KinoticUtil.serviceIdentifierOf(serviceInterface), serviceInterface, MimeTypeUtils.APPLICATION_JSON_VALUE);
     }
 
     @Override

--- a/kinotic-js/workspace/packages/system-api/package.json
+++ b/kinotic-js/workspace/packages/system-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/system-api",
-  "version": "5.0.0-beta.11",
+  "version": "5.0.0-beta.12",
   "type": "module",
   "description": "Client API for the Kinotic platform's system plane: the workload and node orchestration services platform machines and operators use.",
   "files": [

--- a/kinotic-js/workspace/packages/system-api/src/api/model/workload/VmNodeStatusType.ts
+++ b/kinotic-js/workspace/packages/system-api/src/api/model/workload/VmNodeStatusType.ts
@@ -2,5 +2,6 @@
 export enum VmNodeStatusType {
     ONLINE = 'ONLINE',
     OFFLINE = 'OFFLINE',
-    DRAINING = 'DRAINING'
+    DRAINING = 'DRAINING',
+    UNREACHABLE = 'UNREACHABLE'
 }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/model/workload/VmNodeStatusType.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/model/workload/VmNodeStatusType.java
@@ -6,5 +6,11 @@ package org.kinotic.system.api.model.workload;
 public enum VmNodeStatusType {
     ONLINE,
     OFFLINE,
-    DRAINING
+    DRAINING,
+    /**
+     * A call to the node's vm-manager could not be delivered and the vm-manager holds no registration: the
+     * node takes no workloads until its next heartbeat brings it back, and its workloads are failed by the
+     * heartbeat timeout like any other silent node's.
+     */
+    UNREACHABLE
 }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/VmNodeOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/VmNodeOrchestrationService.java
@@ -66,6 +66,15 @@ public interface VmNodeOrchestrationService {
     Future<Void> deregisterNode(String nodeId);
 
     /**
+     * Checks a node a call to its vm-manager could not reach. A node whose vm-manager holds no service
+     * registration is marked {@code UNREACHABLE} at once, so no workload is placed on it before the
+     * heartbeat timeout would have noticed; a registered one is left as it is.
+     * @param nodeId the id of the node to check
+     * @return a future that completes when the check has been applied
+     */
+    Future<Void> verifyNode(String nodeId);
+
+    /**
      * Finds a node with sufficient resources to host a workload with the given requirements.
      *
      * @param requiredCpus the number of vCPUs required

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeOrchestrationService.java
@@ -1,6 +1,13 @@
 package org.kinotic.system.internal.api.services;
 
 import io.vertx.core.Future;
+import org.kinotic.system.api.workload.VmManagerProxy;
+import org.kinotic.core.api.utils.KinoticUtil;
+import org.kinotic.core.api.service.ServiceIdentifier;
+import org.kinotic.core.api.event.ListenerStatus;
+import org.kinotic.core.api.event.EventBusService;
+import org.kinotic.core.api.event.CRI;
+import io.vertx.core.Promise;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +43,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
     private final KinoticSystemApiProperties orchestratorProperties;
     private final VmNodeService vmNodeService;
     private final WorkloadService workloadService;
+    private final EventBusService eventBusService;
     private ScheduledExecutorService scheduler;
 
     @PostConstruct
@@ -212,9 +220,37 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
         return vmNodeService.findAvailableNode(requiredCpus, requiredMemoryMb, requiredDiskMb);
     }
 
+    @Override
+    public Future<Void> verifyNode(String nodeId) {
+        Validate.notNull(nodeId, "Node id cannot be null");
+        ServiceIdentifier vmManager = KinoticUtil.serviceIdentifierOf(VmManagerProxy.class);
+        CRI address = new ServiceIdentifier(vmManager.zone(), vmManager.namespace(), vmManager.name(), nodeId, vmManager.version()).cri();
+        // the first emission is the current registration state; completes on the monitor's delivery context
+        Promise<ListenerStatus> registration = Promise.promise();
+        eventBusService.monitorListenerStatus(address).next().subscribe(registration::complete, registration::fail);
+        return registration.future()
+                           .compose(status -> status == ListenerStatus.ACTIVE
+                                   ? Future.succeededFuture()
+                                   : vmNodeService.findById(nodeId).compose(node -> markUnreachable(nodeId, node)));
+    }
+
+    private Future<Void> markUnreachable(String nodeId, VmNode node) {
+        Future<Void> ret;
+        if (node == null || node.getStatus().getType() == VmNodeStatusType.OFFLINE
+                || node.getStatus().getType() == VmNodeStatusType.UNREACHABLE) {
+            ret = Future.succeededFuture();
+        } else {
+            log.warn("VmNode {} ({}) is unreachable and holds no vm-manager registration, taking no workloads", node.getName(), nodeId);
+            node.setStatus(new VmNodeStatus(VmNodeStatusType.UNREACHABLE, node.getStatus().getHealthMessage()));
+            // findAvailableNode selects on status.type with a search, so the change has to be indexed first
+            ret = vmNodeService.saveSync(node).mapEmpty();
+        }
+        return ret;
+    }
+
     /**
-     * Periodically checks all ONLINE nodes and marks any that haven't sent a heartbeat
-     * within the timeout as OFFLINE. Running workloads on offline nodes are marked FAILED.
+     * Periodically marks every node that has not sent a heartbeat within the timeout OFFLINE, whatever it
+     * reported last, and marks the workloads running on it FAILED.
      */
     private void checkNodeHealth() {
         try {
@@ -225,7 +261,8 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
             vmNodeService.findAll(Pageable.create(0, 500, null))
                     .onSuccess(page -> {
                         for (VmNode node : page.getContent()) {
-                            if (node.getStatus().getType() == VmNodeStatusType.ONLINE
+                            // a DRAINING or UNREACHABLE node that falls silent is as dead as an ONLINE one
+                            if (node.getStatus().getType() != VmNodeStatusType.OFFLINE
                                     && node.getLastSeen() != null
                                     && node.getLastSeen().before(cutoffDate)) {
 

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
@@ -1,6 +1,8 @@
 package org.kinotic.system.internal.api.services;
 
 import io.vertx.core.Future;
+import org.kinotic.core.api.exceptions.RpcServiceUnavailableException;
+import org.kinotic.core.api.exceptions.RpcMissingServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
@@ -32,6 +34,17 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
     private final VmManagerProxy vmManagerProxy;
     private final VmNodeService vmNodeService;
     private final WorkloadService workloadService;
+
+    // A call the bus could not deliver, or whose serving node left, is the earliest sign a node is gone;
+    // the orchestrator checks the node at once instead of waiting for the heartbeat timeout
+    private <T> Future<T> verifyingNodeOnFailure(String nodeId, Future<T> call) {
+        return call.onFailure(error -> {
+            if (error instanceof RpcMissingServiceException || error instanceof RpcServiceUnavailableException) {
+                nodeOrchestrationService.verifyNode(nodeId)
+                                        .onFailure(verifyError -> log.warn("Could not verify node {} after an unreachable vm-manager", nodeId, verifyError));
+            }
+        });
+    }
 
     @Override
     public Future<Workload> deployWorkload(Workload workload) {
@@ -67,7 +80,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                             .compose(savedWorkload ->
                                 // Dispatch to the VmManager on the selected node. For a
                                 // non-detached workload the reply arrives once the run ends.
-                                vmManagerProxy.startWorkload(node.getId(), savedWorkload)
+                                verifyingNodeOnFailure(node.getId(), vmManagerProxy.startWorkload(node.getId(), savedWorkload))
                                         .compose(this::applyStartReply)
                                         .recover(error -> {
                                             log.error("Failed to start workload {} on node {}",
@@ -99,7 +112,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                     return workloadService.saveSync(workload);
                 })
                 .compose(workload ->
-                    vmManagerProxy.restartWorkload(workload.getNodeId(), workloadId)
+                    verifyingNodeOnFailure(workload.getNodeId(), vmManagerProxy.restartWorkload(workload.getNodeId(), workloadId))
                             .compose(this::applyStartReply)
                             .recover(error -> {
                                 log.error("Failed to restart workload {} on node {}",
@@ -126,7 +139,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                     return workloadService.saveSync(workload);
                 })
                 .compose(workload ->
-                    vmManagerProxy.stopWorkload(workload.getNodeId(), workloadId)
+                    verifyingNodeOnFailure(workload.getNodeId(), vmManagerProxy.stopWorkload(workload.getNodeId(), workloadId))
                             .compose(v -> {
                                 workload.setStatus(WorkloadStatus.STOPPED);
                                 return workloadService.saveSync(workload);
@@ -147,7 +160,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                     }
 
                     // Dispatch destroy to the VmManager on the workload's node
-                    return vmManagerProxy.destroyWorkload(workload.getNodeId(), workloadId)
+                    return verifyingNodeOnFailure(workload.getNodeId(), vmManagerProxy.destroyWorkload(workload.getNodeId(), workloadId))
                             .compose(v ->
                                 // Free allocated resources on the node
                                 vmNodeService.findById(workload.getNodeId())

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubVmNodeService.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubVmNodeService.java
@@ -7,6 +7,8 @@ import org.kinotic.system.api.model.workload.VmNode;
 import org.kinotic.system.api.services.VmNodeService;
 
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -68,7 +70,8 @@ public class StubVmNodeService implements VmNodeService {
 
     @Override
     public Future<Page<VmNode>> findAll(Pageable pageable) {
-        throw new UnsupportedOperationException();
+        List<VmNode> all = new ArrayList<>(saved.values());
+        return Future.succeededFuture(new Page<>(all, (long) all.size()));
     }
 
     @Override

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
@@ -1,6 +1,16 @@
 package org.kinotic.system.internal.api.services;
 
 import io.vertx.core.Future;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Date;
+import reactor.core.publisher.Flux;
+import org.kinotic.core.api.exceptions.RpcServiceUnavailableException;
+import org.kinotic.core.api.exceptions.RpcMissingServiceException;
+import org.kinotic.core.api.event.ListenerStatus;
+import org.kinotic.core.api.event.EventBusService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kinotic.system.api.config.KinoticSystemApiProperties;
@@ -33,6 +43,8 @@ public class WorkloadOrchestrationTest {
     private StubWorkloadService workloads;
     private StubVmNodeService nodes;
     private StubVmManagerProxy vmManager;
+    private EventBusService eventBus;
+    private KinoticSystemApiProperties properties;
     private DefaultVmNodeOrchestrationService nodeOrchestration;
     private DefaultWorkloadOrchestrationService orchestration;
 
@@ -42,10 +54,57 @@ public class WorkloadOrchestrationTest {
         nodes = new StubVmNodeService();
         nodes.availableNode = new VmNode(NODE_ID, "node-1", "host-1");
         vmManager = new StubVmManagerProxy();
-        nodeOrchestration = new DefaultVmNodeOrchestrationService(new KinoticSystemApiProperties(),
-                                                                  nodes, workloads);
+        // the node's vm-manager registration, as the cluster reports it: absent unless a test says otherwise
+        eventBus = mock(EventBusService.class);
+        when(eventBus.monitorListenerStatus(any())).thenReturn(Flux.just(ListenerStatus.INACTIVE));
+        properties = new KinoticSystemApiProperties();
+        nodeOrchestration = new DefaultVmNodeOrchestrationService(properties, nodes, workloads, eventBus);
         orchestration = new DefaultWorkloadOrchestrationService(nodeOrchestration, vmManager,
                                                                 nodes, workloads);
+    }
+
+    @Test
+    public void unreachableVmManagerMarksItsNodeUnreachableAtOnce() throws Exception {
+        nodes.saveSync(nodes.availableNode);
+        vmManager.failStartWith = new RpcMissingServiceException("no vm-manager registered for node-1");
+
+        assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
+
+        assertEquals(VmNodeStatusType.UNREACHABLE, nodes.saved.get(NODE_ID).getStatus().getType());
+    }
+
+    @Test
+    public void reachableVmManagerKeepsItsNodeOnlineWhenACallFails() throws Exception {
+        nodes.saveSync(nodes.availableNode);
+        when(eventBus.monitorListenerStatus(any())).thenReturn(Flux.just(ListenerStatus.ACTIVE));
+        vmManager.failStartWith = new RpcServiceUnavailableException("the gateway serving it left mid-call");
+
+        assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
+
+        assertEquals(VmNodeStatusType.ONLINE, nodes.saved.get(NODE_ID).getStatus().getType());
+    }
+
+    @Test
+    public void silentNodeGoesOfflineWhateverItReportedLast() throws Exception {
+        properties.getSystemApi().getVmNode().setHealthCheckIntervalSeconds(1);
+        properties.getSystemApi().getVmNode().setHeartbeatTimeoutSeconds(1);
+        Workload deployed = await(orchestration.deployWorkload(newWorkload()));
+        VmNode node = nodes.saved.get(NODE_ID);
+        node.setStatus(new VmNodeStatus(VmNodeStatusType.DRAINING, "telemetry shipping lost"));
+        node.setLastSeen(new Date(System.currentTimeMillis() - 10_000));
+        nodes.saveSync(node);
+
+        nodeOrchestration.init();
+        try {
+            long deadline = System.currentTimeMillis() + 10_000;
+            while (nodes.saved.get(NODE_ID).getStatus().getType() != VmNodeStatusType.OFFLINE && System.currentTimeMillis() < deadline) {
+                Thread.sleep(100);
+            }
+            assertEquals(VmNodeStatusType.OFFLINE, nodes.saved.get(NODE_ID).getStatus().getType());
+            assertEquals(WorkloadStatus.FAILED, workloads.saved.get(deployed.getId()).getStatus());
+        } finally {
+            nodeOrchestration.destroy();
+        }
     }
 
     @Test

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -120,9 +120,9 @@ Some of what a node promises can stop being true while it runs, and each failure
 
 Each node re-checks these and sends what it can no longer guarantee with its heartbeat, so a node's liveness and its fitness arrive in one call. A node reporting problems moves to `DRAINING`, so the orchestrator places no further workloads on it, and back to `ONLINE` once it reports none. The workloads already there keep running — a node that stopped enforcing a limit is unfit to take on more, not required to drop what it has.
 
-`VmNode.status` carries both parts: `status.type` is `ONLINE`, `DRAINING`, or `OFFLINE`, and `status.healthMessage` is why, or null when the node is fit. The system console shows the reason on the node.
+`VmNode.status` carries both parts: `status.type` is `ONLINE`, `DRAINING`, `UNREACHABLE`, or `OFFLINE`, and `status.healthMessage` is why, or null when the node is fit. The system console shows the reason on the node.
 
-A node that loses its connection to the server — a server restart, a network partition — reconnects on its own and is `ONLINE` again with its next heartbeat. The orchestrator marks it `OFFLINE` after `heartbeatTimeoutSeconds` without one.
+A node that loses its connection to the server — a server restart, a network partition — reconnects on its own and is `ONLINE` again with its next heartbeat. The orchestrator marks it `OFFLINE` after `heartbeatTimeoutSeconds` without one, whatever it reported last, and fails the workloads running on it. A call to the node's vm-manager that cannot be delivered is an earlier sign: the orchestrator checks the vm-manager's registration at once and, finding none, marks the node `UNREACHABLE`, so nothing is placed on it while the heartbeat timeout runs; its next heartbeat brings it back to `ONLINE`.
 
 | Provider | What it re-checks |
 |---|---|


### PR DESCRIPTION
Phase 9 of the node-failure / proxy-hang series (plan: `docs/future-prompts/Node failure handling for service proxies.md`), the last one. Replaces #550, which was closed on top of the dropped Phase 8 history and could not be retargeted. Based on #551, the fail-on-disconnect rule that replaced Phases 7 and 8, so the diff is Phase 9 only; GitHub retargets it to `develop` when #551 merges.

## The fast path: a failed call is the earliest sign a node is gone

```java
// DefaultWorkloadOrchestrationService — wraps the four VmManagerProxy calls
private <T> Future<T> verifyingNodeOnFailure(String nodeId, Future<T> call) {
    return call.onFailure(error -> {
        if (error instanceof RpcMissingServiceException || error instanceof RpcServiceUnavailableException) {
            nodeOrchestrationService.verifyNode(nodeId)...;
        }
    });
}

// DefaultVmNodeOrchestrationService.verifyNode — the vm-manager's registration decides
CRI address = new ServiceIdentifier(vmManager.zone(), vmManager.namespace(), vmManager.name(), nodeId, vmManager.version()).cri();
eventBusService.monitorListenerStatus(address).next()...
    status == ACTIVE ? leave it : mark UNREACHABLE
```

`UNREACHABLE` is a new `VmNodeStatusType` (Java and TS): the node takes no workloads while the heartbeat timeout runs, and its next heartbeat brings it back to `ONLINE` through the existing status comparison. Its workloads are deliberately left to the reaper: a vm-manager reconnecting after a blip holds no registration for a few seconds, and failing workloads on that would be a false positive that the reaper's timeout exists to avoid.

`KinoticUtil.serviceIdentifierOf(Class)` carries the proxy-to-identifier derivation `DefaultServiceRegistry.serviceProxy(Class)` had inline, so the orchestrator addresses the node's vm-manager exactly the way the proxy does.

## The reaper no longer skips DRAINING nodes

```java
// DefaultVmNodeOrchestrationService.checkNodeHealth — before
if (node.getStatus().getType() == VmNodeStatusType.ONLINE      // DRAINING never entered
// after
if (node.getStatus().getType() != VmNodeStatusType.OFFLINE      // ONLINE, DRAINING, UNREACHABLE alike
```

The vm-manager reports telemetry-shipping problems as DRAINING, so a node that lost Loki or Tempo and then died kept its workloads RUNNING forever.

## Tests

`WorkloadOrchestrationTest` (+3, through the real orchestration services against the in-memory stubs, with the bus at the mock boundary):

- an unreachable vm-manager with no registration marks its node `UNREACHABLE` at once;
- one still registered leaves it `ONLINE` when a call fails;
- a silent `DRAINING` node goes `OFFLINE` and its workload `FAILED` on the next health check.

`StubVmNodeService.findAll` now returns the saved nodes. Full `:kinotic-system-api:test` green (20 tests, 3 Azure integration tests skipped as before); core `RpcTests` green (39) after the registry change; `bunx tsc --noEmit` clean on system-api. `@kinotic-ai/system-api` moves to 5.0.0-beta.12 for the enum value.

Also carries the future prompt for a typed heartbeat option in vertx-stomp-lite.

## Docs and plan

The configuration page's node section describes `UNREACHABLE` and the reaper's behaviour; the plan's Phase 9 section records what was built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY)_