### PR TITLE
Expand any diagram to full screen on click

### DIFF
--- a/website/app/components/DiagramFrame.vue
+++ b/website/app/components/DiagramFrame.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { onBeforeUnmount, ref } from 'vue'
+
+// A click fills the screen with the diagram. The Fullscreen API takes the whole display where
+// the browser offers it for an element; where it does not (iOS Safari), a fixed overlay covers
+// the viewport instead. The diagram never moves in the DOM either way, so the marker ids and
+// the theme palette its own stylesheet carries keep resolving.
+const frame = ref<HTMLElement | null>(null)
+const expanded = ref(false)
+let overlay = false
+
+function lockScroll(lock: boolean) {
+  document.documentElement.style.overflow = lock ? 'hidden' : ''
+}
+
+function teardown() {
+  document.removeEventListener('fullscreenchange', onFullscreenChange)
+  window.removeEventListener('keydown', onKeydown)
+  if (overlay) {
+    lockScroll(false)
+    overlay = false
+  }
+}
+
+// Fullscreen mode leaves on Escape, the browser's own exit gesture, or exitFullscreen(); all
+// three arrive here, so this is the one place fullscreen state is read back
+function onFullscreenChange() {
+  expanded.value = document.fullscreenElement === frame.value
+  if (!expanded.value) {
+    teardown()
+  }
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    close()
+  }
+}
+
+async function open() {
+  const element = frame.value
+  if (expanded.value || !element) {
+    return
+  }
+  if (element.requestFullscreen) {
+    document.addEventListener('fullscreenchange', onFullscreenChange)
+    try {
+      await element.requestFullscreen()
+      return
+    } catch {
+      // Refused (a browser policy, or a display that cannot go fullscreen): fall through to the overlay
+      document.removeEventListener('fullscreenchange', onFullscreenChange)
+    }
+  }
+  overlay = true
+  expanded.value = true
+  lockScroll(true)
+  window.addEventListener('keydown', onKeydown)
+}
+
+function close() {
+  if (!expanded.value) {
+    return
+  }
+  if (document.fullscreenElement === frame.value) {
+    document.exitFullscreen()
+  } else {
+    expanded.value = false
+    teardown()
+  }
+}
+
+function toggle() {
+  if (expanded.value) {
+    close()
+  } else {
+    open()
+  }
+}
+
+// Expanded, the backdrop closes and the drawing itself does not, so a click while reading
+// stays put
+function onStageClick(event: MouseEvent) {
+  if (!expanded.value) {
+    open()
+  } else if (!(event.target as Element).closest('svg')) {
+    close()
+  }
+}
+
+onBeforeUnmount(() => {
+  if (expanded.value) {
+    close()
+  }
+  teardown()
+})
+</script>
+
+<template>
+  <div ref="frame" class="diagram-frame" :class="{ 'is-expanded': expanded }">
+    <div
+      class="diagram-frame__stage"
+      role="button"
+      tabindex="0"
+      :aria-label="expanded ? 'Close the expanded diagram' : 'Expand the diagram'"
+      @click="onStageClick"
+      @keydown.enter.prevent="toggle"
+      @keydown.space.prevent="toggle"
+    >
+      <slot />
+    </div>
+    <button v-if="expanded" class="diagram-frame__close" type="button" aria-label="Close" @click.stop="close">
+      <UIcon name="i-lucide-x" />
+    </button>
+    <span v-else class="diagram-frame__hint" aria-hidden="true">
+      <UIcon name="i-lucide-maximize-2" />
+    </span>
+  </div>
+</template>
+
+<style>
+.diagram-frame {
+  position: relative;
+  margin: 1.5rem 0;
+}
+
+.diagram-frame__stage {
+  cursor: zoom-in;
+  outline: none;
+  border-radius: 6px;
+}
+
+.diagram-frame__stage:focus-visible {
+  outline: 2px solid var(--ui-primary);
+  outline-offset: 4px;
+}
+
+.diagram-frame__hint {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  display: inline-flex;
+  padding: 0.35rem;
+  border-radius: 6px;
+  background: var(--ui-bg-elevated);
+  color: var(--ui-text-muted);
+  font-size: 1rem;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.15s;
+  pointer-events: none;
+}
+
+.diagram-frame:hover .diagram-frame__hint,
+.diagram-frame__stage:focus-visible ~ .diagram-frame__hint {
+  opacity: 1;
+}
+
+/* Expanded: one set of rules for the Fullscreen API and for the overlay fallback */
+.diagram-frame.is-expanded {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  margin: 0;
+  background: var(--ui-bg);
+}
+
+.diagram-frame:fullscreen::backdrop {
+  background: var(--ui-bg);
+}
+
+.diagram-frame.is-expanded .diagram-frame__stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 2.5rem;
+  box-sizing: border-box;
+  border-radius: 0;
+  cursor: zoom-out;
+}
+
+/* The slotted wrapper and its drawing fill the stage; the viewBox letterboxes the drawing in it */
+.diagram-frame.is-expanded .diagram-frame__stage > * {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+.diagram-frame.is-expanded .diagram-frame__stage svg {
+  min-width: 0;
+  width: 100%;
+  height: 100%;
+  cursor: default;
+}
+
+.diagram-frame__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1;
+  display: inline-flex;
+  padding: 0.5rem;
+  border: 1px solid var(--ui-border);
+  border-radius: 999px;
+  background: var(--ui-bg-elevated);
+  color: var(--ui-text);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.diagram-frame__close:hover {
+  background: var(--ui-bg-accented);
+}
+</style>

--- a/website/app/components/content/ArchitectureDiagram.vue
+++ b/website/app/components/content/ArchitectureDiagram.vue
@@ -1,4 +1,5 @@
 <template>
+  <DiagramFrame>
   <div class="arch-diagram-wrap">
     <svg class="arch-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1172 825" role="img" aria-label="Kinotic three-plane network architecture: internet clients reach two public gateways over HTTPS; the system server is reachable only through a VPN gate or from inside the Azure VNet; the app plane is an isolated island; shared data stores are the only coupling between the buses.">
 
@@ -173,6 +174,7 @@
       <text class="t-tiny" x="766" y="654" text-anchor="middle">logs</text>
     </svg>
   </div>
+  </DiagramFrame>
 </template>
 
 <style>

--- a/website/app/components/content/DevelopmentServerDiagram.vue
+++ b/website/app/components/content/DevelopmentServerDiagram.vue
@@ -1,4 +1,5 @@
 <template>
+  <DiagramFrame>
   <div class="dev-server-diagram-wrap">
     <svg class="dev-server-diagram" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1172 860" role="img" aria-label="Development server topology: peers and GitHub reach kinotic-server over two forwarded ports; Azure keeps Front Door, the sites storage account, email, DNS, a Key Vault and a snapshot container; one Proxmox host runs a platform VM with kinotic-server, three Elasticsearch nodes and the observability stack, and a node VM running the vm-manager with Cloud Hypervisor micro VMs; each Elasticsearch node and the node runtime own a whole physical disk.">
 
@@ -181,6 +182,7 @@
       <text class="t-tag" x="36" y="826">HOST · PROXMOX VE · RYZEN 9 · 96 GB · 5 SSDS</text>
     </svg>
   </div>
+  </DiagramFrame>
 </template>
 
 <style>

--- a/website/app/components/content/RpcLivenessDiagram.vue
+++ b/website/app/components/content/RpcLivenessDiagram.vue
@@ -4,6 +4,7 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
 </script>
 
 <template>
+  <DiagramFrame>
   <div class="rpc-diagram-wrap">
 
     <!-- ═══════════════════════════ OVERVIEW: registration is liveness ═══════════════════════════ -->
@@ -301,6 +302,7 @@ defineProps<{ view?: 'overview' | 'failure' | 'reconnect' }>()
       <text class="t-mono-red" x="575" y="696" text-anchor="middle">Overflow → the same. The next CONNECT hands the client a new reply CRI and its reset path fails the in-flight calls; down past the window, the client fails them itself.</text>
     </svg>
   </div>
+  </DiagramFrame>
 </template>
 
 <style>
@@ -334,7 +336,7 @@ svg.rpc-diagram {
   --pink-tint: rgba(216, 121, 172, 0.12);
 }
 
-.rpc-diagram-wrap { overflow-x: auto; margin: 1.5rem 0; }
+.rpc-diagram-wrap { overflow-x: auto; }
 svg.rpc-diagram { min-width: 760px; width: 100%; height: auto; display: block; }
 
 /* ── SVG vocabulary ─────────────────────────────── */


### PR DESCRIPTION
## What

Every SVG diagram on the docs site now pops out to full screen when clicked.

- `website/app/components/DiagramFrame.vue` is a new wrapper. A click, Enter, or Space expands the diagram through the Fullscreen API, so it takes the whole display; where an element cannot go fullscreen (iOS Safari) it falls back to a fixed overlay covering the viewport. The close button, Escape, or a click on the backdrop collapses it; a click on the drawing itself does not, so it stays put while reading. An expand glyph appears in the corner on hover.
- The three diagram components (`ArchitectureDiagram`, the three-view `RpcLivenessDiagram`, `DevelopmentServerDiagram`) wrap their existing markup in it. No markdown page changes.
- The diagram never moves in the DOM, so its SVG marker ids and its own light/dark palette keep resolving. The expanded background uses the site's `--ui-bg` token, so it follows the theme.

## Verification

- `bun run generate` completes cleanly with the wrapped components.
- A Playwright run against the generated site, on all three pages: expand fills the viewport with the drawing letterboxed to fit (1320×820 in a 1400×900 viewport), the close button collapses the fullscreen state, and with the Fullscreen API removed the overlay fallback locks scroll, closes on Escape and on backdrop click, and releases the scroll lock. Screenshots checked in light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAvrrSkaubKq3msfAJa6gJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAvrrSkaubKq3msfAJa6gJ)_