### PR TITLE
Review fixes for the node-failure series: lost replies, leaked leases, a resurrected session, and a stream that closed its own connection

### DIFF
--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -496,6 +496,12 @@ known defect.
   live stream's correlation id is answered with an error instead of dropped with its span open; an
   unknown control cancels the source it answers with an error; a single-value reply that cannot be
   sent is answered the same way whether it came from `onNext` or an empty completion.
+- `ServiceInvocationSupervisor` no longer dispatches through `vertx.executeBlocking`: an invocation
+  runs on its delivery context, so the synchronous slice of one service's invocations is no longer
+  serialized on one ordered worker and no worker hop or shared pool sits in the request path. A slow
+  handler hands off inside itself, the rule the platform docs now state. The stream registry uses
+  `putIfAbsent` and removes inline, and the in-flight count is a pair of plain methods. The argument
+  tokenizer is a synchronous call with no `block()` on the event loop.
 
 Not fixed: `cancelRequest` sends the cancel to the request address, which on an unscoped
 multi-instance service may not be the producing instance. Routing it through `__origin-cri` would not

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -1,7 +1,7 @@
 # Node failure handling for service proxies — phase plan
 
 Plan of record for making a proxy call fail when the node serving it dies, instead of hanging
-forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545; Phase 6 in #547; Phases 7 and 8 were built as #548 and #549 and dropped, see their section; the fail-on-disconnect rule that replaces them is PR #551; Phase 9 is PR #552, based on #551 (#550 was closed with the dropped Phase 8 base); the wrap-up is PR #553, based on #552; TS service streaming with cancel is PR #554, based on #553. Everything below was re-validated against `develop` at `3adf17d`
+forever. Phase 1 landed in PR #476; Phase 2 in #540; Phase 3 in #544; Phase 4 is PR #545; Phase 5 is PR #546, based on #545; Phase 6 in #547; Phases 7 and 8 were built as #548 and #549 and dropped, see their section; the fail-on-disconnect rule that replaces them is PR #551; Phase 9 is PR #552, based on #551 (#550 was closed with the dropped Phase 8 base); the wrap-up is PR #553, based on #552; TS service streaming with cancel is PR #554, based on #553; the review fixes are PR #558. Everything below was re-validated against `develop` at `3adf17d`
 (2026-09-08); the adjustments that pass produced are folded in, and the phase numbering below
 supersedes the earlier chat numbering (mapping at the end).
 

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -479,6 +479,24 @@ merged stack.
 - A NONE keep-alive connection deleted a login session it had not created; `disconnected()` duplicated
   `closed()`; membership snapshots could emit out of order.
 
+A second pass took the TS connection layer and the Java supervisor on their own, with the bar of no
+known defect.
+
+- `StompConnectionManager` is reworked around a `StompActivation` per `activate()` call, which owns
+  the listeners, the pending reject, a socket produced for stompjs, and the attempt stompjs is
+  awaiting. `deactivate()` ends only the activation it took, waits for that attempt before the next
+  activation may start, and reports an open connection's end once. A fatal raised by an ended
+  activation's attempt or listener is not published; a bad CONNECTED frame rejects the connect with
+  its own reason; a connect queued behind a `disconnect()` never starts; `activate()` rejects with
+  `Error`s; the attempt budget is granted again for each connection's reconnects. A fake STOMP server
+  behind the socket factory drives these in `ConnectionLifecycle.test.ts`.
+- `ServiceInvocationSupervisor`: a stream whose caller's reply listener goes INACTIVE, whose listener
+  monitor ends, or whose service stops after the drain began ends with an error reply instead of a
+  silent cancel; `fail()` sends that reply once whichever path gets there first; a request reusing a
+  live stream's correlation id is answered with an error instead of dropped with its span open; an
+  unknown control cancels the source it answers with an error; a single-value reply that cannot be
+  sent is answered the same way whether it came from `onNext` or an empty completion.
+
 Not fixed: `cancelRequest` sends the cancel to the request address, which on an unscoped
 multi-instance service may not be the producing instance. Routing it through `__origin-cri` would not
 help, because the Java supervisor sets that header to the request address it received, the same

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -443,6 +443,47 @@ Still open, and outside this repository's harness:
 - An end-to-end run against a cluster: a Java caller and a UI caller each mid-call while the serving
   node is killed, and a UI mid-call while its gateway node is killed.
 
+## Review fixes (after the merges)
+
+A four-way adversarial review of everything the series landed, one reviewer per area, found the
+defects below; each was traced in the code before it was fixed. All are on one branch on top of the
+merged stack.
+
+- Every TS `invokeStream` ended with a trailing `null`: stompjs yields an empty array, never an
+  absent body, so a stream's bodiless completion reached `EventBus` with data present and was emitted
+  as a value. Since Phase 1. An empty body is now no body where frames become events.
+- A TS stream killed its own connection on its second value: the reply grant was one send per
+  delivered invocation, consumed by the first reply, and the zone rules refuse `reply://`. A reply to
+  a pending invocation's own destination is allowed while it is pending.
+- A lease could fall out of the watcher's node index: `watch` added the id to a set fetched with
+  `computeIfAbsent`, outside the lock, and a concurrent `settle` emptying that set dropped it. The add
+  runs inside `compute`.
+- Reply-consumer collision on reconnect: the reply discriminator was per client instance, so a
+  reconnect within the heartbeat window shared its reply address with the previous socket's consumer
+  and `send` round-robined replies into the dead socket. Minted per connection.
+- A request during a pending `connect()` cached the reply subscription on a null or stale address,
+  which the vm-manager's reconnect loop hit through its heartbeat. `requestStream` requires a
+  connection and an address; `connect()` resets the cache when the address changed.
+- The session touch put a session back that a logout had deleted, because the clustered store only
+  checks versions on an existing entry. The touch reads first and never re-creates.
+- `DefaultRpcServiceProxyHandle.settle()` released the lease before the map entry, so a reply that beat
+  the ack leaked a lease; the reply handler's `containsKey` then `get` could NPE and release the proxy.
+- `SingleValueSubscriber.onNext` rethrowing leaked the in-flight count, so `stop()` waited the full
+  drain; an invocation queued for the worker pool was not counted until it ran.
+- `beforeSave` stamped `lastSeen` on every `VmNode` save, so marking a node UNREACHABLE restarted its
+  reaper clock; only a heartbeat or registration stamps it. `verifyNode` bridged a Mono through a
+  context-less Promise.
+- TS supervisor: a value the converter cannot serialise, an unknown control, and an error reply with
+  no reply-to each became an uncaught exception or a running stream; `connectionLost` fired per failed
+  reconnect attempt; `disconnect()` waited behind a `connect()` that could never settle.
+- A NONE keep-alive connection deleted a login session it had not created; `disconnected()` duplicated
+  `closed()`; membership snapshots could emit out of order.
+
+Not fixed: `cancelRequest` sends the cancel to the request address, which on an unscoped
+multi-instance service may not be the producing instance. Routing it through `__origin-cri` would not
+help, because the Java supervisor sets that header to the request address it received, the same
+shared address. A node-scoped cancel needs the producing node's identity on the stream's replies.
+
 ## Numbering
 
 | Earlier chat numbering | This document |

--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -503,10 +503,18 @@ known defect.
   `putIfAbsent` and removes inline, and the in-flight count is a pair of plain methods. The argument
   tokenizer is a synchronous call with no `block()` on the event loop.
 
-Not fixed: `cancelRequest` sends the cancel to the request address, which on an unscoped
-multi-instance service may not be the producing instance. Routing it through `__origin-cri` would not
-help, because the Java supervisor sets that header to the request address it received, the same
-shared address. A node-scoped cancel needs the producing node's identity on the stream's replies.
+The second review's remaining findings (`Node failure review round two.md`) are fixed on the same
+branch: a cancel is published to every instance of the service, so the one producing the stream gets
+it whichever instance round-robin gave the request; a reply the gateway connection does not owe is
+dropped instead of ending the connection, and a TS service drops results for invocations of a lost
+connection; `VertxFutureRpcReturnValueHandler` completes idempotently; lease keys are qualified per
+connection; a CONNECTION keep-alive touches the session at connect and every quarter of the timeout;
+a control event earns no reply grant; a reused subscription id ends its predecessor; a requester whose
+listener is gone is answered as well as cancelled; VmNode status and allocation are partial updates so
+only a heartbeat writes `lastSeen`, and the reaper takes STOPPING workloads with the rest; the TS
+supervisor stops a synchronous stream on its first unsendable value, answers with the
+`{exceptionName, exceptionClass, errorMessage}` shape every runtime reads, and the vm-manager bounds
+its graceful disconnect on shutdown.
 
 ## Numbering
 

--- a/docs/future-prompts/Node failure review round two.md
+++ b/docs/future-prompts/Node failure review round two.md
@@ -1,0 +1,156 @@
+Second adversarial review of the node-failure series, run after the first round's fixes landed as
+PR #558. Every item below was traced in the code before it was written down; none is fixed yet.
+The TS connection manager and event bus were taken out of this list and reworked directly, so
+nothing here concerns `StompConnectionManager.ts` or `EventBus.ts`. Work the list top down; each
+item names the file, the code, the sequence that misbehaves, and the fix. Add the test each one
+names, or say why the harness cannot express it.
+
+## 1. A refused reply kills the client's connection
+
+`EndpointConnectionHandler.send()` allows a `reply://` send only when `outgoingInvocations.owesReply`
+is true or the authorizer has a grant; `ZoneRules.sendAllowed` never allows the scheme; and
+`DefaultStompServerHandler` answers a failed send with `sendErrorAndDisconnect`. Two ordinary
+sequences reach that path:
+
+- A cancel crossing values in flight. `OutgoingInvocations.cancel()` forgets the invocation before the
+  cancel frame reaches the client, and the values the client already sent sit queued behind the
+  socket's per-frame `pause()`, so the next value is refused. A UI navigating away from a stream does
+  this through `deliver()`'s cancel branch as well.
+- A late reply after a reconnect. A vm-manager finishes an invocation it received on the old socket
+  and sends the reply on the new one, whose `OutgoingInvocations` does not hold it.
+
+Either way the connection dies, `dispose()` fails every invocation it owed, the `srv://`
+registration drops, and Phase 9 marks the node UNREACHABLE.
+
+```java
+// EndpointConnectionHandler.send — a reply this connection does not owe is dropped, not fatal
+if (incomingEvent.cri().scheme().equals(EventConstants.REPLY_DESTINATION_SCHEME)) {
+    if (outgoingInvocations.owesReply(incomingEvent)) {
+        outgoingInvocations.observeReply(incomingEvent);
+        services.eventBusService.send(incomingEvent);
+    } else if (stompAuthorizer.sendAllowed(incomingEvent.cri())) {
+        services.eventBusService.send(incomingEvent);
+    } else {
+        log.debug("Dropping reply to {} for an invocation this connection does not owe", incomingEvent.cri());
+    }
+    return Future.succeededFuture();
+}
+```
+
+```ts
+// ServiceInvocationSupervisor.ts — results of an invocation from a previous connection are not sent
+private connectionGeneration = 0                       // ++ in the connectionLost subscription
+const generation = this.connectionGeneration           // captured in processInvocationRequest
+if (generation !== this.connectionGeneration) { span.end(); return }   // in the result and error callbacks
+```
+
+`EndpointConnectionHandlerTests.testEveryReplyOfAPendingInvocationIsAllowed` asserts the refusal
+today; change it to assert the late reply is not forwarded and the send succeeds.
+
+## 2. A lost-node failure racing a reply releases the whole proxy
+
+```java
+// VertxFutureRpcReturnValueHandler — Vert.x 5 Promise.complete/fail throw when already completed
+promise.complete(rpcResponseConverter.convert(incomingEvent, methodParameter));
+promise.fail(e);
+```
+
+`DefaultRpcServiceProxyHandle.failLost` runs on the request's context and the reply handler on the
+consumer's, so both can reach the same promise. The second throws; the catch calls `promise.fail`
+and throws again; the reply handler's catch calls `release()`. Every other call on the proxy fails
+and every later one refuses, and `@Proxy` beans are singletons. Fix: `tryComplete`/`tryFail` in all
+five places, after which the `catch (IllegalStateException)` in `failLost` is dead. Test: a
+`Future`-returning proxy whose node leaves as the reply arrives keeps serving afterwards.
+
+## 3. Lease keys are the client's own correlation ids
+
+`IncomingInvocations.pin` passes the STOMP client's `correlation-id` header straight into the
+node-wide `RequestLivenessWatcher`. Two connections on one gateway using the same id overwrite each
+other's leases and settle each other's: one hangs when its node dies, the other is failed for a
+node it never used. Prefix the key per connection:
+
+```java
+private final String leasePrefix = UUID.randomUUID() + ":";
+services.requestLivenessWatcher.watch(leasePrefix + correlationId, nodeId, () -> fail(correlationId, destination, nodeId));
+services.requestLivenessWatcher.settle(leasePrefix + correlationId);     // settle() and dispose()
+```
+
+## 4. `SingleValueSubscriber.onComplete` is the unguarded twin of the `onNext` fix
+
+```java
+if(!valueReceived){
+    convertAndSend(incomingMetadata, handlerMethod, null);   // rethrows; no error reply, count never left
+}
+```
+
+Every `Mono<Void>` method takes this path. Mirror `onNext`: catch, `handleException`, `failSpan`,
+`leaveInFlight.run()`, return.
+
+## 5. Full-document `VmNode` writes move `lastSeen` backwards
+
+With the stamp moved into `heartbeat()`, `deployWorkload`, `destroyWorkload`, `markUnreachable` and
+the reaper write back the `lastSeen` they read. A heartbeat inside their read-to-write window is
+overwritten with the older value. It can reap a live node only when two heartbeat intervals exceed
+the timeout (defaults 30 s against 90 s cannot), but the two knobs are set independently on node and
+server. Fix: partial updates for status and allocation through `CrudServiceTemplate.partialUpdateSync`,
+exposed as `VmNodeService.updateStatusSync` and `updateAllocationSync`, so only a heartbeat or a
+registration ever writes `lastSeen`. Also: the reaper skips `STOPPING`, so a workload whose stop
+failed on a dead node stays STOPPING forever; include it.
+
+`WorkloadOrchestrationTest`: the new tests assert on state written by `verifyNode`'s continuation,
+which runs on the `Vertx` context the fix added, while the test asserts on its own thread. Poll for
+the status, and close the `Vertx` instance in `@AfterEach`. Add: marking UNREACHABLE leaves
+`lastSeen` alone; both `registerNode` branches stamp; the reaper takes an UNREACHABLE node OFFLINE.
+
+## 6. Gateway session touch, three small ones
+
+- vertx-core 5.1.6 never flushes the session on a WebSocket upgrade (`completeHandshake` skips the
+  headers-end handlers), so a CONNECTION keep-alive connection's first store write is `T/2` after
+  connect. Call `touchSession()` in `connect()` for CONNECTION mode. The `replyToId` comment saying
+  it is reused across reconnects is false for the same reason; every connect mints one.
+- `lastSessionFlush` advances before the store round trip completes, so in CONNECTION mode one
+  failed flush lands the next on the TTL boundary. Run the timer at `T/4`, or advance on success.
+- A requester's cancel carries a reply-to and is not recorded, so `subscribe()`'s handler adds a
+  one-shot grant nothing consumes. Grant only when the event has no control header.
+
+## 7. Gateway, watch and subscriptions
+
+- A spurious INACTIVE on the first emission of `monitorListenerStatus` (the requester's registration
+  not yet replicated to this node) cancels a healthy stream silently. `OutgoingInvocations.cancel()`
+  should also answer the requester with `RpcServiceUnavailableException`; a requester that is truly
+  gone makes that a silent NO_HANDLERS.
+- `IncomingInvocations.subscribe` overwrites a duplicate subscription id without unregistering the
+  previous consumer, which keeps the reply address ACTIVE after the connection closes. Unregister the
+  one replaced. Same pattern in `EndpointConnectionHandler.subscribe` for the other schemes.
+
+## 8. Core, three small ones
+
+- `ServiceInvocationSupervisor.stop()` fails the streams that exist when it starts; a stream begun by
+  an invocation still draining is never failed. Fail them again once drained.
+- `McpToolInvoker`'s ack-failure path calls `ret.complete` after `pendingCalls.remove` without
+  checking the removal, so an ack timeout after the reply throws. Complete only when this path
+  removed the entry.
+- `DefaultRpcServiceProxyHandle.invoke()` can put into `responseMap` after `release()` scanned it,
+  leaving a request whose reply consumer is gone. Re-check `released` after the put.
+
+## 9. TS supervisor, three small ones
+
+- A synchronous source whose value the converter cannot serialise is not stopped: `subscription` is
+  still null inside `subscribe()`, so one error reply per value goes out plus a completion. Gate on a
+  `failed` flag in `next` and `complete`.
+- `handleException` sends `{message}`; `RpcError.fromEvent` reads the Java `ServiceExceptionWrapper`
+  shape, so a TS-hosted service's errors carry no `exceptionName`. Emit
+  `{exceptionName, exceptionClass, errorMessage}`.
+- vm-manager `shutdown()` awaits a graceful `disconnect()` that on a half-open socket waits for the
+  heartbeat timeout plus the WebSocket close timeout. Bound it and exit.
+
+## 10. Design-level: the unscoped-service cancel miss
+
+`DefaultRpcServiceProxyHandle.cancelRequest` sends the cancel to the request address; with two remote
+instances of an unscoped service and no interleaved traffic, round-robin lands it on the wrong one
+every time. `__origin-cri` is the same shared address, so routing through it changes nothing. The
+proxy's reply address is never INACTIVE while the proxy lives, so a quiet stream leaks its
+`StreamSubscriber`, upstream subscription, address monitor and map entry until the JVM leaves. The
+fix is a per-instance control address: the supervisor listens on
+`srv://<nodeId>@<qualifiedName>/__control`, puts it in `__origin-cri`, and the proxy cancels to the
+origin it saw on the first value. A wire change, to be decided separately.

--- a/docs/future-prompts/Node failure review round two.md
+++ b/docs/future-prompts/Node failure review round two.md
@@ -153,26 +153,19 @@ fix is a per-instance control address: the supervisor listens on
 `srv://<nodeId>@<qualifiedName>/__control`, puts it in `__origin-cri`, and the proxy cancels to the
 origin it saw on the first value. A wire change, to be decided separately.
 
-## 11. Design-level: every invocation of a service runs one at a time
+## 11. Decided: invocations run on the delivery context, and a slow handler hands off itself
 
-`ServiceInvocationSupervisor.listenAt` dispatches with `vertx.executeBlocking(callable)`, whose
-one-argument overload is `executeBlocking(callable, true)`: ordered. Vert.x delivers each event on a
-duplicated context, but a duplicate's ordered tasks share its parent's queue, and the parent is the
-consumer's context, one per supervisor. So the invocations of one service run serially on one worker
-however many nodes call it, while the participant local stays per invocation. Measured with a
-service whose method sleeps 500 ms: four concurrent calls took 2177 ms, all on
-`vert.x-worker-thread-7`; a method that reads `securityContext.currentParticipant()` saw its own
-caller's participant on every call and none for a caller without one.
+`ServiceInvocationSupervisor.listenAt` dispatched with `vertx.executeBlocking(callable)`, whose
+one-argument overload is ordered. Each delivery has its own duplicated context, but a duplicate's
+ordered tasks share the consumer context's queue, so the synchronous slice of every invocation of
+one service (argument parsing, the call, up to the handler returning its `Future`) ran one at a time
+on one worker. Measured with a handler that sleeps 500 ms: four concurrent calls took 2177 ms on
+`vert.x-worker-thread-7`. For a handler that returns a `Future` at once the slice is microseconds,
+which is why a 1k-concurrent load test of `JsonEntitiesService` never showed it; a burst of large
+bodies to one service would have, since the parsing is inside the slice.
 
-```java
-// ServiceInvocationSupervisor.listenAt — today: ordered, one invocation of this service at a time
-vertx.executeBlocking(() -> { ... processEvent(event); ... });
-// concurrent: every invocation on any free worker
-vertx.executeBlocking(() -> { ... processEvent(event); ... }, false);
-```
-
-The one-line change makes every published service re-entrant. A service that relied on the
-serialization without knowing it (a mutable field written by a handler, a non-thread-safe client)
-would start racing, so this is a decision to take across the published services, not a fix to slip
-in. Reactive results already leave the worker after the method returns, so only the synchronous part
-of a handler is serialized today.
+Every `@Publish`ed interface in the tree returns `Future`, `CompletableFuture`, `Mono` or `Flux`, or
+a trivial in-memory value, and every Elasticsearch use is the async client, so the worker hop bought
+nothing. `processEvent` now runs on the delivery context, the same way the proxy has always handled
+replies, and the rule is stated in the platform docs the way Vert.x states it: never block the event
+loop; a slow handler calls `vertx.executeBlocking` inside itself and returns the `Future`.

--- a/docs/future-prompts/Node failure review round two.md
+++ b/docs/future-prompts/Node failure review round two.md
@@ -123,10 +123,8 @@ the status, and close the `Vertx` instance in `@AfterEach`. Add: marking UNREACH
   previous consumer, which keeps the reply address ACTIVE after the connection closes. Unregister the
   one replaced. Same pattern in `EndpointConnectionHandler.subscribe` for the other schemes.
 
-## 8. Core, three small ones
+## 8. Core, two small ones
 
-- `ServiceInvocationSupervisor.stop()` fails the streams that exist when it starts; a stream begun by
-  an invocation still draining is never failed. Fail them again once drained.
 - `McpToolInvoker`'s ack-failure path calls `ret.complete` after `pendingCalls.remove` without
   checking the removal, so an ack timeout after the reply throws. Complete only when this path
   removed the entry.
@@ -154,3 +152,27 @@ proxy's reply address is never INACTIVE while the proxy lives, so a quiet stream
 fix is a per-instance control address: the supervisor listens on
 `srv://<nodeId>@<qualifiedName>/__control`, puts it in `__origin-cri`, and the proxy cancels to the
 origin it saw on the first value. A wire change, to be decided separately.
+
+## 11. Design-level: every invocation of a service runs one at a time
+
+`ServiceInvocationSupervisor.listenAt` dispatches with `vertx.executeBlocking(callable)`, whose
+one-argument overload is `executeBlocking(callable, true)`: ordered. Vert.x delivers each event on a
+duplicated context, but a duplicate's ordered tasks share its parent's queue, and the parent is the
+consumer's context, one per supervisor. So the invocations of one service run serially on one worker
+however many nodes call it, while the participant local stays per invocation. Measured with a
+service whose method sleeps 500 ms: four concurrent calls took 2177 ms, all on
+`vert.x-worker-thread-7`; a method that reads `securityContext.currentParticipant()` saw its own
+caller's participant on every call and none for a caller without one.
+
+```java
+// ServiceInvocationSupervisor.listenAt — today: ordered, one invocation of this service at a time
+vertx.executeBlocking(() -> { ... processEvent(event); ... });
+// concurrent: every invocation on any free worker
+vertx.executeBlocking(() -> { ... processEvent(event); ... }, false);
+```
+
+The one-line change makes every published service re-entrant. A service that relied on the
+serialization without knowing it (a mutable field written by a handler, a non-thread-safe client)
+would start racing, so this is a decision to take across the published services, not a fix to slip
+in. Reactive results already leave the worker after the method returns, so only the synchronous part
+of a handler is serialized today.

--- a/docs/future-prompts/Node failure review round two.md
+++ b/docs/future-prompts/Node failure review round two.md
@@ -1,9 +1,10 @@
-Second adversarial review of the node-failure series, run after the first round's fixes landed as
-PR #558. Every item below was traced in the code before it was written down; none is fixed yet.
+Second adversarial review of the node-failure series, run after the first round's fixes landed on
+PR #558. Every item below was traced in the code before it was written down, and every one is now
+resolved on that same PR: 1 through 9 as written (4 fell out of the supervisor pass), 10 by
+publishing cancels instead of routing them, 11 by dispatching invocations on the delivery context.
 The TS connection manager and event bus were taken out of this list and reworked directly, so
-nothing here concerns `StompConnectionManager.ts` or `EventBus.ts`. Work the list top down; each
-item names the file, the code, the sequence that misbehaves, and the fix. Add the test each one
-names, or say why the harness cannot express it.
+nothing here concerns `StompConnectionManager.ts` or `EventBus.ts`. The items stay as the record of
+what was found and why each fix has the shape it has.
 
 ## 1. A refused reply kills the client's connection
 
@@ -75,7 +76,7 @@ services.requestLivenessWatcher.watch(leasePrefix + correlationId, nodeId, () ->
 services.requestLivenessWatcher.settle(leasePrefix + correlationId);     // settle() and dispose()
 ```
 
-## 4. `SingleValueSubscriber.onComplete` is the unguarded twin of the `onNext` fix
+## 4. `SingleValueSubscriber.onComplete` is the unguarded twin of the `onNext` fix (fixed by the supervisor pass)
 
 ```java
 if(!valueReceived){
@@ -142,7 +143,16 @@ the status, and close the `Vertx` instance in `@AfterEach`. Add: marking UNREACH
 - vm-manager `shutdown()` awaits a graceful `disconnect()` that on a half-open socket waits for the
   heartbeat timeout plus the WebSocket close timeout. Bound it and exit.
 
-## 10. Design-level: the unscoped-service cancel miss
+## 10. Decided: a cancel is published to every instance
+
+The per-instance control address below was the first design; the ack already names the node, but
+Vert.x has no way to send to one node on a shared address and its node selector sees only the
+address, so a node-scoped cancel needs a new address per service per node. A cancel names a UUID
+correlation id, and an instance that does not hold it already ignores it, so the cancel is
+published instead: every instance receives it, the producer acts, nothing else changes on the
+wire. `RpcLivenessTests.testCancelReachesTheInstanceProducingTheStream` pins it.
+
+The original finding, kept for the record:
 
 `DefaultRpcServiceProxyHandle.cancelRequest` sends the cancel to the request address; with two remote
 instances of an unscoped service and no interleaved traffic, round-robin lands it on the wrong one

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
@@ -159,8 +159,7 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
 
     @Override
     public void disconnected() {
-        // we remove the session since the client disconnected on purpose
-        endpointConnectionHandler.removeSession();
+        // closed() follows a DISCONNECT frame and ends the session with the connection
     }
 
     @Override

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -48,6 +48,7 @@ public class EndpointConnectionHandler {
     private ConnectedInfo connectedInfo;
     private StompAuthorizer stompAuthorizer;
     private SessionKeepAliveMode sessionKeepAliveMode = SessionKeepAliveMode.ACTIVITY;
+    private boolean sessionCreatedHere;
     private long sessionTimer = -1;
 
     public EndpointConnectionHandler(Services services) {
@@ -60,6 +61,8 @@ public class EndpointConnectionHandler {
     public Future<MultiMap> handshake(RoutingContext routingContext) {
         session = routingContext.session();
         this.connectedInfo = connectedInfoFromSession();
+        // a session with no login behind it was created for this upgrade
+        sessionCreatedHere = connectedInfo == null;
 
         // vertx-stomp-lite upgrades the request only after this future completes, and the
         // ServerWebSocket it creates keeps the request's header MultiMap for the life of the
@@ -135,7 +138,8 @@ public class EndpointConnectionHandler {
     }
 
     public void removeSession() {
-        if (sessionKeepAliveMode == SessionKeepAliveMode.NONE && session != null) {
+        // a login session the client presented belongs to the browser, not to this connection
+        if (sessionKeepAliveMode == SessionKeepAliveMode.NONE && session != null && sessionCreatedHere) {
             // The Vert.x SessionHandler deletes a destroyed session from the store when the response
             // ends. A WebSocket's response ended at the upgrade, so the store entry is removed here,
             // which keeps a reconnect within the timeout from resuming the session and its replyToId.
@@ -148,7 +152,11 @@ public class EndpointConnectionHandler {
     public Future<Void> send(Event<byte[]> incomingEvent) {
         signalActivity();
 
-        if (!stompAuthorizer.sendAllowed(incomingEvent.cri())) {
+        // a reply to an invocation this client is serving is allowed for as long as the invocation is pending
+        boolean allowed = (incomingEvent.cri().scheme().equals(EventConstants.REPLY_DESTINATION_SCHEME)
+                           && outgoingInvocations.owesReply(incomingEvent))
+                          || stompAuthorizer.sendAllowed(incomingEvent.cri());
+        if (!allowed) {
             return Future.failedFuture(new AuthorizationException("Not Authorized to send to " + incomingEvent.cri()));
         }
 
@@ -243,18 +251,14 @@ public class EndpointConnectionHandler {
 
             EventConsumer eventConsumer = services.eventBusService.listen(cri);
             eventConsumer.handler(event -> {
-                        // If reply-to is set we implicitly allow the subscriber to send a single message to the given destination
-                        // Reply-To is known to be scoped to the sender because there is a check when the system receives the event above
-                        // Ex:
-                        // Device -> subscribes to srv://MAC@device.rpc.channel
-                        // JS Client sends message to Device with a reply to of reply://REPLY_TO_ID@continuum.js.EventBus/replyHandler
-                        //
-                        // When the system receives the message in the send() handler above it verifies the reply-to matches the sender reply to id
-                        // Then we temporarily allow the device to send to the clients reply-to.
-                        // Which will allow the message to be routed back to the client.
+                        // An invocation with a correlation id is pending until its terminal reply, and its
+                        // replies are allowed for that long. Any other event carrying a reply-to gets one
+                        // send to it: the reply-to was verified against the sender's replyToId when the
+                        // event entered through send(), so it can only name the sender's own destination.
+                        boolean pending = outgoingInvocations.deliver(event, subscriptionHandler);
                         String replyTo = event.metadata().get(EventConstants.REPLY_TO_HEADER);
-                        if (replyTo != null) {
-                            // wildcard in the reply to are not allowed since they could bypass security constraints
+                        if (!pending && replyTo != null) {
+                            // a wildcard could match destinations beyond the sender's own
                             if (!replyTo.contains("*")) {
                                 stompAuthorizer.addTemporarySendAllowed(replyTo);
                             } else {
@@ -262,7 +266,6 @@ public class EndpointConnectionHandler {
                                          event);
                             }
                         }
-                        outgoingInvocations.deliver(event, subscriptionHandler);
                         subscriptionHandler.handleEvent(event);
                     })
                     .exceptionHandler(subscriptionHandler::handleError);
@@ -359,18 +362,25 @@ public class EndpointConnectionHandler {
         }
     }
 
+    // The stored copy is refreshed rather than the local one: it carries the version the store expects and
+    // whatever a request on the same cookie has put since. A session the store no longer has, deleted by a
+    // logout or expired, is never written back, because a put with no stored entry would re-create it.
     private void flushSession(Session flushed) {
-        services.sessionStore.put(flushed).onFailure(throwable -> {
-            // a request on the same cookie may have stored a newer version in the meantime; the stored
-            // copy carries the same data, so it is adopted and the touch retried on it once
-            services.sessionStore.get(flushed.id()).onSuccess(stored -> {
-                if (stored != null && session == flushed) {
-                    session = stored;
-                    stored.setAccessed();
-                    services.sessionStore.put(stored)
-                                         .onFailure(retryFailure -> log.warn("Session {} could not be refreshed in the store", stored.id(), retryFailure));
-                }
-            });
+        services.sessionStore.get(flushed.id()).onComplete(ar -> {
+            if (session != flushed) {
+                return;
+            }
+            if (ar.failed()) {
+                log.warn("Session {} could not be read from the store", flushed.id(), ar.cause());
+            } else if (ar.result() == null) {
+                log.debug("Session {} is no longer in the store and is not refreshed", flushed.id());
+            } else {
+                Session stored = ar.result();
+                session = stored;
+                stored.setAccessed();
+                services.sessionStore.put(stored)
+                                     .onFailure(throwable -> log.warn("Session {} could not be refreshed in the store", stored.id(), throwable));
+            }
         });
     }
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -112,8 +112,7 @@ public class EndpointConnectionHandler {
                         new AuthenticationException("A Vert.x session is required unless session keep alive mode is NONE"));
             } else {
                 // The replyToId is generated server side so the client cannot pick a guessable
-                // or colliding value. It is reused for the life of the session so the client's
-                // reply destination stays stable across reconnects.
+                // or colliding value
                 if (connectedInfo.getReplyToId() == null) {
                     connectedInfo.setReplyToId(UUID.randomUUID().toString());
                 }
@@ -124,6 +123,8 @@ public class EndpointConnectionHandler {
 
                 signalActivity();
                 if (sessionKeepAliveMode == SessionKeepAliveMode.CONNECTION) {
+                    // the upgrade response never reaches the store, so the connection's first write is this one
+                    touchSession();
                     startSessionTouchTimer();
                 }
                 ret = Future.succeededFuture(Map.of(EventConstants.CONNECTED_INFO_HEADER,
@@ -152,11 +153,24 @@ public class EndpointConnectionHandler {
     public Future<Void> send(Event<byte[]> incomingEvent) {
         signalActivity();
 
-        // a reply to an invocation this client is serving is allowed for as long as the invocation is pending
-        boolean allowed = (incomingEvent.cri().scheme().equals(EventConstants.REPLY_DESTINATION_SCHEME)
-                           && outgoingInvocations.owesReply(incomingEvent))
-                          || stompAuthorizer.sendAllowed(incomingEvent.cri());
-        if (!allowed) {
+        if (incomingEvent.cri().scheme().equals(EventConstants.REPLY_DESTINATION_SCHEME)) {
+            // A reply is a one-way delivery to the requester's reply destination. It is never invoked and
+            // never itself replies, so no ack and no reply-to validation apply. A reply to an invocation this
+            // client is serving is allowed for as long as the invocation is pending; one for an invocation
+            // this connection no longer holds, such as a value crossing a cancel or a reply finished after a
+            // reconnect, is dropped rather than ending the connection.
+            if (outgoingInvocations.owesReply(incomingEvent)) {
+                outgoingInvocations.observeReply(incomingEvent);
+                services.eventBusService.send(incomingEvent);
+            } else if (stompAuthorizer.sendAllowed(incomingEvent.cri())) {
+                services.eventBusService.send(incomingEvent);
+            } else {
+                log.debug("Dropping reply to {} for an invocation this connection does not owe", incomingEvent.cri());
+            }
+            return Future.succeededFuture();
+        }
+
+        if (!stompAuthorizer.sendAllowed(incomingEvent.cri())) {
             return Future.failedFuture(new AuthorizationException("Not Authorized to send to " + incomingEvent.cri()));
         }
 
@@ -171,6 +185,13 @@ public class EndpointConnectionHandler {
 
                 String correlationId = incomingEvent.metadata().get(EventConstants.CORRELATION_ID_HEADER);
                 incomingInvocations.track(incomingEvent);
+
+                // A control event names a stream by correlation id and is published: the instance producing
+                // the stream is whichever one took the request, and the others ignore an id they do not hold
+                if (incomingEvent.metadata().contains(EventConstants.CONTROL_HEADER)) {
+                    services.eventBusService.publish(incomingEvent);
+                    return Future.succeededFuture();
+                }
 
                 return services.eventBusService
                         .sendWithAck(incomingEvent)
@@ -204,14 +225,6 @@ public class EndpointConnectionHandler {
         } else if (incomingEvent.cri().scheme().equals(EventConstants.STREAM_DESTINATION_SCHEME)) {
 
             return services.eventStreamService.send(incomingEvent);
-
-        } else if (incomingEvent.cri().scheme().equals(EventConstants.REPLY_DESTINATION_SCHEME)) {
-
-            // A reply is a one-way delivery to the requester's reply destination. It is never
-            // invoked and never itself replies, so no ack and no reply-to validation apply.
-            outgoingInvocations.observeReply(incomingEvent);
-            services.eventBusService.send(incomingEvent);
-            return Future.succeededFuture();
 
         } else {
             return Future.failedFuture(new IllegalArgumentException("CRI scheme not supported"));
@@ -257,7 +270,8 @@ public class EndpointConnectionHandler {
                         // event entered through send(), so it can only name the sender's own destination.
                         boolean pending = outgoingInvocations.deliver(event, subscriptionHandler);
                         String replyTo = event.metadata().get(EventConstants.REPLY_TO_HEADER);
-                        if (!pending && replyTo != null) {
+                        // a control event is never answered, so its reply-to earns no grant
+                        if (!pending && replyTo != null && !event.metadata().contains(EventConstants.CONTROL_HEADER)) {
                             // a wildcard could match destinations beyond the sender's own
                             if (!replyTo.contains("*")) {
                                 stompAuthorizer.addTemporarySendAllowed(replyTo);
@@ -270,7 +284,7 @@ public class EndpointConnectionHandler {
                     })
                     .exceptionHandler(subscriptionHandler::handleError);
 
-            subscriptions.put(subscriptionIdentifier, eventConsumer);
+            replaceSubscription(subscriptionIdentifier, eventConsumer);
 
             log.debug("New Service Subscription cri: {} id: {} for login: {}",
                       cri.raw(),
@@ -284,7 +298,7 @@ public class EndpointConnectionHandler {
             eventConsumer.handler(subscriptionHandler::handleEvent)
                          .exceptionHandler(subscriptionHandler::handleError);
 
-            subscriptions.put(subscriptionIdentifier, eventConsumer);
+            replaceSubscription(subscriptionIdentifier, eventConsumer);
 
             log.debug("New Event Subscription cri: {} id: {} for login: {}",
                       cri.raw(),
@@ -317,6 +331,14 @@ public class EndpointConnectionHandler {
             } else {
                 log.debug("No subscription exists for subscriptionIdentifier: {}", subscriptionIdentifier);
             }
+        }
+    }
+
+    // a subscription id the client reuses ends the consumer it named before
+    private void replaceSubscription(String subscriptionIdentifier, EventConsumer eventConsumer) {
+        EventConsumer previous = subscriptions.put(subscriptionIdentifier, eventConsumer);
+        if (previous != null) {
+            previous.unregister();
         }
     }
 
@@ -389,7 +411,8 @@ public class EndpointConnectionHandler {
             log.error("Session-touch timer already started");
             throw new IllegalStateException("Internal server error");
         }
-        long sessionUpdateInterval = services.apiGatewayProperties.getSessionTimeout() / 2;
+        // a quarter of the timeout, so a flush that fails is retried before the stored copy expires
+        long sessionUpdateInterval = services.apiGatewayProperties.getSessionTimeout() / 4;
         sessionTimer = services.vertx.setPeriodic(sessionUpdateInterval, event -> {
             if (session == null) {
                 log.error("Session is null while session-touch timer is active");

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/IncomingInvocations.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/IncomingInvocations.java
@@ -12,6 +12,7 @@ import org.kinotic.gateway.internal.endpoints.Services;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Invocations the client on this connection has sent to the cluster and is waiting on. Each one is pinned
@@ -25,6 +26,8 @@ import java.util.Map;
 public class IncomingInvocations {
 
     private final Services services;
+    // correlation ids are the client's own, so the node-wide lease key is qualified per connection
+    private final String leasePrefix = UUID.randomUUID() + ":";
     private final Map<String, EventConsumer> replySubscriptions = new HashMap<>();
     // pending invocations by correlation id; only ever touched on the connection's event loop
     private final Map<String, Metadata> invocations = new HashMap<>();
@@ -44,7 +47,11 @@ public class IncomingInvocations {
                          subscriptionHandler.handleEvent(event);
                      })
                      .exceptionHandler(subscriptionHandler::handleError);
-        replySubscriptions.put(subscriptionIdentifier, eventConsumer);
+        // a subscription id the client reuses ends the consumer it named before
+        EventConsumer previous = replySubscriptions.put(subscriptionIdentifier, eventConsumer);
+        if (previous != null) {
+            previous.unregister();
+        }
     }
 
     /**
@@ -82,7 +89,7 @@ public class IncomingInvocations {
         if (correlationId != null) {
             // the reply can arrive before the ack; computeIfPresent then does nothing
             invocations.computeIfPresent(correlationId, (_, replyMetadata) -> {
-                services.requestLivenessWatcher.watch(correlationId, nodeId, () -> fail(correlationId, destination, nodeId));
+                services.requestLivenessWatcher.watch(leasePrefix + correlationId, nodeId, () -> fail(correlationId, destination, nodeId));
                 return replyMetadata;
             });
         }
@@ -93,7 +100,7 @@ public class IncomingInvocations {
      */
     public void settle(String correlationId) {
         if (correlationId != null && invocations.remove(correlationId) != null) {
-            services.requestLivenessWatcher.settle(correlationId);
+            services.requestLivenessWatcher.settle(leasePrefix + correlationId);
         }
     }
 
@@ -101,7 +108,7 @@ public class IncomingInvocations {
      * Releases every pending invocation and unsubscribes every reply destination.
      */
     public void dispose() {
-        invocations.keySet().forEach(services.requestLivenessWatcher::settle);
+        invocations.keySet().forEach(correlationId -> services.requestLivenessWatcher.settle(leasePrefix + correlationId));
         invocations.clear();
         replySubscriptions.values().forEach(EventConsumer::unregister);
         replySubscriptions.clear();

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/OutgoingInvocations.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/OutgoingInvocations.java
@@ -40,8 +40,10 @@ public class OutgoingInvocations {
      * names. An invocation without a correlation id or reply-to expects no reply and is not recorded.
      * @param event the invocation
      * @param subscriptionHandler the subscription it is delivered through; a cancel goes back through the same one
+     * @return true when the invocation is now pending, so its replies are allowed until the terminal one
      */
-    public void deliver(Event<byte[]> event, StompSubscriptionHandler subscriptionHandler) {
+    public boolean deliver(Event<byte[]> event, StompSubscriptionHandler subscriptionHandler) {
+        boolean ret = false;
         Metadata metadata = event.metadata();
         String correlationId = metadata.get(EventConstants.CORRELATION_ID_HEADER);
         if (correlationId != null) {
@@ -49,14 +51,26 @@ public class OutgoingInvocations {
             if (control == null) {
                 if (metadata.contains(EventConstants.REPLY_TO_HEADER)) {
                     invocations.put(correlationId, new OutgoingInvocation(event.cri(),
-                                                                                       EventUtil.replyMetadataOf(metadata),
-                                                                                       subscriptionHandler,
-                                                                                       services.vertx.getOrCreateContext()));
+                                                                          EventUtil.replyMetadataOf(metadata),
+                                                                          subscriptionHandler,
+                                                                          services.vertx.getOrCreateContext()));
+                    ret = true;
                 }
             } else if (EventConstants.CONTROL_VALUE_CANCEL.equals(control)) {
                 forget(correlationId);
             }
         }
+        return ret;
+    }
+
+    /**
+     * @return true when the reply answers a pending invocation and is addressed to that invocation's
+     * reply destination
+     */
+    public boolean owesReply(Event<byte[]> reply) {
+        OutgoingInvocation invocation = invocations.get(reply.metadata().get(EventConstants.CORRELATION_ID_HEADER));
+        return invocation != null
+                && reply.cri().raw().equals(CRI.create(invocation.replyMetadata().get(EventConstants.REPLY_TO_HEADER)).raw());
     }
 
     /**

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/OutgoingInvocations.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/OutgoingInvocations.java
@@ -123,7 +123,9 @@ public class OutgoingInvocations {
                                   throwable -> log.warn("Requester watch for invocation {} failed", correlationId, throwable));
     }
 
-    // the requester is gone: forget the invocation and tell the client to stop the stream
+    // Nothing listens on the requester's reply destination: forget the invocation and tell the client to stop
+    // the stream. The requester is answered too, so one whose registration this node had not seen yet gets
+    // the error instead of silence; a requester that is gone drops it with the rest.
     private void cancel(String correlationId) {
         OutgoingInvocation invocation = invocations.get(correlationId);
         if (invocation != null) {
@@ -131,6 +133,13 @@ public class OutgoingInvocations {
             Metadata metadata = Metadata.create(Map.of(EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_CANCEL,
                                                        EventConstants.CORRELATION_ID_HEADER, correlationId));
             invocation.subscriptionHandler().handleEvent(Event.create(invocation.cri(), metadata, null));
+            RpcServiceUnavailableException cause = new RpcServiceUnavailableException(
+                    "No listener on the reply destination of the stream");
+            try {
+                services.eventBusService.send(services.exceptionConverter.convert(invocation.replyMetadata(), cause));
+            } catch (Exception e) {
+                log.error("Could not answer invocation {} after its requester stopped listening", correlationId, e);
+            }
         }
     }
 

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandlerTests.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandlerTests.java
@@ -36,6 +36,7 @@ import org.kinotic.gateway.api.config.ApiGatewayProperties;
 import org.kinotic.gateway.internal.endpoints.Services;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.ObjectProvider;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -51,6 +52,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -262,6 +264,44 @@ public class EndpointConnectionHandlerTests {
         // the cancelled invocation is no longer owed: the forwarded value is the only send, the close adds none
         handler.shutdown();
         verify(eventBusService).send(any());
+    }
+
+    @Test
+    public void testEveryReplyOfAPendingInvocationIsAllowed() throws Exception {
+        when(eventBusService.monitorListenerStatus(any())).thenReturn(Flux.just(ListenerStatus.ACTIVE));
+        EndpointConnectionHandler handler = connect(Map.of());
+        String requester = EventConstants.REPLY_DESTINATION_SCHEME + "://other:replies@kinotic.js.EventBus/replyHandler";
+        deliverInvocation(handler, requester, "inv-4");
+
+        // two stream values, then the completion
+        for (int i = 0; i < 2; i++) {
+            Metadata valueMetadata = Metadata.create(Map.of(EventConstants.CORRELATION_ID_HEADER, "inv-4"));
+            handler.send(Event.create(CRI.create(requester), valueMetadata, new byte[0])).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+        Metadata completion = Metadata.create(Map.of(EventConstants.CORRELATION_ID_HEADER, "inv-4",
+                                                     EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_COMPLETE));
+        handler.send(Event.create(CRI.create(requester), completion, new byte[0])).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        verify(eventBusService, times(3)).send(any());
+
+        // the invocation is over: a further reply to the requester is refused
+        Metadata late = Metadata.create(Map.of(EventConstants.CORRELATION_ID_HEADER, "inv-4"));
+        Assertions.assertTrue(handler.send(Event.create(CRI.create(requester), late, new byte[0])).failed());
+    }
+
+    @Test
+    public void testSessionDeletedFromTheStoreIsNotRecreatedByTheTouch() throws Exception {
+        Session session = services.sessionStore.createSession(SESSION_TIMEOUT_MS * 10);
+        services.sessionStore.put(session).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        EndpointConnectionHandler handler = connect(session, Map.of());
+        // connect() touched the session; let that write land before the delete
+        Thread.sleep(300);
+
+        // a logout deletes the session; the connection's next touch must not put it back
+        services.sessionStore.delete(session.id()).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        Thread.sleep(SESSION_TIMEOUT_MS / 4 + 50);
+        handler.unsubscribe("none");
+        Thread.sleep(500);
+        Assertions.assertNull(storedSession(session.id()), "the touch re-created a deleted session");
     }
 
     @Test

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandlerTests.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandlerTests.java
@@ -44,12 +44,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.endsWith;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -141,7 +144,7 @@ public class EndpointConnectionHandlerTests {
         handler.send(request(replyTo, "corr-1")).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
         ArgumentCaptor<Runnable> onLost = ArgumentCaptor.forClass(Runnable.class);
-        verify(requestLivenessWatcher).watch(eq("corr-1"), eq("node-2"), onLost.capture());
+        verify(requestLivenessWatcher).watch(endsWith(":corr-1"), eq("node-2"), onLost.capture());
         onLost.getValue().run();
 
         ArgumentCaptor<Event<byte[]>> sent = ArgumentCaptor.forClass(Event.class);
@@ -161,13 +164,13 @@ public class EndpointConnectionHandlerTests {
         // the subscription handler the test installed receives what the reply consumer delivers
         handler.send(request(replyTo, "corr-2")).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
         ArgumentCaptor<Runnable> onLost = ArgumentCaptor.forClass(Runnable.class);
-        verify(requestLivenessWatcher).watch(eq("corr-2"), eq("node-2"), onLost.capture());
+        verify(requestLivenessWatcher).watch(endsWith(":corr-2"), eq("node-2"), onLost.capture());
 
         Metadata replyMetadata = Metadata.create(Map.of(EventConstants.CORRELATION_ID_HEADER, "corr-2",
                                                         EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_COMPLETE));
         replyDelivery.get().handle(Event.create(CRI.create(replyTo), replyMetadata, new byte[0]));
 
-        verify(requestLivenessWatcher).settle("corr-2");
+        verify(requestLivenessWatcher).settle(endsWith(":corr-2"));
         // a node loss reported after the reply has nothing left to answer
         onLost.getValue().run();
         verify(eventBusService, never()).send(any());
@@ -181,7 +184,7 @@ public class EndpointConnectionHandlerTests {
 
         handler.shutdown();
 
-        verify(requestLivenessWatcher).settle("corr-3");
+        verify(requestLivenessWatcher).settle(endsWith(":corr-3"));
         verify(replyConsumer).unregister();
     }
 
@@ -250,20 +253,26 @@ public class EndpointConnectionHandlerTests {
         verify(eventBusService).monitorListenerStatus(watched.capture());
         Assertions.assertEquals(requester, watched.getValue().raw());
 
+        // the requester's answer is written on the connection's context, after the cancel frame
+        CountDownLatch answered = new CountDownLatch(1);
+        doAnswer(_ -> { answered.countDown(); return null; }).when(eventBusService).send(any());
         requesterStatus.tryEmitNext(ListenerStatus.INACTIVE);
-        long deadline = System.currentTimeMillis() + 5000;
-        while (delivered.size() < 2 && System.currentTimeMillis() < deadline) {
-            Thread.sleep(50);
-        }
+        Assertions.assertTrue(answered.await(5, TimeUnit.SECONDS), "the requester was never answered");
         Assertions.assertEquals(2, delivered.size(), "no cancel reached the connection");
         Event<byte[]> cancel = delivered.get(1);
         Assertions.assertEquals(SERVICE_DESTINATION, cancel.cri().raw());
         Assertions.assertEquals(EventConstants.CONTROL_VALUE_CANCEL, cancel.metadata().get(EventConstants.CONTROL_HEADER));
         Assertions.assertEquals("inv-3", cancel.metadata().get(EventConstants.CORRELATION_ID_HEADER));
 
-        // the cancelled invocation is no longer owed: the forwarded value is the only send, the close adds none
+        // the requester is answered with the typed error, so one whose registration this node had not seen
+        // yet learns the stream is over; the cancelled invocation is no longer owed, so the close adds nothing
         handler.shutdown();
-        verify(eventBusService).send(any());
+        ArgumentCaptor<Event<byte[]>> sent = ArgumentCaptor.forClass(Event.class);
+        verify(eventBusService, times(2)).send(sent.capture());
+        Event<byte[]> answer = sent.getAllValues().get(1);
+        Assertions.assertEquals(requester, answer.cri().raw());
+        Assertions.assertEquals("inv-3", answer.metadata().get(EventConstants.CORRELATION_ID_HEADER));
+        Assertions.assertNotNull(answer.metadata().get(EventConstants.ERROR_HEADER));
     }
 
     @Test
@@ -283,9 +292,101 @@ public class EndpointConnectionHandlerTests {
         handler.send(Event.create(CRI.create(requester), completion, new byte[0])).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
         verify(eventBusService, times(3)).send(any());
 
-        // the invocation is over: a further reply to the requester is refused
+        // the invocation is over: a further reply to the requester is dropped, and the connection lives on
         Metadata late = Metadata.create(Map.of(EventConstants.CORRELATION_ID_HEADER, "inv-4"));
-        Assertions.assertTrue(handler.send(Event.create(CRI.create(requester), late, new byte[0])).failed());
+        Assertions.assertTrue(handler.send(Event.create(CRI.create(requester), late, new byte[0])).succeeded());
+        verify(eventBusService, times(3)).send(any());
+    }
+
+    @Test
+    public void testControlEventEarnsNoReplyGrant() throws Exception {
+        EndpointConnectionHandler handler = connect(Map.of());
+        String requester = EventConstants.REPLY_DESTINATION_SCHEME + "://other:replies@kinotic.js.EventBus/replyHandler";
+        List<Event<byte[]>> delivered = new ArrayList<>();
+        handler.subscribe(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0"), "svc-1", new StompSubscriptionHandler() {
+            @Override
+            public void handleEvent(Event<byte[]> event) {
+                delivered.add(event);
+            }
+
+            @Override
+            public void handleError(Throwable throwable) {}
+        });
+        // a requester's cancel names a stream this connection never held; it carries a reply-to like every request
+        Metadata cancel = Metadata.create(Map.of(EventConstants.REPLY_TO_HEADER, requester,
+                                                 EventConstants.CORRELATION_ID_HEADER, "inv-5",
+                                                 EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_CANCEL));
+        replyDelivery.get().handle(Event.create(CRI.create(SERVICE_DESTINATION), cancel, null));
+        Assertions.assertEquals(1, delivered.size());
+
+        // nothing is owed to that requester and the cancel granted nothing, so a reply to it goes nowhere
+        Metadata reply = Metadata.create(Map.of(EventConstants.CORRELATION_ID_HEADER, "inv-5"));
+        Assertions.assertTrue(handler.send(Event.create(CRI.create(requester), reply, new byte[0])).succeeded());
+        verify(eventBusService, never()).send(any());
+    }
+
+    @Test
+    public void testClientCancelIsPublishedToEveryInstance() throws Exception {
+        EndpointConnectionHandler handler = connect(Map.of());
+        String replyTo = subscribeReplies(handler);
+        handler.send(request(replyTo, "inv-6")).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        Metadata metadata = Metadata.create(Map.of(EventConstants.REPLY_TO_HEADER, replyTo,
+                                                   EventConstants.CORRELATION_ID_HEADER, "inv-6",
+                                                   EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_CANCEL));
+        handler.send(Event.create(CRI.create(SERVICE_DESTINATION), metadata, null)).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        // the request went to one instance; the cancel reaches all of them and settles the lease
+        verify(eventBusService, times(1)).sendWithAck(any());
+        ArgumentCaptor<Event<byte[]>> published = ArgumentCaptor.forClass(Event.class);
+        verify(eventBusService).publish(published.capture());
+        Assertions.assertEquals(EventConstants.CONTROL_VALUE_CANCEL, published.getValue().metadata().get(EventConstants.CONTROL_HEADER));
+        verify(requestLivenessWatcher).settle(endsWith(":inv-6"));
+    }
+
+    @Test
+    public void testLeasesAreQualifiedPerConnection() throws Exception {
+        EndpointConnectionHandler first = connect(Map.of());
+        EndpointConnectionHandler second = connect(Map.of());
+        String firstReplyTo = subscribeReplies(first);
+        String secondReplyTo = subscribeReplies(second);
+
+        // two clients on one gateway using the same correlation id
+        first.send(request(firstReplyTo, "dup")).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        second.send(request(secondReplyTo, "dup")).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        ArgumentCaptor<String> leases = ArgumentCaptor.forClass(String.class);
+        verify(requestLivenessWatcher, times(2)).watch(leases.capture(), eq("node-2"), any());
+        Assertions.assertNotEquals(leases.getAllValues().get(0), leases.getAllValues().get(1));
+
+        // the first client's terminal reply settles its own lease only
+        Metadata completion = Metadata.create(Map.of(EventConstants.CORRELATION_ID_HEADER, "dup",
+                                                     EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_COMPLETE));
+        replyDelivery.get().handle(Event.create(CRI.create(secondReplyTo), completion, new byte[0]));
+        verify(requestLivenessWatcher, times(1)).settle(any());
+        verify(requestLivenessWatcher).settle(leases.getAllValues().get(1));
+    }
+
+    @Test
+    public void testReusedSubscriptionIdEndsThePreviousConsumer() throws Exception {
+        EndpointConnectionHandler handler = connect(Map.of());
+        subscribeReplies(handler);
+        subscribeReplies(handler);
+        verify(replyConsumer, times(1)).unregister();
+    }
+
+    @Test
+    public void testConnectionKeepAliveTouchesTheSessionAtConnect() throws Exception {
+        Session session = services.sessionStore.createSession(SESSION_TIMEOUT_MS * 10);
+        services.sessionStore.put(session).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        long storedBefore = storedSession(session.id()).lastAccessed();
+        Thread.sleep(20);
+
+        connect(session, Map.of(EventConstants.SESSION_KEEP_ALIVE_HEADER, "CONNECTION"));
+        long deadline = System.currentTimeMillis() + 5000;
+        while (storedSession(session.id()).lastAccessed() == storedBefore && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        Assertions.assertTrue(storedSession(session.id()).lastAccessed() > storedBefore, "the connect never reached the store");
     }
 
     @Test

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/KinoticIgniteClusterManager.java
@@ -187,13 +187,14 @@ public class KinoticIgniteClusterManager extends IgniteClusterManager {
         });
     }
 
-    // The snapshot is taken on the calling thread and emitted on the delivery context; a seed queued
-    // behind a membership event must not overwrite that event's newer snapshot with its stale one
+    // The snapshot is taken on the delivery context, where emissions are serialised, so two membership
+    // events handled on different worker threads cannot emit their snapshots out of order; a seed queued
+    // behind a membership event does not overwrite that event's snapshot
     private void emitClusterNodes(boolean seed) {
-        Set<String> nodes = Set.copyOf(getNodes());
         deliveryContext().runOnContext(v -> {
             if(!seed || !clusterNodesEmitted){
                 clusterNodesEmitted = true;
+                Set<String> nodes = Set.copyOf(getNodes());
                 Sinks.EmitResult result = clusterNodesSink.tryEmitNext(nodes);
                 if(result.isFailure()){
                     log.warn("Failed to emit cluster nodes {}: {}", nodes, result);

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/DefaultRequestLivenessWatcher.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/DefaultRequestLivenessWatcher.java
@@ -63,7 +63,13 @@ public class DefaultRequestLivenessWatcher implements RequestLivenessWatcher {
     @Override
     public void watch(String correlationId, String nodeId, Runnable onLost) {
         leases.put(correlationId, new Lease(nodeId, onLost, vertx.getOrCreateContext()));
-        correlationIdsByNode.computeIfAbsent(nodeId, _ -> ConcurrentHashMap.newKeySet()).add(correlationId);
+        // the add runs under the key's lock, so a concurrent settle() emptying and dropping this node's set
+        // cannot leave the id in a set that is no longer in the map
+        correlationIdsByNode.compute(nodeId, (_, correlationIds) -> {
+            Set<String> ret = correlationIds != null ? correlationIds : ConcurrentHashMap.newKeySet();
+            ret.add(correlationId);
+            return ret;
+        });
         // The node may have left between the acknowledgement and this call; the latest snapshot decides,
         // and membershipChanged catches a departure that lands while this method runs
         Set<String> current = members;
@@ -76,10 +82,7 @@ public class DefaultRequestLivenessWatcher implements RequestLivenessWatcher {
     public void settle(String correlationId) {
         Lease lease = leases.remove(correlationId);
         if(lease != null){
-            correlationIdsByNode.computeIfPresent(lease.nodeId(), (_, correlationIds) -> {
-                correlationIds.remove(correlationId);
-                return correlationIds.isEmpty() ? null : correlationIds;
-            });
+            unindex(lease.nodeId(), correlationId);
         }
     }
 
@@ -109,8 +112,16 @@ public class DefaultRequestLivenessWatcher implements RequestLivenessWatcher {
     private void lose(String correlationId) {
         Lease lease = leases.remove(correlationId);
         if(lease != null){
+            unindex(lease.nodeId(), correlationId);
             lease.context().runOnContext(_ -> lease.onLost().run());
         }
+    }
+
+    private void unindex(String nodeId, String correlationId) {
+        correlationIdsByNode.computeIfPresent(nodeId, (_, correlationIds) -> {
+            correlationIds.remove(correlationId);
+            return correlationIds.isEmpty() ? null : correlationIds;
+        });
     }
 
     private record Lease(String nodeId, Runnable onLost, Context context) {}

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -160,17 +160,15 @@ public class ServiceInvocationSupervisor {
 
     private EventConsumer listenAt(CRI cri){
         EventConsumer consumer = eventBusService.listen(cri);
+        // Runs on the delivery's context: a handler that is slow hands off inside itself and returns a
+        // Future, the same contract Vert.x sets for an event loop
         consumer.handler(event -> {
-                    // counted at dispatch, so an event still queued for the worker pool holds stop()'s drain
-                    Runnable leaveInFlight = enterInFlight();
-                    vertx.executeBlocking(() -> {
-                        try {
-                            processEvent(event);
-                        } finally {
-                            leaveInFlight.run();
-                        }
-                        return null;
-                    });
+                    enterInFlight();
+                    try {
+                        processEvent(event);
+                    } finally {
+                        leaveInFlight();
+                    }
                 })
                 .exceptionHandler(throwable -> log.error("Event listener error", throwable))
                 // Vert.x invokes the end handler on every unregistration, including the one stop() performs.
@@ -231,21 +229,18 @@ public class ServiceInvocationSupervisor {
         }
     }
 
-    /**
-     * Counts an invocation as in flight until the returned callback runs; running it more than once has no
-     * further effect.
-     */
-    private Runnable enterInFlight(){
+    private void enterInFlight(){
         inFlight.incrementAndGet();
-        AtomicBoolean left = new AtomicBoolean(false);
-        return () -> {
-            if(left.compareAndSet(false, true) && inFlight.decrementAndGet() == 0){
-                Promise<Void> drainedPromise = drained;
-                if(drainedPromise != null){
-                    drainedPromise.tryComplete();
-                }
+    }
+
+    // The last invocation out completes the drain stop() is waiting on; before stop() there is no promise
+    private void leaveInFlight(){
+        if(inFlight.decrementAndGet() == 0){
+            Promise<Void> drainedPromise = drained;
+            if(drainedPromise != null){
+                drainedPromise.tryComplete();
             }
-        };
+        }
     }
 
     private Map<String, HandlerMethod> buildMethodMap(ServiceDescriptor serviceDescriptor,
@@ -330,10 +325,11 @@ public class ServiceInvocationSupervisor {
         String correlationId = incomingEvent.metadata().get(EventConstants.CORRELATION_ID_HEADER);
         Validate.notNull(correlationId, "Streaming control plain messages require a CORRELATION_ID_HEADER to be set");
 
-        activeStreamingResults.computeIfPresent(correlationId, (_, streamSubscriber) -> {
+        // outside the map's lock: a cancel ends the stream, whose hookFinally removes this entry
+        StreamSubscriber streamSubscriber = activeStreamingResults.get(correlationId);
+        if(streamSubscriber != null){
             streamSubscriber.processControlEvent(incomingEvent);
-            return streamSubscriber;
-        });
+        }
     }
 
     private void processEvent(Event<byte[]> incomingEvent){
@@ -464,7 +460,9 @@ public class ServiceInvocationSupervisor {
             if(!reactiveAdapter.isMultiValue()){
 
                 Publisher<?> publisher = reactiveAdapter.toPublisher(result);
-                publisher.subscribe(new SingleValueSubscriber(incomingMetadata, handlerMethod, incomingEvent, span, enterInFlight()));
+                // the reply is produced after this call returns, so the invocation stays in flight until then
+                enterInFlight();
+                publisher.subscribe(new SingleValueSubscriber(incomingMetadata, handlerMethod, incomingEvent, span));
 
             }else{
 
@@ -475,20 +473,17 @@ public class ServiceInvocationSupervisor {
 
                 String correlationId = incomingEvent.metadata().get(EventConstants.CORRELATION_ID_HEADER);
 
-                StreamSubscriber streamSubscriber = activeStreamingResults.computeIfAbsent(correlationId, _ -> {
-                    Flux<?> flux = Flux.from(reactiveAdapter.toPublisher(result));
+                CRI replyCRI = CRI.create(incomingEvent.metadata().get(EventConstants.REPLY_TO_HEADER));
+                Flux<ListenerStatus> replyListenerStatus = eventBusService.monitorListenerStatus(replyCRI);
+                StreamSubscriber streamSubscriber = new StreamSubscriber(incomingMetadata, handlerMethod, replyListenerStatus, incomingEvent.cri().raw(), span);
 
-                    CRI replyCRI = CRI.create(incomingEvent.metadata().get(EventConstants.REPLY_TO_HEADER));
-                    Flux<ListenerStatus> replyListenerStatus = eventBusService.monitorListenerStatus(replyCRI);
-
-                    StreamSubscriber subscriber = new StreamSubscriber(incomingMetadata, handlerMethod, replyListenerStatus, incomingEvent.cri().raw(), span);
-                    flux.subscribe(subscriber);
-                    return subscriber;
-                });
                 // a second request reusing a live stream's correlation id is answered with the error, not dropped
-                if(streamSubscriber.incomingMetadata != incomingMetadata){
+                if(activeStreamingResults.putIfAbsent(correlationId, streamSubscriber) != null){
                     throw new IllegalArgumentException("A stream with correlationId " + correlationId + " is already in progress");
                 }
+                // registered before subscribing, and subscribed outside the map's lock: control events for the
+                // stream arrive on this same context, and a synchronous source ends inside subscribe
+                Flux.from(reactiveAdapter.toPublisher(result)).subscribe(streamSubscriber);
             }
         }
     }
@@ -556,17 +551,15 @@ public class ServiceInvocationSupervisor {
         private final HandlerMethod handlerMethod;
         private final Event<byte[]> incomingEvent;
         private final Span span;
-        private final Runnable leaveInFlight;
         private Subscription subscription;
         private boolean valueReceived = false;
-        private boolean failed = false;
+        private boolean done = false;
 
-        public SingleValueSubscriber(Metadata incomingMetadata, HandlerMethod handlerMethod, Event<byte[]> incomingEvent, Span span, Runnable leaveInFlight) {
+        public SingleValueSubscriber(Metadata incomingMetadata, HandlerMethod handlerMethod, Event<byte[]> incomingEvent, Span span) {
             this.incomingMetadata = incomingMetadata;
             this.handlerMethod = handlerMethod;
             this.incomingEvent = incomingEvent;
             this.span = span;
-            this.leaveInFlight = leaveInFlight;
         }
 
         @Override
@@ -587,11 +580,18 @@ public class ServiceInvocationSupervisor {
             try {
                 convertAndSend(incomingMetadata, handlerMethod, value);
             } catch (Exception e) {
-                failed = true;
                 handleException(incomingMetadata, e);
                 failSpan(span, e);
-                leaveInFlight.run();
+                finish();
                 subscription.cancel();
+            }
+        }
+
+        // A Publisher from user code may signal twice; the invocation leaves the in-flight count once
+        private void finish() {
+            if(!done){
+                done = true;
+                leaveInFlight();
             }
         }
 
@@ -604,7 +604,7 @@ public class ServiceInvocationSupervisor {
             }
             handleException(incomingMetadata, t);
             failSpan(span, t);
-            leaveInFlight.run();
+            finish();
         }
 
         @Override
@@ -612,9 +612,9 @@ public class ServiceInvocationSupervisor {
             if(!valueReceived){
                 reply(null);
             }
-            if(!failed){
+            if(!done){
                 span.end();
-                leaveInFlight.run();
+                finish();
             }
         }
     }
@@ -724,13 +724,7 @@ public class ServiceInvocationSupervisor {
 
             replyListenerStatusSubscriber.cancel();
 
-            String correlationId = incomingMetadata.get(EventConstants.CORRELATION_ID_HEADER);
-            // we must do this in a background thread since if the flux is created like Flux.just this will be executed in the same thread as the invocation
-            // and hence inside the activeStreamingResults.computeIfAbsent block
-            vertx.executeBlocking(() -> {
-                activeStreamingResults.remove(correlationId);
-                return null;
-            });
+            activeStreamingResults.remove(incomingMetadata.get(EventConstants.CORRELATION_ID_HEADER));
         }
 
         @Override

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -199,11 +199,8 @@ public class ServiceInvocationSupervisor {
                 unregistered = Future.all(unregistered, unscopedInvocationEventConsumer.unregister()).mapEmpty();
             }
 
-            // A stream's caller is still listening, so it gets a terminal error rather than a silent cancel
             String serviceName = serviceDescriptor.serviceIdentifier().qualifiedName();
-            for(StreamSubscriber streamSubscriber : activeStreamingResults.values()){
-                streamSubscriber.fail(new RpcServiceUnavailableException("Service " + serviceName + " stopped while producing the stream"));
-            }
+            failActiveStreams(serviceName);
 
             Promise<Void> drainedPromise = Promise.promise();
             drained = drainedPromise;
@@ -217,9 +214,20 @@ public class ServiceInvocationSupervisor {
             });
             return Future.all(unregistered, drainedPromise.future())
                          .<Void>mapEmpty()
-                         .andThen(_ -> vertx.cancelTimer(timer));
+                         .andThen(_ -> {
+                             vertx.cancelTimer(timer);
+                             // an invocation that was draining may have started a stream since the first pass
+                             failActiveStreams(serviceName);
+                         });
         }else{
             return Future.failedFuture(new IllegalStateException("Service already stopped"));
+        }
+    }
+
+    // A stream's caller is still listening, so it gets a terminal error rather than a silent cancel
+    private void failActiveStreams(String serviceName){
+        for(StreamSubscriber streamSubscriber : activeStreamingResults.values()){
+            streamSubscriber.fail(new RpcServiceUnavailableException("Service " + serviceName + " stopped while producing the stream"));
         }
     }
 
@@ -313,7 +321,7 @@ public class ServiceInvocationSupervisor {
             Event<byte[]> convertedEvent = exceptionConverter.convert(incomingMetadata, e);
             eventBusService.send(convertedEvent);
         } catch (Exception ex) {
-            log.error("Error occurred when calling exception converter",e);
+            log.error("Error occurred when calling exception converter for {}", e.toString(), ex);
         }
     }
 
@@ -467,16 +475,20 @@ public class ServiceInvocationSupervisor {
 
                 String correlationId = incomingEvent.metadata().get(EventConstants.CORRELATION_ID_HEADER);
 
-                activeStreamingResults.computeIfAbsent(correlationId, _ -> {
+                StreamSubscriber streamSubscriber = activeStreamingResults.computeIfAbsent(correlationId, _ -> {
                     Flux<?> flux = Flux.from(reactiveAdapter.toPublisher(result));
 
                     CRI replyCRI = CRI.create(incomingEvent.metadata().get(EventConstants.REPLY_TO_HEADER));
                     Flux<ListenerStatus> replyListenerStatus = eventBusService.monitorListenerStatus(replyCRI);
 
-                    StreamSubscriber streamSubscriber = new StreamSubscriber(incomingMetadata, handlerMethod, replyListenerStatus, incomingEvent.cri().raw(), span);
-                    flux.subscribe(streamSubscriber);
-                    return streamSubscriber;
+                    StreamSubscriber subscriber = new StreamSubscriber(incomingMetadata, handlerMethod, replyListenerStatus, incomingEvent.cri().raw(), span);
+                    flux.subscribe(subscriber);
+                    return subscriber;
                 });
+                // a second request reusing a live stream's correlation id is answered with the error, not dropped
+                if(streamSubscriber.incomingMetadata != incomingMetadata){
+                    throw new IllegalArgumentException("A stream with correlationId " + correlationId + " is already in progress");
+                }
             }
         }
     }
@@ -536,8 +548,7 @@ public class ServiceInvocationSupervisor {
     }
 
     /**
-     * Subscriber that handles a single-value reactive result from a method invocation.
-     * Replaces the previous Mono.from() pattern.
+     * Subscriber that replies with the single value of a reactive result, or null when it completes empty.
      */
     private class SingleValueSubscriber implements Subscriber<Object> {
 
@@ -567,10 +578,15 @@ public class ServiceInvocationSupervisor {
         @Override
         public void onNext(Object value) {
             valueReceived = true;
+            reply(value);
+        }
+
+        // A throw out of a Subscriber callback reaches no onError, so a value that cannot be sent is
+        // answered with the error here and the invocation is over
+        private void reply(Object value) {
             try {
                 convertAndSend(incomingMetadata, handlerMethod, value);
             } catch (Exception e) {
-                // a throw out of onNext reaches no onError, so the caller is answered and the count left here
                 failed = true;
                 handleException(incomingMetadata, e);
                 failSpan(span, e);
@@ -593,14 +609,13 @@ public class ServiceInvocationSupervisor {
 
         @Override
         public void onComplete() {
-            if(failed){
-                return;
-            }
             if(!valueReceived){
-                convertAndSend(incomingMetadata, handlerMethod, null);
+                reply(null);
             }
-            span.end();
-            leaveInFlight.run();
+            if(!failed){
+                span.end();
+                leaveInFlight.run();
+            }
         }
     }
 
@@ -617,16 +632,14 @@ public class ServiceInvocationSupervisor {
 
         @Override
         protected void hookOnComplete() {
-            // This condition should not occur under normal operation
-            log.error("Reply Listener Monitor completed for some reason! Terminating streaming result.");
-            streamSubscription.cancel();
+            log.error("Reply listener monitor completed, terminating the streaming result");
+            streamSubscription.fail(new RpcServiceUnavailableException("The reply destination of the stream can no longer be monitored"));
         }
 
         @Override
         protected void hookOnError(@NonNull Throwable throwable) {
-            // This condition should not occur under normal operation
-            log.error("Reply Listener Monitor threw an exception. Terminating streaming result.", throwable);
-            streamSubscription.cancel();
+            log.error("Reply listener monitor failed, terminating the streaming result", throwable);
+            streamSubscription.fail(new RpcServiceUnavailableException("The reply destination of the stream can no longer be monitored", throwable));
         }
 
         @Override
@@ -634,13 +647,9 @@ public class ServiceInvocationSupervisor {
             if(log.isTraceEnabled()){
                 log.trace("Received ListenerStatus {}", status);
             }
-            // TODO: handle resume restart type logic
             if(status == ListenerStatus.INACTIVE){
-                if(!streamSubscription.isDisposed()) {
-                    log.trace("No more listeners active terminating streaming result.");
-                    streamSubscription.cancel();
-                    // ReplyListenerStatusSubscriber will be canceled by the streamSubscription
-                }
+                // A caller that is still listening gets the error; one that is gone drops it with the rest
+                streamSubscription.fail(new RpcServiceUnavailableException("No listener on the reply destination of the stream"));
             }
         }
     }
@@ -656,6 +665,8 @@ public class ServiceInvocationSupervisor {
         private final Flux<ListenerStatus> replyListenerStatus;
         private final String originCri;
         private final Span span;
+        // stop() and the reply listener monitor can fail the stream from different threads at once
+        private final AtomicBoolean failed = new AtomicBoolean(false);
         private ReplyListenerStatusSubscriber replyListenerStatusSubscriber;
 
         public StreamSubscriber(Metadata incomingMetadata,
@@ -674,7 +685,7 @@ public class ServiceInvocationSupervisor {
          * Ends the stream with a terminal error for its caller, then cancels the source.
          */
         public void fail(Throwable throwable){
-            if(!isDisposed()){
+            if(!isDisposed() && failed.compareAndSet(false, true)){
                 handleException(incomingMetadata, throwable);
                 span.recordException(throwable);
                 span.setStatus(StatusCode.ERROR);
@@ -698,6 +709,8 @@ public class ServiceInvocationSupervisor {
                     this.requestUnbounded();
                     break;
                 default:
+                    // the error reply that answers the control event is terminal for the requester, so the source ends with it
+                    this.cancel();
                     throw new IllegalArgumentException("Unknown control header value " + control);
             }
         }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -160,10 +160,18 @@ public class ServiceInvocationSupervisor {
 
     private EventConsumer listenAt(CRI cri){
         EventConsumer consumer = eventBusService.listen(cri);
-        consumer.handler(event -> vertx.executeBlocking(() -> {
-                    processEvent(event);
-                    return null;
-                }))
+        consumer.handler(event -> {
+                    // counted at dispatch, so an event still queued for the worker pool holds stop()'s drain
+                    Runnable leaveInFlight = enterInFlight();
+                    vertx.executeBlocking(() -> {
+                        try {
+                            processEvent(event);
+                        } finally {
+                            leaveInFlight.run();
+                        }
+                        return null;
+                    });
+                })
                 .exceptionHandler(throwable -> log.error("Event listener error", throwable))
                 // Vert.x invokes the end handler on every unregistration, including the one stop() performs.
                 // stop() clears active before unregistering, so a successful CAS here means something other
@@ -338,12 +346,7 @@ public class ServiceInvocationSupervisor {
                     processControlPlaneRequest(incomingEvent);
                 }else{
                     if(validateReplyTo(incomingEvent)){
-                        Runnable leaveInFlight = enterInFlight();
-                        try {
-                            processInvocationRequest(incomingEvent);
-                        } finally {
-                            leaveInFlight.run();
-                        }
+                        processInvocationRequest(incomingEvent);
                     }else{
                         log.error("ReplyTo header is missing or invalid incoming message will be ignored\n{}", EventUtil.toString(
                                 incomingEvent,
@@ -543,7 +546,9 @@ public class ServiceInvocationSupervisor {
         private final Event<byte[]> incomingEvent;
         private final Span span;
         private final Runnable leaveInFlight;
+        private Subscription subscription;
         private boolean valueReceived = false;
+        private boolean failed = false;
 
         public SingleValueSubscriber(Metadata incomingMetadata, HandlerMethod handlerMethod, Event<byte[]> incomingEvent, Span span, Runnable leaveInFlight) {
             this.incomingMetadata = incomingMetadata;
@@ -555,13 +560,23 @@ public class ServiceInvocationSupervisor {
 
         @Override
         public void onSubscribe(Subscription s) {
+            subscription = s;
             s.request(1);
         }
 
         @Override
         public void onNext(Object value) {
             valueReceived = true;
-            convertAndSend(incomingMetadata, handlerMethod, value);
+            try {
+                convertAndSend(incomingMetadata, handlerMethod, value);
+            } catch (Exception e) {
+                // a throw out of onNext reaches no onError, so the caller is answered and the count left here
+                failed = true;
+                handleException(incomingMetadata, e);
+                failSpan(span, e);
+                leaveInFlight.run();
+                subscription.cancel();
+            }
         }
 
         @Override
@@ -578,6 +593,9 @@ public class ServiceInvocationSupervisor {
 
         @Override
         public void onComplete() {
+            if(failed){
+                return;
+            }
             if(!valueReceived){
                 convertAndSend(incomingMetadata, handlerMethod, null);
             }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/json/AbstractJacksonSupport.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/json/AbstractJacksonSupport.java
@@ -20,7 +20,6 @@ import org.springframework.core.codec.CodecException;
 import org.springframework.core.codec.DecodingException;
 import org.springframework.core.codec.EncodingException;
 import org.springframework.util.MimeTypeUtils;
-import reactor.core.publisher.Flux;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectReader;
@@ -103,20 +102,13 @@ public abstract class AbstractJacksonSupport {
         Validate.notNull(event, "event must not be null");
         Validate.notNull(parameters, "parameters must not be null");
 
-        // TODO: remove the use of the Spring Tokenizer since I have found out about the performance issues with reactor
-        // Should we use the JacksonTokenizer borrowed from spring? We are not really taking advantage of the claimed non blocking or the Flux themselves
-        // I really don't see a way to do that anyhow since all Arguments at least for the invoker must be available upfront.
-        // A return value could be parsed and streamed but that would require more machinery.
-        // And we would want to plum that all the way to the caller.
-        List<TokenBuffer> tokens = JacksonTokenizer.tokenize(Flux.just(event.data()),
+        List<TokenBuffer> tokens = JacksonTokenizer.tokenize(event.data(),
                                                              jsonMapper,
                                                              dataInArray,
-                                                             kinoticProperties.getMaxEventPayloadSize())
-                                                   .collectList()
-                                                   .block();
+                                                             kinoticProperties.getMaxEventPayloadSize());
 
         List<Object> ret = new LinkedList<>();
-        int tokenCount = (tokens != null) ? tokens.size() : 0;
+        int tokenCount = tokens.size();
 
         // Count the number of parameters that come from JSON tokens (i.e. not Participant)
         int jsonParamCount = 0;

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/json/JacksonTokenizer.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/json/JacksonTokenizer.java
@@ -18,7 +18,6 @@ package org.kinotic.core.internal.api.service.json;
 
 import org.springframework.core.codec.DecodingException;
 import org.springframework.core.io.buffer.DataBufferLimitException;
-import reactor.core.publisher.Flux;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
@@ -90,18 +89,16 @@ final class JacksonTokenizer {
 		}
 	}
 
-	private Flux<TokenBuffer> endOfInput() {
-		return Flux.defer(() -> {
-			this.inputFeeder.endOfInput();
-			try {
-				List<TokenBuffer> tokens = new ArrayList<>();
-				parseTokens(tokens);
-				return Flux.fromIterable(tokens);
-			}
-			catch (JacksonException ex) {
-				throw new DecodingException("JSON decoding error: " + ex.getOriginalMessage(), ex);
-			}
-		});
+	private List<TokenBuffer> endOfInput() {
+		this.inputFeeder.endOfInput();
+		try {
+			List<TokenBuffer> tokens = new ArrayList<>();
+			parseTokens(tokens);
+			return tokens;
+		}
+		catch (JacksonException ex) {
+			throw new DecodingException("JSON decoding error: " + ex.getOriginalMessage(), ex);
+		}
 	}
 
 	private void parseTokens(List<TokenBuffer> tokens) {
@@ -195,34 +192,31 @@ final class JacksonTokenizer {
 
 
 	/**
-	 * Tokenize the given {@code Flux<byte>} into {@code Flux<TokenBuffer>}.
-	 * @param buffers the source data buffers
+	 * Tokenize the given JSON bytes into a list of {@code TokenBuffer}s, one per top-level value.
+	 * @param bytes the complete JSON document
 	 * @param objectMapper the current mapper instance
 	 * @param tokenizeArrays if {@code true} and the "top level" JSON object is
-	 * an array, each element is returned individually immediately after it is received
+	 * an array, each element is returned individually
 	 * @param maxInMemorySize maximum memory size
 	 * @return the resulting token buffers
+	 * @throws DecodingException when the bytes are not valid JSON
+	 * @throws DataBufferLimitException when a single value exceeds {@code maxInMemorySize}
 	 */
-	public static Flux<TokenBuffer> tokenize(Flux<byte[]> buffers,
+	public static List<TokenBuffer> tokenize(byte[] bytes,
 											 ObjectMapper objectMapper,
 											 boolean tokenizeArrays,
 											 int maxInMemorySize) {
-
+		JsonParser parser;
 		try {
-			JsonParser parser;
-			try {
-				parser = objectMapper.createNonBlockingByteBufferParser();
-			}
-			catch (UnsupportedOperationException ex) {
-				parser = objectMapper.createNonBlockingByteArrayParser();
-			}
-			JacksonTokenizer tokenizer =
-					new JacksonTokenizer(parser, tokenizeArrays, maxInMemorySize);
-			return buffers.concatMapIterable(tokenizer::tokenize).concatWith(tokenizer.endOfInput());
+			parser = objectMapper.createNonBlockingByteBufferParser();
 		}
-		catch (JacksonException ex) {
-			return Flux.error(ex);
+		catch (UnsupportedOperationException ex) {
+			parser = objectMapper.createNonBlockingByteArrayParser();
 		}
+		JacksonTokenizer tokenizer = new JacksonTokenizer(parser, tokenizeArrays, maxInMemorySize);
+		List<TokenBuffer> tokens = new ArrayList<>(tokenizer.tokenize(bytes));
+		tokens.addAll(tokenizer.endOfInput());
+		return tokens;
 	}
 
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
@@ -148,10 +148,10 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
 
                     String correlationId = event.metadata().get(EventConstants.CORRELATION_ID_HEADER);
                     if(correlationId != null){
-                        if(responseMap.containsKey(correlationId)){
+                        // one lookup: a cancel or a lost node can remove the entry from another context
+                        RpcReturnValueHandler handler = responseMap.get(correlationId);
+                        if(handler != null){
                             try {
-                                // provide message to handler for processing
-                                RpcReturnValueHandler handler = responseMap.get(correlationId);
                                 if(handler.processResponse(event)){
                                     settle(correlationId);
                                 }
@@ -210,11 +210,13 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
         if(released.compareAndSet(false,true)){
             replyEventConsumer.unregister();
 
-            responseMap.forEach((correlationId, returnValueHandler) -> {
-                requestLivenessWatcher.settle(correlationId);
-                returnValueHandler.cancel(serviceClass.getSimpleName() + " released. No further responses will be processed");
-            });
-            responseMap.clear();
+            for(String correlationId : responseMap.keySet()){
+                RpcReturnValueHandler returnValueHandler = responseMap.remove(correlationId);
+                if(returnValueHandler != null){
+                    requestLivenessWatcher.settle(correlationId);
+                    returnValueHandler.cancel(serviceClass.getSimpleName() + " released. No further responses will be processed");
+                }
+            }
             recentlyReaped.clear();
         }
     }
@@ -247,8 +249,10 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
      * that acknowledged it and no longer receives replies.
      */
     private void settle(String correlationId){
-        requestLivenessWatcher.settle(correlationId);
+        // the entry goes first: once it is gone the ack's computeIfPresent can no longer pin, so the lease
+        // released next is the last one this request can have
         responseMap.remove(correlationId);
+        requestLivenessWatcher.settle(correlationId);
     }
 
     @Override

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
@@ -224,7 +224,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
     /**
      * Handles a reply for a correlationId this proxy no longer tracks by cancelling the orphaned stream.
      * The server can't detect such an abandoned stream itself, since all of this proxy's requests share one
-     * reply destination, so we route a cancel to the origin CRI the server sends on stream replies.
+     * reply destination, so a cancel goes to the origin CRI the server sends on stream replies.
      */
     private void reapOrphanedStream(Event<byte[]> event, String correlationId){
         String originCri = event.metadata().get(EventConstants.ORIGIN_CRI_HEADER);
@@ -237,11 +237,17 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
         if(recentlyReaped.add(correlationId)){
             vertx.setTimer(REAP_DEBOUNCE_MS, _ -> recentlyReaped.remove(correlationId));
 
-            Metadata metadata = Metadata.create();
-            metadata.put(EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_CANCEL);
-            metadata.put(EventConstants.CORRELATION_ID_HEADER, correlationId);
-            eventBusService.send(Event.create(CRI.create(originCri), metadata, null));
+            sendCancel(CRI.create(originCri), correlationId);
         }
+    }
+
+    // Published, not sent: the instance producing the stream is whichever one round-robin gave the request,
+    // so every instance of the service gets the cancel and the ones without the stream ignore it
+    private void sendCancel(CRI serviceCri, String correlationId){
+        Metadata metadata = Metadata.create();
+        metadata.put(EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_CANCEL);
+        metadata.put(EventConstants.CORRELATION_ID_HEADER, correlationId);
+        eventBusService.publish(Event.create(serviceCri, metadata, null));
     }
 
     /**
@@ -293,6 +299,12 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
             RpcReturnValueHandler handler = new TracingRpcReturnValueHandler(
                     rpcReturnValueHandlerFactory.createReturnValueHandler(method, args), span);
             responseMap.put(correlationId, handler);
+            // release() may have scanned the map between the guard above and this put
+            if(released.get()){
+                responseMap.remove(correlationId);
+                handler.cancel(serviceClass.getSimpleName() + " released. No further responses will be processed");
+                throw new IllegalStateException("RpcServiceProxyHandle has already been released. No service method can be called after release.");
+            }
 
             // Create Event to be sent to remote end to cause service invocation
             Metadata metadata = Metadata.create();
@@ -354,16 +366,8 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
                 @Override
                 public void cancelRequest() {
                     if(handler.isMultiValue()) {
-                        // Now publish message for remote control
-                        Metadata metadata = Metadata.create();
-                        metadata.put(EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_CANCEL);
-                        metadata.put(EventConstants.CORRELATION_ID_HEADER, correlationId);
-
-                        // Send data to remote end for control request
-                        eventBusService.sendWithAck(Event.create(requestCri,
-                                                                 metadata,
-                                                                 null))
-                                       .onComplete(ar -> settle(correlationId));
+                        sendCancel(requestCri, correlationId);
+                        settle(correlationId);
                     } else {
                         throw new IllegalStateException("Cancel is not supported if RpcReturnValueHandler.isMultiValue returns false");
                     }
@@ -381,12 +385,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
     private void failLost(String correlationId, CRI requestCri, String nodeId){
         RpcReturnValueHandler lost = responseMap.remove(correlationId);
         if(lost != null){
-            try {
-                lost.processError(new RpcServiceUnavailableException("Node " + nodeId + " left the cluster while serving the request to " + requestCri.raw()));
-            } catch (IllegalStateException e) {
-                // the reply completed the handler between the removal above and this signal
-                log.debug("Request {} to {} settled before its node loss was signalled", correlationId, requestCri.raw());
-            }
+            lost.processError(new RpcServiceUnavailableException("Node " + nodeId + " left the cluster while serving the request to " + requestCri.raw()));
         }
     }
 

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/types/VertxFutureRpcReturnValueHandler.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/types/VertxFutureRpcReturnValueHandler.java
@@ -47,14 +47,15 @@ public class VertxFutureRpcReturnValueHandler implements RpcReturnValueHandler {
     public boolean processResponse(Event<byte[]> incomingEvent) {
         try{
             // Error data is returned differently
+            // the reply and a lost-node failure run on different contexts and can both reach this promise
             if(incomingEvent.metadata().contains(EventConstants.ERROR_HEADER)) {
-                promise.fail(exceptionConverter.convert(incomingEvent));
+                promise.tryFail(exceptionConverter.convert(incomingEvent));
             }else{
-                promise.complete(rpcResponseConverter.convert(incomingEvent, methodParameter));
+                promise.tryComplete(rpcResponseConverter.convert(incomingEvent, methodParameter));
             }
         }catch (Exception e){
             log.error("Error converting the incoming message to expected java type", e);
-            promise.fail(e);
+            promise.tryFail(e);
         }
         return true;
     }
@@ -72,12 +73,12 @@ public class VertxFutureRpcReturnValueHandler implements RpcReturnValueHandler {
 
     @Override
     public void processError(Throwable throwable) {
-        promise.fail(throwable);
+        promise.tryFail(throwable);
     }
 
     @Override
     public void cancel(String message) {
-        promise.fail(message);
+        promise.tryFail(message);
     }
 
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcLivenessTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcLivenessTests.java
@@ -117,6 +117,27 @@ public class RpcLivenessTests {
     }
 
     @Test
+    public void testLeaseSurvivesASiblingSettlingOnTheSameNode() throws Exception {
+        KinoticIgniteClusterManager secondClusterManager = startSecondNode();
+        String nodeId = secondClusterManager.getNodeId();
+        CompletableFuture<Void> lost = new CompletableFuture<>();
+        withParticipant(() -> {
+            requestLivenessWatcher.watch("first", nodeId, () -> {});
+            requestLivenessWatcher.watch("second", nodeId, () -> lost.complete(null));
+            return null;
+        });
+        awaitPendingCount(2);
+
+        // settling the first must not take the node's index entry away from the second
+        requestLivenessWatcher.settle("first");
+        awaitPendingCount(1);
+        stopSecondNode();
+
+        lost.get(1, TimeUnit.MINUTES);
+        awaitPendingCount(0);
+    }
+
+    @Test
     public void testInFlightCallRepliesAfterUnregister() throws Exception {
         GatedDrainTestService service = new GatedDrainTestService();
         ServiceIdentifier serviceIdentifier = register(service);

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcLivenessTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcLivenessTests.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.kinotic.core.api.RpcServiceProxyHandle;
 import org.kinotic.core.api.ServiceRegistry;
 import org.kinotic.core.api.event.Event;
+import org.kinotic.core.api.event.EventConstants;
 import org.kinotic.core.api.exceptions.RpcServiceUnavailableException;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.core.api.security.SecurityContext;
@@ -28,6 +29,7 @@ import org.kinotic.core.internal.utils.MetaUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -177,6 +179,36 @@ public class RpcLivenessTests {
     }
 
     @Test
+    public void testCancelReachesTheInstanceProducingTheStream() throws Exception {
+        GatedDrainTestService service = new GatedDrainTestService();
+        ServiceIdentifier serviceIdentifier = register(service);
+        RpcServiceProxyHandle<DrainTestService> handle = serviceRegistry.serviceProxy(serviceIdentifier, DrainTestService.class);
+        try {
+            Flux<String> stream = withParticipant(() -> handle.getService().streamUntilStopped());
+            CountDownLatch firstValue = new CountDownLatch(1);
+            Disposable subscription = stream.subscribe(_ -> firstValue.countDown());
+            Assertions.assertTrue(firstValue.await(10, TimeUnit.SECONDS), "the stream never produced");
+
+            // a second instance of the service, joining after the stream started: a cancel sent to the shared
+            // address could land here instead of on the instance producing the stream
+            CountDownLatch cancelSeenBySibling = new CountDownLatch(1);
+            vertx.eventBus().<Event<byte[]>>consumer(serviceIdentifier.cri().baseResource(), message -> {
+                     if(EventConstants.CONTROL_VALUE_CANCEL.equals(message.body().metadata().get(EventConstants.CONTROL_HEADER))){
+                         cancelSeenBySibling.countDown();
+                     }
+                 })
+                 .completion().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+            subscription.dispose();
+            Assertions.assertTrue(cancelSeenBySibling.await(10, TimeUnit.SECONDS), "the sibling instance never saw the cancel");
+            Assertions.assertTrue(service.streamCancelled.await(10, TimeUnit.SECONDS), "the producing instance never saw the cancel");
+        } finally {
+            handle.release();
+            serviceRegistry.unregister(serviceIdentifier).toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
     public void testLocalCallSurvivesUnrelatedNodeDeparture() throws Exception {
         startSecondNode();
         GatedDrainTestService service = new GatedDrainTestService();
@@ -266,6 +298,7 @@ public class RpcLivenessTests {
     private static class GatedDrainTestService implements DrainTestService {
         final CompletableFuture<String> gate = new CompletableFuture<>();
         final CountDownLatch gateReached = new CountDownLatch(1);
+        final CountDownLatch streamCancelled = new CountDownLatch(1);
 
         @Override
         public Mono<String> awaitGate() {
@@ -277,7 +310,7 @@ public class RpcLivenessTests {
         public Flux<String> streamUntilStopped() {
             Sinks.Many<String> sink = Sinks.many().unicast().onBackpressureBuffer();
             sink.tryEmitNext("first");
-            return sink.asFlux();
+            return sink.asFlux().doOnCancel(streamCancelled::countDown);
         }
     }
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
@@ -446,6 +446,22 @@ public class RpcTests {
     }
 
     @Test
+    public void testInvocationsOfOneServiceOverlap(){
+        // four calls whose results complete 500 ms later, off the delivery context; they are dispatched on
+        // the service's context and must not wait on one another
+        long start = System.currentTimeMillis();
+        List<CompletableFuture<String>> calls = new ArrayList<>();
+        for(int i = 0; i < 4; i++){
+            calls.add(rpcTestServiceProxy.getMonoAfterDelay("done", 500).toFuture());
+        }
+        for(CompletableFuture<String> call : calls){
+            Assertions.assertEquals("done", call.orTimeout(10, TimeUnit.SECONDS).join());
+        }
+        long elapsed = System.currentTimeMillis() - start;
+        Assertions.assertTrue(elapsed < 1500, "four 500 ms results took " + elapsed + " ms, so they were serialized");
+    }
+
+    @Test
     public void testMultipleRequests(){
         Mono<String> mono = Mono.fromFuture(rpcTestServiceProxy.getString());
 

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
@@ -10,6 +10,10 @@ import io.vertx.core.eventbus.MessageConsumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.kinotic.core.api.exceptions.RpcServiceUnavailableException;
+import org.kinotic.core.internal.api.service.rpc.RpcReturnValueHandlerFactory;
+import org.kinotic.core.internal.api.service.rpc.RpcRequest;
+import org.kinotic.core.internal.api.service.rpc.RpcReturnValueHandler;
 import org.kinotic.core.api.Kinotic;
 import org.kinotic.core.api.event.CRI;
 import org.kinotic.core.api.event.Event;
@@ -71,6 +75,8 @@ public class RpcTests {
     private Vertx vertx;
     @Autowired
     private SecurityContext securityContext;
+    @Autowired
+    private RpcReturnValueHandlerFactory rpcReturnValueHandlerFactory;
 
     private static final String PARTICIPANT_ID = "test-participant";
 
@@ -443,6 +449,26 @@ public class RpcTests {
         } finally {
             serviceConsumer.unregister();
         }
+    }
+
+    @Test
+    public void testFutureHandlerSettlesOnceUnderCompetingSignals() throws Exception {
+        // a lost-node failure and a reply reach the same handler from different contexts; the second signal is dropped
+        RpcReturnValueHandler handler = rpcReturnValueHandlerFactory.createReturnValueHandler(
+                RpcTestServiceProxy.class.getMethod("getAnotherString"), new Object[0]);
+        @SuppressWarnings("unchecked")
+        Future<String> future = (Future<String>) handler.getReturnValue(new RpcRequest() {
+            @Override
+            public void send() {}
+            @Override
+            public void cancelRequest() {}
+        });
+        handler.processError(new RpcServiceUnavailableException("node left"));
+        handler.processError(new IllegalStateException("late"));
+        handler.cancel("released");
+
+        Assertions.assertTrue(future.failed());
+        Assertions.assertInstanceOf(RpcServiceUnavailableException.class, future.cause());
     }
 
     @Test

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/DefaultRpcTestService.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/DefaultRpcTestService.java
@@ -15,6 +15,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.util.TokenBuffer;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -139,6 +140,11 @@ public class DefaultRpcTestService implements RpcTestService{
     @Override
     public Mono<String> getMonoWithValue() {
         return Mono.just("Hello Bob");
+    }
+
+    @Override
+    public Mono<String> getMonoAfterDelay(String value, long delayMillis) {
+        return Mono.delay(Duration.ofMillis(delayMillis)).map(_ -> value);
     }
 
     @Override

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestService.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestService.java
@@ -79,6 +79,11 @@ public interface RpcTestService {
 
     Mono<String> getMonoWithValue();
 
+    /**
+     * Completes with the given value after the delay, off the delivery context.
+     */
+    Mono<String> getMonoAfterDelay(String value, long delayMillis);
+
     Mono<Void> getMonoWithVoidFromEmpty();
 
     Mono<Void> getMonoWithVoidFromNull();

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestServiceProxy.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestServiceProxy.java
@@ -63,6 +63,8 @@ public interface RpcTestServiceProxy {
 
     Mono<String> getMonoWithValue();
 
+    Mono<String> getMonoAfterDelay(String value, long delayMillis);
+
     Mono<Void> getMonoWithVoidFromEmpty();
 
     Mono<Void> getMonoWithVoidFromNull();

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/mcp/McpToolInvoker.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/mcp/McpToolInvoker.java
@@ -130,17 +130,20 @@ public class McpToolInvoker {
         eventBusService.sendWithAck(event)
                        .onComplete(ar -> {
                            if (ar.failed()) {
-                               // a failed send never gets a reply, so its pending entry is removed here
-                               pendingCalls.remove(correlationId);
-                               // mapSendFailure also reports unreachability to the directory on NO_HANDLERS
-                               Throwable mapped = KinoticUtil.mapSendFailure(ar.cause(), requestCri, serviceDirectory);
-                               if (mapped instanceof RpcMissingServiceException) {
-                                   ret.complete(McpCallToolResult.error("Service is offline: " + tool.getCri()));
-                               } else if (mapped instanceof RpcServiceUnavailableException) {
-                                   ret.complete(McpCallToolResult.error("Service became unavailable: " + tool.getCri()));
-                               } else {
-                                   log.warn("MCP tool '{}' dispatch to {} failed", tool.getName(), tool.getCri(), ar.cause());
-                                   ret.complete(McpCallToolResult.error(ar.cause().getMessage()));
+                               // only the party that removes the entry completes it: a reply can land before an
+                               // acknowledgement times out
+                               Promise<McpCallToolResult> unsent = pendingCalls.remove(correlationId);
+                               if (unsent != null) {
+                                   // mapSendFailure also reports unreachability to the directory on NO_HANDLERS
+                                   Throwable mapped = KinoticUtil.mapSendFailure(ar.cause(), requestCri, serviceDirectory);
+                                   if (mapped instanceof RpcMissingServiceException) {
+                                       unsent.complete(McpCallToolResult.error("Service is offline: " + tool.getCri()));
+                                   } else if (mapped instanceof RpcServiceUnavailableException) {
+                                       unsent.complete(McpCallToolResult.error("Service became unavailable: " + tool.getCri()));
+                                   } else {
+                                       log.warn("MCP tool '{}' dispatch to {} failed", tool.getName(), tool.getCri(), ar.cause());
+                                       unsent.complete(McpCallToolResult.error(ar.cause().getMessage()));
+                                   }
                                }
                            } else {
                                // computeIfPresent serializes with the reply handler's remove, so a reply that

--- a/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
@@ -77,6 +77,8 @@ export class EventBus implements IEventBus {
     private readonly log: Logger = createDebugLogger('kinotic:EventBus')
     private stompConnectionManager: StompConnectionManager = new StompConnectionManager()
     private connectionLifecycle: Promise<unknown> = Promise.resolve()
+    // counts disconnect() calls, so a connect() queued before one of them never starts
+    private disconnectRequests: number = 0
     private requestRepliesObservable: ConnectableObservable<IEvent> | null = null
     private requestRepliesSubject: Subject<IEvent> | null = null
     private requestRepliesSubscription: Subscription | null = null
@@ -88,7 +90,7 @@ export class EventBus implements IEventBus {
 
     constructor() {
         // the manager has already deactivated when it reports a fatal error; in-flight requests fail here
-        this.stompConnectionManager.fatalErrors.subscribe(() => this.cleanup())
+        this.stompConnectionManager.fatalErrors.subscribe(() => this.serverInfo = null)
         // The server drops every reply consumer and lease of a closed connection, so a call in flight
         // across a drop is failed here rather than waited on. The manager reports each open connection's
         // end once, however it ends, so this is the one place connectionLost is emitted.
@@ -115,7 +117,12 @@ export class EventBus implements IEventBus {
     }
 
     public connect(options: ConnectOptions): Promise<ConnectedInfo> {
+        const disconnectsWhenQueued = this.disconnectRequests
         return this.serializeLifecycle(async () => {
+            // a disconnect() requested while this connect was queued cancels it
+            if (this.disconnectRequests !== disconnectsWhenQueued) {
+                throw new Error('Disconnected before the connection was started')
+            }
             if(!this.stompConnectionManager.active){
                 const connectedInfo = await this.stompConnectionManager.activate(options)
                 // copy so the reported server never aliases the caller's options object
@@ -129,15 +136,14 @@ export class EventBus implements IEventBus {
     }
 
     public disconnect(force?: boolean): Promise<void> {
+        this.disconnectRequests++
         // A connect() waiting for its socket holds the lifecycle queue. Deactivating now rejects it, so the
-        // teardown queued below runs at once instead of waiting on a server that may never answer. A
-        // connect() queued but not yet started is unaffected by that, so the queued teardown deactivates
-        // again once its turn comes.
+        // teardown queued below runs at once instead of waiting on a server that may never answer.
         const deactivated = this.stompConnectionManager.deactivate(force)
         return this.serializeLifecycle(async () => {
             await deactivated
             await this.stompConnectionManager.deactivate(force)
-            this.cleanup()
+            this.serverInfo = null
         })
     }
 
@@ -295,12 +301,6 @@ export class EventBus implements IEventBus {
 
     public observe(cri: string): Observable<IEvent> {
         return this._observe(cri)
-    }
-
-    // Runs on a fatal error and on disconnect(); the manager has reported the connection's end by then
-    private cleanup(): void{
-        this.resetRequestReplies('Connection disconnected')
-        this.serverInfo = null
     }
 
     /**

--- a/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
@@ -90,7 +90,8 @@ export class EventBus implements IEventBus {
         // the manager has already deactivated when it reports a fatal error; in-flight requests fail here
         this.stompConnectionManager.fatalErrors.subscribe(() => this.cleanup())
         // The server drops every reply consumer and lease of a closed connection, so a call in flight
-        // across a drop is failed here rather than waited on
+        // across a drop is failed here rather than waited on. The manager reports each open connection's
+        // end once, however it ends, so this is the one place connectionLost is emitted.
         this.stompConnectionManager.connectionLostHandler = () => {
             this.resetRequestReplies('Connection lost')
             this.connectionLostSubject.next()
@@ -296,13 +297,9 @@ export class EventBus implements IEventBus {
         return this._observe(cri)
     }
 
-    // Runs on a fatal error and on disconnect()
+    // Runs on a fatal error and on disconnect(); the manager has reported the connection's end by then
     private cleanup(): void{
         this.resetRequestReplies('Connection disconnected')
-        // serverInfo is set once a connection is up, so nothing was lost before that
-        if (this.serverInfo !== null) {
-            this.connectionLostSubject.next()
-        }
         this.serverInfo = null
     }
 

--- a/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
@@ -4,7 +4,7 @@ import {createDebugLogger, type Logger} from '@/internal/api/Logger'
 import {StompConnectionManager} from '@/internal/api/StompConnectionManager'
 import {context, propagation} from '@opentelemetry/api';
 import type {IMessage} from '@stomp/rx-stomp';
-import {ConnectableObservable, firstValueFrom, Observable, Subject, Subscription, throwError, type Unsubscribable} from 'rxjs'
+import {ConnectableObservable, firstValueFrom, Observable, Subject, Subscription, type Unsubscribable} from 'rxjs'
 import {filter, map, multicast, tap} from 'rxjs/operators'
 import {Optional} from 'typescript-optional'
 import {v4 as uuidv4} from 'uuid'
@@ -87,8 +87,7 @@ export class EventBus implements IEventBus {
     private static readonly REAP_DEBOUNCE_MS = 5000
 
     constructor() {
-        // We send an error any in-flight requests and clean up our connection state on fatal errors
-        // The StompConnectionManager will automatically deactivate on fatal errors
+        // the manager has already deactivated when it reports a fatal error; in-flight requests fail here
         this.stompConnectionManager.fatalErrors.subscribe(() => this.cleanup())
         // The server drops every reply consumer and lease of a closed connection, so a call in flight
         // across a drop is failed here rather than waited on
@@ -117,10 +116,6 @@ export class EventBus implements IEventBus {
     public connect(options: ConnectOptions): Promise<ConnectedInfo> {
         return this.serializeLifecycle(async () => {
             if(!this.stompConnectionManager.active){
-
-                // reset state in case connection ended due to max connection attempts
-                this.cleanup()
-
                 const connectedInfo = await this.stompConnectionManager.activate(options)
                 // copy so the reported server never aliases the caller's options object
                 this.serverInfo = {...options.server} as ServerInfo
@@ -133,11 +128,14 @@ export class EventBus implements IEventBus {
     }
 
     public disconnect(force?: boolean): Promise<void> {
-        // A pending connect() holds the lifecycle queue until its socket opens. Deactivating first rejects
-        // it, so the teardown queued below runs at once instead of waiting on a server that may never answer.
+        // A connect() waiting for its socket holds the lifecycle queue. Deactivating now rejects it, so the
+        // teardown queued below runs at once instead of waiting on a server that may never answer. A
+        // connect() queued but not yet started is unaffected by that, so the queued teardown deactivates
+        // again once its turn comes.
         const deactivated = this.stompConnectionManager.deactivate(force)
         return this.serializeLifecycle(async () => {
             await deactivated
+            await this.stompConnectionManager.deactivate(force)
             this.cleanup()
         })
     }
@@ -193,12 +191,17 @@ export class EventBus implements IEventBus {
     }
 
     public requestStream(event: IEvent, sendControlEvents: boolean = true): Observable<IEvent> {
-        // The manager mints the reply destination on every CONNECTED frame and clears it on deactivate, so
-        // a connected manager always has one. The shared reply subscription was torn down at the last drop,
-        // so the first request on a connection builds it on that connection's destination.
-        const replyToCri = this.stompConnectionManager.replyToCri
-        if(this.stompConnectionManager.connected && replyToCri != null){
-            return new Observable<IEvent>((subscriber) => {
+        return new Observable<IEvent>((subscriber) => {
+                // Read at subscribe time, not when the Observable was created: a reconnect in between
+                // mints a new destination. The manager mints it on every CONNECTED frame and clears it on
+                // deactivate, so a connected manager always has one. The shared reply subscription was torn
+                // down at the last drop, so the first request on a connection builds it on that
+                // connection's destination.
+                const replyToCri = this.stompConnectionManager.replyToCri
+                if (!this.stompConnectionManager.connected || replyToCri == null) {
+                    subscriber.error(this.createSendUnavailableError())
+                    return
+                }
 
                 if (this.requestRepliesObservable == null) {
                     this.requestRepliesSubject = new Subject<IEvent>()
@@ -282,10 +285,7 @@ export class EventBus implements IEventBus {
                         }
                     }
                 })
-            })
-        }else{
-            return throwError(() => this.createSendUnavailableError())
-        }
+        })
     }
 
     public listen(_serverInfo: ServerInfo): Promise<void> {
@@ -296,8 +296,7 @@ export class EventBus implements IEventBus {
         return this._observe(cri)
     }
 
-    // Runs on a fatal error, on disconnect(), and ahead of a connect(); the emission ahead of a connect finds
-    // nothing streaming
+    // Runs on a fatal error and on disconnect()
     private cleanup(): void{
         this.resetRequestReplies('Connection disconnected')
         // serverInfo is set once a connection is up, so nothing was lost before that

--- a/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
@@ -77,7 +77,6 @@ export class EventBus implements IEventBus {
     private readonly log: Logger = createDebugLogger('kinotic:EventBus')
     private stompConnectionManager: StompConnectionManager = new StompConnectionManager()
     private connectionLifecycle: Promise<unknown> = Promise.resolve()
-    private replyToCri: string  | null = null
     private requestRepliesObservable: ConnectableObservable<IEvent> | null = null
     private requestRepliesSubject: Subject<IEvent> | null = null
     private requestRepliesSubscription: Subscription | null = null
@@ -91,10 +90,6 @@ export class EventBus implements IEventBus {
         // We send an error any in-flight requests and clean up our connection state on fatal errors
         // The StompConnectionManager will automatically deactivate on fatal errors
         this.stompConnectionManager.fatalErrors.subscribe(() => this.cleanup())
-        this.stompConnectionManager.replyToCriChangedHandler = (replyToCri: string) => {
-            this.replyToCri = replyToCri
-            this.resetRequestReplies('Reply destination changed')
-        }
         // The server drops every reply consumer and lease of a closed connection, so a call in flight
         // across a drop is failed here rather than waited on
         this.stompConnectionManager.connectionLostHandler = () => {
@@ -129,13 +124,6 @@ export class EventBus implements IEventBus {
                 const connectedInfo = await this.stompConnectionManager.activate(options)
                 // copy so the reported server never aliases the caller's options object
                 this.serverInfo = {...options.server} as ServerInfo
-
-                // the initial connection reports its reply destination here rather than through
-                // replyToCriChangedHandler; a request that raced this connect built its replies on the old one
-                if (this.replyToCri !== this.stompConnectionManager.replyToCri) {
-                    this.resetRequestReplies('Reply destination changed')
-                }
-                this.replyToCri = this.stompConnectionManager.replyToCri
 
                 return connectedInfo
             }else{
@@ -205,14 +193,17 @@ export class EventBus implements IEventBus {
     }
 
     public requestStream(event: IEvent, sendControlEvents: boolean = true): Observable<IEvent> {
-        // the shared reply subscription is built on replyToCri, which a pending connect() has not set yet
-        if(this.stompConnectionManager.connected && this.replyToCri != null){
+        // The manager mints the reply destination on every CONNECTED frame and clears it on deactivate, so
+        // a connected manager always has one. The shared reply subscription was torn down at the last drop,
+        // so the first request on a connection builds it on that connection's destination.
+        const replyToCri = this.stompConnectionManager.replyToCri
+        if(this.stompConnectionManager.connected && replyToCri != null){
             return new Observable<IEvent>((subscriber) => {
 
                 if (this.requestRepliesObservable == null) {
                     this.requestRepliesSubject = new Subject<IEvent>()
                     // Reaper: before multicast, so it runs once per reply to cancel streams we no longer track.
-                    this.requestRepliesObservable = this._observe(this.replyToCri as string)
+                    this.requestRepliesObservable = this._observe(replyToCri)
                                                         .pipe(tap((value: IEvent) => this.cancelIfUnexpected(value)),
                                                               multicast(this.requestRepliesSubject)) as ConnectableObservable<IEvent>
                     this.requestRepliesSubscription = this.requestRepliesObservable.connect()
@@ -274,7 +265,7 @@ export class EventBus implements IEventBus {
 
                 subscriber.add(defaultMessagesSubscription)
 
-                event.setHeader(EventConstants.REPLY_TO_HEADER, this.replyToCri as string)
+                event.setHeader(EventConstants.REPLY_TO_HEADER, replyToCri)
                 event.setHeader(EventConstants.CORRELATION_ID_HEADER, correlationId)
 
                 this.send(event)
@@ -314,7 +305,6 @@ export class EventBus implements IEventBus {
             this.connectionLostSubject.next()
         }
         this.serverInfo = null
-        this.replyToCri = null
     }
 
     /**
@@ -358,13 +348,13 @@ export class EventBus implements IEventBus {
         cancelEvent.setHeader(EventConstants.CORRELATION_ID_HEADER, correlationId)
         // The service ignores it, but the gateway rejects any service send without a reply-to
         // and terminates the connection over the rejection.
-        cancelEvent.setHeader(EventConstants.REPLY_TO_HEADER, this.replyToCri as string)
+        cancelEvent.setHeader(EventConstants.REPLY_TO_HEADER, this.stompConnectionManager.replyToCri as string)
         this.send(cancelEvent)
     }
 
     /**
      * Tears down the shared request-replies stream so the next request rebuilds it against the
-     * current {@link replyToCri}. Any in-flight requests are failed with the given reason since
+     * connection's reply destination. Any in-flight requests are failed with the given reason since
      * their replies can no longer be delivered.
      */
     private resetRequestReplies(reason: string): void {

--- a/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/EventBus.ts
@@ -130,6 +130,11 @@ export class EventBus implements IEventBus {
                 // copy so the reported server never aliases the caller's options object
                 this.serverInfo = {...options.server} as ServerInfo
 
+                // the initial connection reports its reply destination here rather than through
+                // replyToCriChangedHandler; a request that raced this connect built its replies on the old one
+                if (this.replyToCri !== this.stompConnectionManager.replyToCri) {
+                    this.resetRequestReplies('Reply destination changed')
+                }
                 this.replyToCri = this.stompConnectionManager.replyToCri
 
                 return connectedInfo
@@ -140,8 +145,11 @@ export class EventBus implements IEventBus {
     }
 
     public disconnect(force?: boolean): Promise<void> {
+        // A pending connect() holds the lifecycle queue until its socket opens. Deactivating first rejects
+        // it, so the teardown queued below runs at once instead of waiting on a server that may never answer.
+        const deactivated = this.stompConnectionManager.deactivate(force)
         return this.serializeLifecycle(async () => {
-            await this.stompConnectionManager.deactivate(force)
+            await deactivated
             this.cleanup()
         })
     }
@@ -197,7 +205,8 @@ export class EventBus implements IEventBus {
     }
 
     public requestStream(event: IEvent, sendControlEvents: boolean = true): Observable<IEvent> {
-        if(this.stompConnectionManager.active){
+        // the shared reply subscription is built on replyToCri, which a pending connect() has not set yet
+        if(this.stompConnectionManager.connected && this.replyToCri != null){
             return new Observable<IEvent>((subscriber) => {
 
                 if (this.requestRepliesObservable == null) {
@@ -238,7 +247,7 @@ export class EventBus implements IEventBus {
                                                               }
                                                               subscriber.complete()
                                                           } else {
-                                                              throw new Error('Control Header ' + value.headers.get(EventConstants.CONTROL_HEADER) + ' is not supported')
+                                                              subscriber.error(new Error('Control Header ' + value.headers.get(EventConstants.CONTROL_HEADER) + ' is not supported'))
                                                           }
 
                                                       } else if (value.hasHeader(EventConstants.ERROR_HEADER)) {
@@ -300,9 +309,12 @@ export class EventBus implements IEventBus {
     // nothing streaming
     private cleanup(): void{
         this.resetRequestReplies('Connection disconnected')
-        this.connectionLostSubject.next()
-
+        // serverInfo is set once a connection is up, so nothing was lost before that
+        if (this.serverInfo !== null) {
+            this.connectionLostSubject.next()
+        }
         this.serverInfo = null
+        this.replyToCri = null
     }
 
     /**
@@ -412,7 +424,9 @@ export class EventBus implements IEventBus {
                                }
                            }
 
-                           return new Event(destination, headers, message.binaryBody)
+                           // stompjs hands over an empty array for a frame with no body; a completion control
+                           // must not look like a value
+                           return new Event(destination, headers, message.binaryBody.length > 0 ? message.binaryBody : undefined)
                        }))
     }
 

--- a/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
@@ -212,9 +212,9 @@ export class ServiceInvocationSupervisor {
         // A control for a stream that already ended names nothing and is dropped
         const stream = this.activeStreams.get(correlationId)
         if (stream) {
-            if (control === EventConstants.CONTROL_VALUE_CANCEL) {
-                stream.subscription.unsubscribe()
-            } else {
+            // either way the stream ends: cancelled, or failed to its caller with the error thrown here
+            stream.subscription.unsubscribe()
+            if (control !== EventConstants.CONTROL_VALUE_CANCEL) {
                 throw new Error(`Unknown control header value ${control}`)
             }
         }
@@ -283,7 +283,11 @@ export class ServiceInvocationSupervisor {
                             this.handleException(event, error)
                             this.failSpan(span, error)
                         }
-                    )
+                    ).catch((e) => {
+                        // the result itself could not be sent
+                        this.handleException(event, e)
+                        this.failSpan(span, e)
+                    })
                 } else {
                     this.processMethodInvocationResult(event, result, span)
                 }
@@ -348,18 +352,29 @@ export class ServiceInvocationSupervisor {
         if (!correlationId) {
             throw new Error("Streaming results require a CORRELATION_ID_HEADER to be set")
         }
-        const subscription = stream.pipe(finalize(() => {
-                                             // Covers every way the stream can end, cancellation included
-                                             this.activeStreams.delete(correlationId)
-                                             span.end()
-                                         }))
-                                   .subscribe({
+        // hoisted so next() can end the stream on a value it cannot send
+        let subscription: Subscription | null = null
+        subscription = stream.pipe(finalize(() => {
+                                       // Covers every way the stream can end, cancellation included
+                                       this.activeStreams.delete(correlationId)
+                                       span.end()
+                                   }))
+                             .subscribe({
                                                   next: (value) => {
-                                                      const reply = this.returnValueConverter.convert(event.headers, value)
-                                                      // Names this service on every value so a caller that no longer
-                                                      // tracks the stream can route a cancel back to it
-                                                      reply.setHeader(EventConstants.ORIGIN_CRI_HEADER, event.cri)
-                                                      this.sendReply(reply)
+                                                      try {
+                                                          const reply = this.returnValueConverter.convert(event.headers, value)
+                                                          // Names this service on every value so a caller that no longer
+                                                          // tracks the stream can route a cancel back to it
+                                                          reply.setHeader(EventConstants.ORIGIN_CRI_HEADER, event.cri)
+                                                          this.sendReply(reply)
+                                                      } catch (e) {
+                                                          // rxjs would report a throw here as an uncaught exception and
+                                                          // leave the stream running
+                                                          this.handleException(event, e)
+                                                          span.recordException(e as Error)
+                                                          span.setStatus({ code: SpanStatusCode.ERROR })
+                                                          subscription?.unsubscribe()
+                                                      }
                                                   },
                                                   error: (error) => {
                                                       this.handleException(event, error)
@@ -393,15 +408,20 @@ export class ServiceInvocationSupervisor {
     }
 
     private handleException(event: IEvent, error: any): void {
-        const errorEvent = Util.createReplyEvent(
-            event.headers,
-            new Map([
-                        [EventConstants.ERROR_HEADER, error.message || "Unknown error"],
-                        [EventConstants.CONTENT_TYPE_HEADER, "application/json"]
-                    ]),
-            new TextEncoder().encode(JSON.stringify({ message: error.message }))
-        )
-        this.sendReply(errorEvent)
+        try {
+            const errorEvent = Util.createReplyEvent(
+                event.headers,
+                new Map([
+                            [EventConstants.ERROR_HEADER, error.message || "Unknown error"],
+                            [EventConstants.CONTENT_TYPE_HEADER, "application/json"]
+                        ]),
+                new TextEncoder().encode(JSON.stringify({ message: error.message }))
+            )
+            this.sendReply(errorEvent)
+        } catch (e) {
+            // a request with no reply-to has nowhere to receive its error
+            this.log.warn(`Could not build the error reply for ${event.cri}`, e)
+        }
     }
 
     private validateReplyTo(event: IEvent): boolean {

--- a/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
@@ -36,6 +36,8 @@ export class ServiceInvocationSupervisor {
     // The streams being produced for callers, keyed by the correlation id their control events name
     private readonly activeStreams: Map<string, ActiveStream> = new Map()
     private connectionLostSubscription: Subscription | null = null
+    // Counts the connections lost since start; an invocation remembers the generation it arrived in
+    private connectionGeneration: number = 0
     private readonly methodMap: Record<string, (...args: any[]) => any>
     private readonly scopeOptionalMethods: Set<string>
     private readonly tracer: Tracer
@@ -111,8 +113,10 @@ export class ServiceInvocationSupervisor {
         }
 
         // The gateway answers every requester of a connection that ended, so a stream produced for one
-        // has no consumer left and is cancelled without a reply
+        // has no consumer left and is cancelled without a reply, and a result still being produced for
+        // one is dropped when it arrives
         this.connectionLostSubscription = this._eventBus.connectionLost.subscribe(() => {
+            this.connectionGeneration++
             for (const stream of this.activeStreams.values()) {
                 stream.subscription.unsubscribe()
             }
@@ -241,6 +245,7 @@ export class ServiceInvocationSupervisor {
 
         const methodName = path;
         const span = this.startInvocationSpan(event, methodName)
+        const generation = this.connectionGeneration
 
         try {
             const args = this.argumentResolver.resolveArguments(event)
@@ -254,7 +259,10 @@ export class ServiceInvocationSupervisor {
                     serviceContext = await interceptor.intercept(event, serviceContext);
                 } catch (e) {
                     this.log.error(`Interceptor failed to create context for event: ${JSON.stringify(event)}`, e)
-                    this.handleException(event, new Error("Internal server error"))
+                    // the span records the cause; the caller is told only that the service could not answer
+                    if (this.replyOwed(generation)) {
+                        this.handleException(event, new Error("Internal server error"))
+                    }
                     this.failSpan(span, e)
                     return
                 }
@@ -278,22 +286,17 @@ export class ServiceInvocationSupervisor {
                 if (result instanceof Promise) {
                     // The method has not finished yet, so the span ends with the promise
                     result.then(
-                        (resolved) => this.processMethodInvocationResult(event, resolved, span),
-                        (error) => {
-                            this.handleException(event, error)
-                            this.failSpan(span, error)
-                        }
+                        (resolved) => this.processMethodInvocationResult(event, resolved, span, generation),
+                        (error) => this.failInvocation(event, error, span, generation)
                     ).catch((e) => {
                         // the result itself could not be sent
-                        this.handleException(event, e)
-                        this.failSpan(span, e)
+                        this.failInvocation(event, e, span, generation)
                     })
                 } else {
-                    this.processMethodInvocationResult(event, result, span)
+                    this.processMethodInvocationResult(event, result, span, generation)
                 }
             } catch (e) {
-                this.handleException(event, e)
-                this.failSpan(span, e)
+                this.failInvocation(event, e, span, generation)
             }
         } catch (e) {
             this.failSpan(span, e)
@@ -331,11 +334,33 @@ export class ServiceInvocationSupervisor {
     }
 
     /**
-     * Replies with the value a method produced and ends the span once the reply is complete: at once for a
-     * single value, and when the stream ends for an {@link Observable}.
+     * Whether a reply to an invocation received in the given connection generation is still owed. The gateway
+     * answers every requester of a connection that ended, so a reply for an invocation of an earlier
+     * generation has no caller left and would reach a gateway that does not expect it.
      */
-    private processMethodInvocationResult(event: IEvent, result: any, span: Span): void {
-        if (isObservable(result)) {
+    private replyOwed(generation: number): boolean {
+        return generation === this.connectionGeneration
+    }
+
+    /**
+     * Fails the invocation on its span, and to its caller when the reply is still owed.
+     */
+    private failInvocation(event: IEvent, error: any, span: Span, generation: number): void {
+        if (this.replyOwed(generation)) {
+            this.handleException(event, error)
+        }
+        this.failSpan(span, error)
+    }
+
+    /**
+     * Replies with the value a method produced and ends the span once the reply is complete: at once for a
+     * single value, and when the stream ends for an {@link Observable}. A value for an invocation whose reply
+     * is no longer owed is dropped and the span ends.
+     */
+    private processMethodInvocationResult(event: IEvent, result: any, span: Span, generation: number): void {
+        if (!this.replyOwed(generation)) {
+            span.end()
+        } else if (isObservable(result)) {
             this.streamResult(event, result, span)
         } else {
             const reply = this.returnValueConverter.convert(event.headers, result)
@@ -354,6 +379,10 @@ export class ServiceInvocationSupervisor {
         }
         // hoisted so next() can end the stream on a value it cannot send
         let subscription: Subscription | null = null
+        // Set once the caller has its terminal error reply. A synchronous source is still inside subscribe()
+        // when a value fails, with no subscription to close yet, so the values and completion it goes on to
+        // deliver are dropped here instead
+        let failed = false
         subscription = stream.pipe(finalize(() => {
                                        // Covers every way the stream can end, cancellation included
                                        this.activeStreams.delete(correlationId)
@@ -361,6 +390,9 @@ export class ServiceInvocationSupervisor {
                                    }))
                              .subscribe({
                                                   next: (value) => {
+                                                      if (failed) {
+                                                          return
+                                                      }
                                                       try {
                                                           const reply = this.returnValueConverter.convert(event.headers, value)
                                                           // Names this service on every value so a caller that no longer
@@ -370,6 +402,7 @@ export class ServiceInvocationSupervisor {
                                                       } catch (e) {
                                                           // rxjs would report a throw here as an uncaught exception and
                                                           // leave the stream running
+                                                          failed = true
                                                           this.handleException(event, e)
                                                           span.recordException(e as Error)
                                                           span.setStatus({ code: SpanStatusCode.ERROR })
@@ -377,16 +410,26 @@ export class ServiceInvocationSupervisor {
                                                       }
                                                   },
                                                   error: (error) => {
+                                                      if (failed) {
+                                                          return
+                                                      }
                                                       this.handleException(event, error)
                                                       // finalize ends the span; this only marks why it ended
                                                       span.recordException(error)
                                                       span.setStatus({ code: SpanStatusCode.ERROR })
                                                   },
                                                   complete: () => {
+                                                      if (failed) {
+                                                          return
+                                                      }
                                                       this.sendReply(Util.createReplyEvent(event.headers,
                                                                                            new Map([[EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_COMPLETE]])))
                                                   }
                                               })
+        // A source that failed while still inside subscribe() had no subscription for next() to close
+        if (failed) {
+            subscription.unsubscribe()
+        }
         // A stream that ended inside subscribe, as a synchronous source does, has already run finalize and
         // takes no control events
         if (!subscription.closed) {
@@ -407,15 +450,22 @@ export class ServiceInvocationSupervisor {
         }
     }
 
+    /**
+     * Replies with the error an invocation failed with. The body describes the exception the way every runtime's
+     * error reply does, so a caller reads a TS service's failure exactly as it reads a Java one: the class name
+     * serves as both the exception name and its class, since a TS class has no package.
+     */
     private handleException(event: IEvent, error: any): void {
         try {
+            const errorMessage = error?.message || "Unknown error"
+            const exceptionName = error instanceof Error ? error.constructor.name : "Error"
             const errorEvent = Util.createReplyEvent(
                 event.headers,
                 new Map([
-                            [EventConstants.ERROR_HEADER, error.message || "Unknown error"],
+                            [EventConstants.ERROR_HEADER, errorMessage],
                             [EventConstants.CONTENT_TYPE_HEADER, "application/json"]
                         ]),
-                new TextEncoder().encode(JSON.stringify({ message: error.message }))
+                new TextEncoder().encode(JSON.stringify({ exceptionName, exceptionClass: exceptionName, errorMessage }))
             )
             this.sendReply(errorEvent)
         } catch (e) {

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompActivation.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompActivation.ts
@@ -10,14 +10,43 @@ import type { Subscription } from 'rxjs'
  */
 export class StompActivation {
 
-    /** True once deactivate() has taken this activation; nothing it started may act afterwards. */
-    public ended: boolean = false
+    private _ended: boolean = false
+    private wake: (() => void) | null = null
 
     /** A socket produced for stompjs that stompjs has not taken yet; closed if the activation ends first. */
     public preparedSocket: IWebSocket | null = null
 
-    private failPending: ((reason: string) => void) | null = null
+    /** The beforeConnect attempt stompjs is awaiting, settled once its continuation in stompjs has run. */
+    public attempt: Promise<void> | null = null
+
+    private failPending: ((reason: Error) => void) | null = null
     private readonly subscriptions: Subscription[] = []
+
+    /** True once deactivate() has taken this activation; nothing it started may act afterwards. */
+    public get ended(): boolean {
+        return this._ended
+    }
+
+    /** Ends the activation; a delay() it is waiting on resolves at once. */
+    public end(): void {
+        this._ended = true
+        this.wake?.()
+        this.wake = null
+    }
+
+    /** Resolves after the given time, or as soon as the activation ends. */
+    public delay(ms: number): Promise<void> {
+        return new Promise(resolve => {
+            const timer = setTimeout(() => {
+                this.wake = null
+                resolve()
+            }, ms)
+            this.wake = (): void => {
+                clearTimeout(timer)
+                resolve()
+            }
+        })
+    }
 
     /** Registers a listener this activation owns. */
     public own(subscription: Subscription): void {
@@ -25,7 +54,7 @@ export class StompActivation {
     }
 
     /** Registers how to reject the activate() promise while its socket has not opened. */
-    public pending(fail: (reason: string) => void): void {
+    public pending(fail: (reason: Error) => void): void {
         this.failPending = fail
     }
 
@@ -35,7 +64,7 @@ export class StompActivation {
     }
 
     /** Rejects a still-pending activate() with the reason; no-op once established. */
-    public failIfPending(reason: string): void {
+    public failIfPending(reason: Error): void {
         const fail = this.failPending
         this.failPending = null
         fail?.(reason)

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompActivation.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompActivation.ts
@@ -1,0 +1,51 @@
+import type { IWebSocket } from '@/api/ConnectOptions'
+import type { Subscription } from 'rxjs'
+
+/**
+ * One activation of the STOMP client: everything a single {@link StompConnectionManager#activate} call
+ * owns, so that deactivating it can never touch a later activation. An activation is ended exactly once.
+ *
+ * @author Navid Mitchell 🤝Grok
+ * @since 9/12/2026
+ */
+export class StompActivation {
+
+    /** True once deactivate() has taken this activation; nothing it started may act afterwards. */
+    public ended: boolean = false
+
+    /** A socket produced for stompjs that stompjs has not taken yet; closed if the activation ends first. */
+    public preparedSocket: IWebSocket | null = null
+
+    private failPending: ((reason: string) => void) | null = null
+    private readonly subscriptions: Subscription[] = []
+
+    /** Registers a listener this activation owns. */
+    public own(subscription: Subscription): void {
+        this.subscriptions.push(subscription)
+    }
+
+    /** Registers how to reject the activate() promise while its socket has not opened. */
+    public pending(fail: (reason: string) => void): void {
+        this.failPending = fail
+    }
+
+    /** The socket is open: the activate() promise can no longer be rejected from here. */
+    public established(): void {
+        this.failPending = null
+    }
+
+    /** Rejects a still-pending activate() with the reason; no-op once established. */
+    public failIfPending(reason: string): void {
+        const fail = this.failPending
+        this.failPending = null
+        fail?.(reason)
+    }
+
+    /** Tears down every listener this activation owns. */
+    public unsubscribeAll(): void {
+        for (const subscription of this.subscriptions) {
+            subscription.unsubscribe()
+        }
+        this.subscriptions.length = 0
+    }
+}

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
@@ -5,9 +5,10 @@ import {ConnectedInfo} from '@/api/security/ConnectedInfo'
 import {type IFrame, RxStomp, RxStompConfig, StompHeaders, RxStompState} from '@stomp/rx-stomp'
 import {ReconnectionTimeMode} from '@stomp/stompjs'
 import debug from 'debug'
-import {Observable, Subject, Subscription} from 'rxjs'
+import {Observable, Subject} from 'rxjs'
 import {skip} from 'rxjs/operators'
 import {v4 as uuidv4} from 'uuid'
+import {StompActivation} from './StompActivation'
 
 /** Fixed REST route the cookie-session pre-flight probes; identical in every environment. */
 const SESSION_CHECK_PATH = '/api/auth/me'
@@ -16,7 +17,9 @@ const SESSION_CHECK_PATH = '/api/auth/me'
  * Owns the process's single RxStomp client and manages its connection lifecycle.
  * The client is created once and reused across activate/deactivate cycles, so
  * subscriptions made through it (service registrations, observed CRIs) survive a
- * disconnect and are re-subscribed by RxStomp on the next activation.
+ * disconnect and are re-subscribed by RxStomp on the next activation. Each activate()
+ * owns its own listeners and pending state, so a deactivate() only ever ends the
+ * activation it was called for, and an activate() waits for an in-flight deactivate().
  */
 export class StompConnectionManager {
 
@@ -27,8 +30,9 @@ export class StompConnectionManager {
     public maxConnectionAttemptsReached: boolean = false
 
     /**
-     * Invoked when an established connection drops, before any reconnect. The server releases everything it
-     * held for the connection at the same moment, so nothing in flight can complete any more.
+     * Invoked once each time an open connection ends: a drop before any reconnect, a fatal error, or
+     * deactivate(). The server releases everything it held for the connection at the same moment, so
+     * nothing in flight can complete any more.
      */
     public connectionLostHandler: (() => void) | null = null
     /**
@@ -37,9 +41,10 @@ export class StompConnectionManager {
      * published services and observed CRIs alive across disconnect/connect cycles.
      */
     public readonly rxStomp: RxStomp = new RxStomp()
-    private isActive: boolean = false
-    private initialConnectedSubscription: Subscription | null = null
-    private webSocketErrorsSubscription: Subscription | null = null
+    // the connection being maintained; null while inactive
+    private activation: StompActivation | null = null
+    // a deactivate() still closing its socket; the next activate() waits for it
+    private teardown: Promise<void> | null = null
     private readonly INITIAL_RECONNECT_DELAY: number = 2000
     private readonly JITTER_MAX: number = 5000
     private readonly MAX_RECONNECT_DELAY: number = 120000 // 2 mins
@@ -49,12 +54,6 @@ export class StompConnectionManager {
     private readonly _fatalErrors: Observable<Error> = this.fatalErrorsSubject.asObservable()
     private initialConnectionSuccessful: boolean = false
     private rxStompHasConnected: boolean = false
-    private serverHeadersSubscription: Subscription | null = null
-    private stompErrorsSubscription: Subscription | null = null
-    private connectionStateSubscription: Subscription | null = null
-    // Rejects the activate() promise whose socket has not opened yet, so a fatal error or a deactivate()
-    // in that window settles the connect instead of leaving it waiting; null once the connection is up
-    private failPendingActivation: ((reason: string) => void) | null = null
 
     private _replyToCri: string | null = null
 
@@ -71,14 +70,14 @@ export class StompConnectionManager {
      * @return true if this {@link StompConnectionManager} is actively trying to maintain a connection to the Stomp server, false if not.
      */
     public get active(): boolean {
-        return this.isActive
+        return this.activation !== null
     }
 
     /**
      * return true if this {@link StompConnectionManager} is active and has a connection to the stomp server
      */
     public get connected(): boolean {
-        return this.isActive && this.rxStomp.connected()
+        return this.activation !== null && this.rxStomp.connected()
     }
 
     /**
@@ -96,26 +95,45 @@ export class StompConnectionManager {
         if (!options?.server?.host) {
             throw new Error('No host provided')
         }
-        if (this.isActive) {
+        if (this.activation) {
+            throw new Error('Stomp connection already active')
+        }
+        // a deactivate() still closing its socket finishes before a new socket is opened
+        await this.teardown
+        if (this.activation) {
             throw new Error('Stomp connection already active')
         }
 
         const server: ServerInfo = options.server as ServerInfo
         const credentialsResolver: CredentialsResolver | undefined = options.credentials
 
+        // Claimed before credential resolution, so a deactivate() from here on ends this activation
+        const activation = new StompActivation()
+        this.activation = activation
+
         // The connection's auth mode is fixed for its life: a user factory owns the socket
         // outright; otherwise the initial resolution decides between upgrade-header auth and
         // the browser session cookie. Per-attempt resolution below refreshes the headers.
         let headerAuth = false
-        if (!options.webSocketFactory) {
-            if (!credentialsResolver) {
-                throw new Error('No credentials supplied and no default resolution applied')
+        try {
+            if (!options.webSocketFactory) {
+                if (!credentialsResolver) {
+                    throw new Error('No credentials supplied and no default resolution applied')
+                }
+                const resolved = await credentialsResolver.resolve(server)
+                if (resolved === null) {
+                    throw new Error('No Kinotic credentials found; consulted: ' + credentialsResolver.name)
+                }
+                headerAuth = resolved.authHeaders != null
             }
-            const resolved = await credentialsResolver.resolve(server)
-            if (resolved === null) {
-                throw new Error('No Kinotic credentials found; consulted: ' + credentialsResolver.name)
+            if (activation.ended) {
+                throw new Error('Deactivated before the connection was established')
             }
-            headerAuth = resolved.authHeaders != null
+        } catch (e) {
+            if (this.activation === activation) {
+                this.activation = null
+            }
+            throw e
         }
 
         return new Promise((resolve, reject): void => {
@@ -131,10 +149,16 @@ export class StompConnectionManager {
             // Sockets may be produced asynchronously (a user factory, or credential resolution
             // refreshing a short-lived secret), but @stomp/stompjs only accepts a synchronous
             // factory. So the socket is produced in beforeConnect — which stompjs awaits
-            // immediately before creating the socket — and handed back synchronously here.
-            let preparedSocket: IWebSocket | null = null
+            // immediately before creating the socket — and handed back synchronously here. The
+            // activation holds it until stompjs takes it, so one it never takes is closed with the
+            // activation instead of being orphaned.
             const userWebSocketFactory = options.webSocketFactory
             const usesPreparedSocket = userWebSocketFactory != null || headerAuth
+            const takePreparedSocket = (): IWebSocket => {
+                const socket = activation.preparedSocket as IWebSocket
+                activation.preparedSocket = null
+                return socket
+            }
 
             const stompConfig: RxStompConfig = {
                 brokerURL: url,
@@ -149,8 +173,11 @@ export class StompConnectionManager {
                 reconnectDelay: this.INITIAL_RECONNECT_DELAY,
                 maxReconnectDelay: this.MAX_RECONNECT_DELAY,
                 reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
-                webSocketFactory: usesPreparedSocket ? () => preparedSocket as IWebSocket : undefined,
+                webSocketFactory: usesPreparedSocket ? takePreparedSocket : undefined,
                 beforeConnect: async (): Promise<void> => {
+                    if (activation.ended) {
+                        return
+                    }
 
                     // Cookie-auth clients (browser, headerless credentials) can't read a rejected WS
                     // upgrade, so probe the session over a readable REST status first — same host as
@@ -181,7 +208,7 @@ export class StompConnectionManager {
 
                         if(this.connectionAttempts > options.maxConnectionAttempts){
                             this.maxConnectionAttemptsReached = true
-                            // signalFatal rejects activate() via initialFailureSubscription on the initial-connect path.
+                            // signalFatal rejects a still-pending activate() with this reason
                             await this.signalFatal(new Error(
                                 'Max number of reconnection attempts reached',
                                 { cause: this.lastWebsocketError ?? undefined }
@@ -196,7 +223,7 @@ export class StompConnectionManager {
 
                     if(userWebSocketFactory){
                         try {
-                            preparedSocket = await userWebSocketFactory()
+                            activation.preparedSocket = await userWebSocketFactory()
                         } catch (e) {
                             await this.signalFatal(new Error('WebSocket factory failed', { cause: e }))
                         }
@@ -211,11 +238,16 @@ export class StompConnectionManager {
                                 // The Node/Bun WebSocket accepts a `headers` option that the DOM lib typings omit.
                                 const WS = WebSocket as unknown as
                                     new (url: string, opts: {headers: Record<string, string>}) => IWebSocket
-                                preparedSocket = new WS(url, {headers: resolved.authHeaders})
+                                activation.preparedSocket = new WS(url, {headers: resolved.authHeaders})
                             }
                         } catch (e) {
                             await this.signalFatal(new Error('Credential resolution failed', { cause: e }))
                         }
+                    }
+                    // a deactivate() landed while the socket was being produced; stompjs will not take it
+                    if (activation.ended && activation.preparedSocket) {
+                        activation.preparedSocket.close()
+                        activation.preparedSocket = null
                     }
                 }
             }
@@ -229,7 +261,7 @@ export class StompConnectionManager {
             this.rxStomp.configure(stompConfig)
 
             // Handles Websocket Errors
-            this.webSocketErrorsSubscription = this.rxStomp.webSocketErrors$.subscribe(async value => {
+            activation.own(this.rxStomp.webSocketErrors$.subscribe(async value => {
                 this.lastWebsocketError = value
                 // The attempt that just failed was the last the budget allows — report now
                 // instead of paying the reconnect delay before the next beforeConnect notices.
@@ -240,32 +272,23 @@ export class StompConnectionManager {
                         { cause: value ?? undefined }
                     ))
                 }
-            })
+            }))
 
             // Forward STOMP ERROR frames as fatal errors. Server-issued ERROR frames close the
             // connection and indicate an unrecoverable condition (auth failure, protocol error).
-            this.stompErrorsSubscription = this.rxStomp.stompErrors$.subscribe(async (frame: IFrame) => {
+            activation.own(this.rxStomp.stompErrors$.subscribe(async (frame: IFrame) => {
                 const stompError = new Error(frame.headers['message'] as string, { cause: frame })
                 await this.signalFatal(new Error('STOMP connection error', { cause: stompError }))
-            })
+            }))
 
-            // Handles Successful Connections
-            this.initialConnectedSubscription = this.rxStomp.connected$.subscribe(() =>{
-                // We only want these for the initial connection
-                this.initialConnectedSubscription?.unsubscribe()
-                this.failPendingActivation = null
-
-                // Successful Connection
-                if(!this.initialConnectionSuccessful){
-                    this.initialConnectionSuccessful = true
-                }
-            })
+            // The first connection of this activation: from here the connect can only resolve
+            activation.own(this.rxStomp.connected$.subscribe(() =>{
+                activation.established()
+                this.initialConnectionSuccessful = true
+            }))
 
             // A fatal error or a deactivate() before the socket opened rejects the connect with its reason
-            this.failPendingActivation = (reason: string) => {
-                this.initialConnectedSubscription?.unsubscribe()
-                reject(reason)
-            }
+            activation.pending(reject)
 
             // Triggered on every CONNECTED frame, including reconnects; each one mints this connection's
             // reply destination. serverHeaders$ is a BehaviorSubject on an rxStomp that outlives a
@@ -273,7 +296,7 @@ export class StompConnectionManager {
             // on subscribe; skipping it stops activate() resolving with a destination that is gone. Stays on
             // serverHeaders$ rather than connected$: rx-stomp emits the headers before it reports OPEN, so
             // the destination is set before anything can be sent on the new connection.
-            this.serverHeadersSubscription = this.rxStomp.serverHeaders$
+            activation.own(this.rxStomp.serverHeaders$
                                                  .pipe(skip(this.rxStompHasConnected ? 1 : 0))
                                                  .subscribe(async (value: StompHeaders) => {
                 this.rxStompHasConnected = true
@@ -307,49 +330,58 @@ export class StompConnectionManager {
                 if (!this.initialConnectionSuccessful) {
                     resolve(connectedInfo)
                 }
-            })
+            }))
 
-            // An open socket closing: the socket and everything the server held behind it are gone. A failed
-            // reconnect attempt also ends in CLOSED, but from CONNECTING, and loses nothing new.
+            // An open socket dropping: the socket and everything the server held behind it are gone. A failed
+            // reconnect attempt also ends in CLOSED, but from CONNECTING, and loses nothing new. A close that
+            // deactivate() itself causes is reported by deactivate().
             let previousState: RxStompState = this.rxStomp.connectionState$.getValue()
-            this.connectionStateSubscription = this.rxStomp.connectionState$.subscribe((state: RxStompState) => {
-                if (state === RxStompState.CLOSED && previousState === RxStompState.OPEN && this.isActive) {
+            activation.own(this.rxStomp.connectionState$.subscribe((state: RxStompState) => {
+                if (state === RxStompState.CLOSED && previousState === RxStompState.OPEN && this.activation === activation) {
                     this.connectionLostHandler?.()
                 }
                 previousState = state
-            })
+            }))
 
-            this.isActive = true
             this.rxStomp.activate()
         })
     }
 
-    public async deactivate(force?: boolean): Promise<void> {
-        if(this.isActive){
-            // cleared before the await so a reentrant deactivate (signalFatal firing while this
-            // teardown is in flight) is a no-op instead of a second rxStomp.deactivate()
-            this.isActive = false
-            await this.rxStomp.deactivate({force: force})
-            this.failPendingActivation?.('Deactivated before the connection was established')
-            this.failPendingActivation = null
-            // watch() subscriptions survive deactivation and re-subscribe on the next activation.
-            // The listeners below are per-activation state that activate() recreates, so they are
-            // torn down with the connection. The connected-listener in particular: on the persistent
-            // client it would otherwise fire on the next activation's CONNECTED frame and mark the
-            // initial connection successful before the new serverHeaders handler resolves it.
-            this.initialConnectedSubscription?.unsubscribe()
-            this.initialConnectedSubscription = null
-            this.webSocketErrorsSubscription?.unsubscribe()
-            this.webSocketErrorsSubscription = null
-            this.serverHeadersSubscription?.unsubscribe()
-            this.serverHeadersSubscription = null
-            this.stompErrorsSubscription?.unsubscribe()
-            this.stompErrorsSubscription = null
-            this.connectionStateSubscription?.unsubscribe()
-            this.connectionStateSubscription = null
+    /**
+     * Ends the current activation. A second call while the socket is still closing returns the same
+     * teardown; a call while inactive resolves at once.
+     * @param force close the socket without a DISCONNECT frame
+     */
+    public deactivate(force?: boolean): Promise<void> {
+        const activation = this.activation
+        let ret: Promise<void>
+        if (activation) {
+            this.activation = null
+            activation.ended = true
+            const wasOpen = this.rxStomp.connected()
             this._replyToCri = null
+            // a connect still waiting for its socket is settled now, not after the close round trip
+            activation.failIfPending('Deactivated before the connection was established')
+            // a socket produced for stompjs that it never took
+            activation.preparedSocket?.close()
+            activation.preparedSocket = null
+            const teardown: Promise<void> = this.rxStomp.deactivate({force: force}).finally(() => {
+                // watch() subscriptions survive deactivation and re-subscribe on the next activation; the
+                // listeners this activation owns end with it
+                activation.unsubscribeAll()
+                if (this.teardown === teardown) {
+                    this.teardown = null
+                }
+                if (wasOpen) {
+                    this.connectionLostHandler?.()
+                }
+            })
+            this.teardown = teardown
+            ret = teardown
+        } else {
+            ret = this.teardown ?? Promise.resolve()
         }
-        return
+        return ret
     }
 
     /**
@@ -372,8 +404,7 @@ export class StompConnectionManager {
     private async signalFatal(err: Error): Promise<void> {
         this.debugLogger('Fatal error, deactivating connection: %O', err)
         // a connect still waiting learns the cause, not the generic reason deactivate() would give it
-        this.failPendingActivation?.(err.message)
-        this.failPendingActivation = null
+        this.activation?.failIfPending(err.message)
         await this.deactivate()
         this.fatalErrorsSubject.next(err)
     }

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
@@ -26,9 +26,9 @@ export class StompConnectionManager {
      */
     public maxConnectionAttemptsReached: boolean = false
     /**
-     * Invoked when the server issues a new replyToId on reconnect, which changes {@link replyToCri}.
-     * This always happens with {@link SessionKeepAliveMode.NONE} since no session carries the
-     * replyToId across connections.
+     * Invoked on every reconnect with the new {@link replyToCri}. The reply destination is minted per
+     * connection, so the consumer the server still holds for the previous socket never receives this
+     * connection's replies.
      */
     public replyToCriChangedHandler: ((replyToCri: string) => void) | null = null
 
@@ -59,7 +59,7 @@ export class StompConnectionManager {
     private serverHeadersSubscription: Subscription | null = null
     private stompErrorsSubscription: Subscription | null = null
     private connectionStateSubscription: Subscription | null = null
-    private readonly uuidv4 = uuidv4()
+    private failPendingActivation: ((reason: string) => void) | null = null
 
     private _replyToCri: string | null = null
 
@@ -258,6 +258,7 @@ export class StompConnectionManager {
                 // We only want these for the initial connection
                 this.initialConnectedSubscription?.unsubscribe()
                 this.initialFailureSubscription?.unsubscribe()
+                this.failPendingActivation = null
 
                 // Successful Connection
                 if(!this.initialConnectionSuccessful){
@@ -270,8 +271,16 @@ export class StompConnectionManager {
             this.initialFailureSubscription = this.fatalErrorsSubject.subscribe((err: Error) => {
                 this.initialConnectedSubscription?.unsubscribe()
                 this.initialFailureSubscription?.unsubscribe()
+                this.failPendingActivation = null
                 reject(err.message)
             })
+
+            // deactivate() settles a connect that is still waiting for its socket
+            this.failPendingActivation = (reason: string) => {
+                this.initialConnectedSubscription?.unsubscribe()
+                this.initialFailureSubscription?.unsubscribe()
+                reject(reason)
+            }
 
             // Triggered on every CONNECTED frame, including reconnects. The replyToId is generated
             // server side, so on reconnect it may change.
@@ -305,8 +314,11 @@ export class StompConnectionManager {
                     return
                 }
 
+                // A fresh discriminator per connection: the server keeps the previous socket's reply
+                // consumer until its heartbeat times out, and two consumers on one address would share
+                // the replies
                 const newReplyToCri: string = EventConstants.REPLY_DESTINATION_PREFIX
-                    + connectedInfo.replyToId + ':' + this.uuidv4
+                    + connectedInfo.replyToId + ':' + uuidv4()
                     + '@kinotic.js.EventBus/replyHandler'
 
                 if (!this.initialConnectionSuccessful) {
@@ -318,11 +330,14 @@ export class StompConnectionManager {
                 }
             })
 
-            // A drop after the initial connect: the socket and everything the server held behind it are gone
+            // An open socket closing: the socket and everything the server held behind it are gone. A failed
+            // reconnect attempt also ends in CLOSED, but from CONNECTING, and loses nothing new.
+            let previousState: RxStompState = this.rxStomp.connectionState$.getValue()
             this.connectionStateSubscription = this.rxStomp.connectionState$.subscribe((state: RxStompState) => {
-                if (state === RxStompState.CLOSED && this.isActive && this.initialConnectionSuccessful) {
+                if (state === RxStompState.CLOSED && previousState === RxStompState.OPEN && this.isActive) {
                     this.connectionLostHandler?.()
                 }
+                previousState = state
             })
 
             this.isActive = true
@@ -336,6 +351,8 @@ export class StompConnectionManager {
             // teardown is in flight) is a no-op instead of a second rxStomp.deactivate()
             this.isActive = false
             await this.rxStomp.deactivate({force: force})
+            this.failPendingActivation?.('Deactivated before the connection was established')
+            this.failPendingActivation = null
             // watch() subscriptions survive deactivation and re-subscribe on the next activation.
             // The listeners below are per-activation state that activate() recreates, so they are
             // torn down with the connection.
@@ -379,6 +396,9 @@ export class StompConnectionManager {
      */
     private async signalFatal(err: Error): Promise<void> {
         this.debugLogger('Fatal error, deactivating connection: %O', err)
+        // a connect still waiting learns the cause, not the generic reason deactivate() would give it
+        this.failPendingActivation?.(err.message)
+        this.failPendingActivation = null
         await this.deactivate()
         this.fatalErrorsSubject.next(err)
     }

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
@@ -25,12 +25,6 @@ export class StompConnectionManager {
      * This will return true if a {@link ConnectOptions#maxConnectionAttempts} threshold was set and was reached
      */
     public maxConnectionAttemptsReached: boolean = false
-    /**
-     * Invoked on every reconnect with the new {@link replyToCri}. The reply destination is minted per
-     * connection, so the consumer the server still holds for the previous socket never receives this
-     * connection's replies.
-     */
-    public replyToCriChangedHandler: ((replyToCri: string) => void) | null = null
 
     /**
      * Invoked when an established connection drops, before any reconnect. The server releases everything it
@@ -64,8 +58,9 @@ export class StompConnectionManager {
     private _replyToCri: string | null = null
 
     /**
-     * The reply destination CRI for this connection, or null before a connection has been established.
-     * It is built from the server-generated replyToId returned in the CONNECTED frame.
+     * The reply destination CRI of the current connection, or null while there is none. It is minted on
+     * every CONNECTED frame from the server-generated replyToId and a discriminator of this connection's
+     * own, so the consumer the server still holds for a previous socket never receives this one's replies.
      */
     public get replyToCri(): string | null {
         return this._replyToCri
@@ -282,15 +277,12 @@ export class StompConnectionManager {
                 reject(reason)
             }
 
-            // Triggered on every CONNECTED frame, including reconnects. The replyToId is generated
-            // server side, so on reconnect it may change.
-            // serverHeaders$ is a BehaviorSubject on an rxStomp that outlives a deactivate/activate
-            // cycle, so a later activation is replayed the previous connection's frame on subscribe —
-            // skipping it stops activate() resolving with the replyToId that just went away. Stays on
-            // serverHeaders$ rather than connected$: rx-stomp emits the headers before it reports OPEN,
-            // so a changed replyToCri reaches replyToCriChangedHandler before anything can be sent on
-            // the new connection. The previous reply destination was released at the drop through
-            // connectionLostHandler, so nothing stale is re-subscribed here.
+            // Triggered on every CONNECTED frame, including reconnects; each one mints this connection's
+            // reply destination. serverHeaders$ is a BehaviorSubject on an rxStomp that outlives a
+            // deactivate/activate cycle, so a later activation is replayed the previous connection's frame
+            // on subscribe; skipping it stops activate() resolving with a destination that is gone. Stays on
+            // serverHeaders$ rather than connected$: rx-stomp emits the headers before it reports OPEN, so
+            // the destination is set before anything can be sent on the new connection.
             this.serverHeadersSubscription = this.rxStomp.serverHeaders$
                                                  .pipe(skip(this.rxStompHasConnected ? 1 : 0))
                                                  .subscribe(async (value: StompHeaders) => {
@@ -321,12 +313,9 @@ export class StompConnectionManager {
                     + connectedInfo.replyToId + ':' + uuidv4()
                     + '@kinotic.js.EventBus/replyHandler'
 
+                this._replyToCri = newReplyToCri
                 if (!this.initialConnectionSuccessful) {
-                    this._replyToCri = newReplyToCri
                     resolve(connectedInfo)
-                } else if (this._replyToCri !== newReplyToCri) {
-                    this._replyToCri = newReplyToCri
-                    this.replyToCriChangedHandler?.(newReplyToCri)
                 }
             })
 

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
@@ -39,7 +39,6 @@ export class StompConnectionManager {
     public readonly rxStomp: RxStomp = new RxStomp()
     private isActive: boolean = false
     private initialConnectedSubscription: Subscription | null = null
-    private initialFailureSubscription: Subscription | null = null
     private webSocketErrorsSubscription: Subscription | null = null
     private readonly INITIAL_RECONNECT_DELAY: number = 2000
     private readonly JITTER_MAX: number = 5000
@@ -252,7 +251,6 @@ export class StompConnectionManager {
             this.initialConnectedSubscription = this.rxStomp.connected$.subscribe(() =>{
                 // We only want these for the initial connection
                 this.initialConnectedSubscription?.unsubscribe()
-                this.initialFailureSubscription?.unsubscribe()
                 this.failPendingActivation = null
 
                 // Successful Connection
@@ -261,19 +259,9 @@ export class StompConnectionManager {
                 }
             })
 
-            // Route any fatal error that arrives before the initial connection succeeds into
-            // the activate() promise so the caller learns why the connection never came up.
-            this.initialFailureSubscription = this.fatalErrorsSubject.subscribe((err: Error) => {
-                this.initialConnectedSubscription?.unsubscribe()
-                this.initialFailureSubscription?.unsubscribe()
-                this.failPendingActivation = null
-                reject(err.message)
-            })
-
-            // deactivate() settles a connect that is still waiting for its socket
+            // A fatal error or a deactivate() before the socket opened rejects the connect with its reason
             this.failPendingActivation = (reason: string) => {
                 this.initialConnectedSubscription?.unsubscribe()
-                this.initialFailureSubscription?.unsubscribe()
                 reject(reason)
             }
 
@@ -344,13 +332,9 @@ export class StompConnectionManager {
             this.failPendingActivation = null
             // watch() subscriptions survive deactivation and re-subscribe on the next activation.
             // The listeners below are per-activation state that activate() recreates, so they are
-            // torn down with the connection.
-            // initialFailureSubscription is deliberately NOT torn down here: signalFatal()
-            // deactivates before emitting, so it must stay subscribed for the fatal error to
-            // reject a pending activate(). It self-unsubscribes when it fires. The stale
-            // connected-listener must go, though — on the persistent client it would otherwise
-            // fire on the next activation's CONNECTED frame and mark the initial connection
-            // successful before the new serverHeaders handler resolves it.
+            // torn down with the connection. The connected-listener in particular: on the persistent
+            // client it would otherwise fire on the next activation's CONNECTED frame and mark the
+            // initial connection successful before the new serverHeaders handler resolves it.
             this.initialConnectedSubscription?.unsubscribe()
             this.initialConnectedSubscription = null
             this.webSocketErrorsSubscription?.unsubscribe()

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
@@ -152,8 +152,7 @@ export class StompConnectionManager {
             // immediately before creating the socket — and handed back synchronously here. The
             // activation holds it until stompjs takes it, so one it never takes is closed with the
             // activation instead of being orphaned.
-            const userWebSocketFactory = options.webSocketFactory
-            const usesPreparedSocket = userWebSocketFactory != null || headerAuth
+            const usesPreparedSocket = options.webSocketFactory != null || headerAuth
             const takePreparedSocket = (): IWebSocket => {
                 const socket = activation.preparedSocket as IWebSocket
                 activation.preparedSocket = null
@@ -174,81 +173,14 @@ export class StompConnectionManager {
                 maxReconnectDelay: this.MAX_RECONNECT_DELAY,
                 reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
                 webSocketFactory: usesPreparedSocket ? takePreparedSocket : undefined,
-                beforeConnect: async (): Promise<void> => {
-                    if (activation.ended) {
-                        return
-                    }
-
-                    // Cookie-auth clients (browser, headerless credentials) can't read a rejected WS
-                    // upgrade, so probe the session over a readable REST status first — same host as
-                    // the socket, at the fixed SESSION_CHECK_PATH. A 401 means the cookie isn't (or is
-                    // no longer) valid — not retriable, so fail fast: this rejects the initial connect
-                    // and surfaces a fatal error on a later reconnect, instead of looping on an
-                    // unauthenticated socket. Other statuses (incl. a server without the route) proceed.
-                    if(!usesPreparedSocket){
-                        const sessionCheckUrl = buildServerUrl(server, 'http') + SESSION_CHECK_PATH
-                        try {
-                            const res = await fetch(sessionCheckUrl, { credentials: 'include' })
-                            if(res.status === 401){
-                                // Not signed in (or the session expired) — an expected outcome, not a
-                                // failure; fail the connect and the app routes to /login from here.
-                                await this.signalFatal(new Error('Authentication required'))
-                                return
-                            }
-                        } catch (e) {
-                            // Couldn't reach the check (network/CORS) — treat as transient and let the socket
-                            // try; the connection attempt that follows reports the real outcome.
-                            this.debugLogger('Session check at %s failed: %O', sessionCheckUrl, e)
-                        }
-                    }
-
-                    // If max connections are set, then make sure we have not exceeded that threshold
-                    if(options?.maxConnectionAttempts){
-                        this.connectionAttempts++
-
-                        if(this.connectionAttempts > options.maxConnectionAttempts){
-                            this.maxConnectionAttemptsReached = true
-                            // signalFatal rejects a still-pending activate() with this reason
-                            await this.signalFatal(new Error(
-                                'Max number of reconnection attempts reached',
-                                { cause: this.lastWebsocketError ?? undefined }
-                            ))
-                            return
-                        }else{
-                            await this.connectionJitterDelay();
-                        }
-                    }else{
-                        await this.connectionJitterDelay();
-                    }
-
-                    if(userWebSocketFactory){
-                        try {
-                            activation.preparedSocket = await userWebSocketFactory()
-                        } catch (e) {
-                            await this.signalFatal(new Error('WebSocket factory failed', { cause: e }))
-                        }
-                    } else if (headerAuth) {
-                        // resolved on every attempt so short-lived credentials refresh each connect
-                        try {
-                            const resolved = await credentialsResolver!.resolve(server)
-                            if (resolved?.authHeaders == null) {
-                                await this.signalFatal(new Error(
-                                    'Credentials resolver no longer supplies auth headers: ' + credentialsResolver!.name))
-                            } else {
-                                // The Node/Bun WebSocket accepts a `headers` option that the DOM lib typings omit.
-                                const WS = WebSocket as unknown as
-                                    new (url: string, opts: {headers: Record<string, string>}) => IWebSocket
-                                activation.preparedSocket = new WS(url, {headers: resolved.authHeaders})
-                            }
-                        } catch (e) {
-                            await this.signalFatal(new Error('Credential resolution failed', { cause: e }))
-                        }
-                    }
-                    // a deactivate() landed while the socket was being produced; stompjs will not take it
-                    if (activation.ended && activation.preparedSocket) {
-                        activation.preparedSocket.close()
-                        activation.preparedSocket = null
-                    }
+                beforeConnect: (): Promise<void> => {
+                    const attempt = this.prepareAttempt(activation, options, server, headerAuth)
+                    // stompjs resumes its _connect in the microtasks after the attempt settles and opens a socket
+                    // for whichever activation is active then; the teardown of this one waits one macrotask past
+                    // that so the next activation cannot be active yet
+                    const settled = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0))
+                    activation.attempt = attempt.then(settled, settled)
+                    return attempt
                 }
             }
 
@@ -265,9 +197,9 @@ export class StompConnectionManager {
                 this.lastWebsocketError = value
                 // The attempt that just failed was the last the budget allows — report now
                 // instead of paying the reconnect delay before the next beforeConnect notices.
-                if (options?.maxConnectionAttempts && this.connectionAttempts >= options.maxConnectionAttempts) {
+                if (!activation.ended && options?.maxConnectionAttempts && this.connectionAttempts >= options.maxConnectionAttempts) {
                     this.maxConnectionAttemptsReached = true
-                    await this.signalFatal(new Error(
+                    await this.signalFatal(activation, new Error(
                         'Max number of reconnection attempts reached',
                         { cause: value ?? undefined }
                     ))
@@ -278,13 +210,15 @@ export class StompConnectionManager {
             // connection and indicate an unrecoverable condition (auth failure, protocol error).
             activation.own(this.rxStomp.stompErrors$.subscribe(async (frame: IFrame) => {
                 const stompError = new Error(frame.headers['message'] as string, { cause: frame })
-                await this.signalFatal(new Error('STOMP connection error', { cause: stompError }))
+                await this.signalFatal(activation, new Error('STOMP connection error', { cause: stompError }))
             }))
 
-            // The first connection of this activation: from here the connect can only resolve
+            // The first connection of this activation: from here the connect can only resolve. Each connection
+            // gets the full attempt budget again for its reconnects.
             activation.own(this.rxStomp.connected$.subscribe(() =>{
                 activation.established()
                 this.initialConnectionSuccessful = true
+                this.connectionAttempts = 0
             }))
 
             // A fatal error or a deactivate() before the socket opened rejects the connect with its reason
@@ -304,8 +238,8 @@ export class StompConnectionManager {
                 const connectedInfoJson: string | undefined = value[EventConstants.CONNECTED_INFO_HEADER]
                 if (connectedInfoJson == null) {
                     if (!this.initialConnectionSuccessful) {
+                        activation.failIfPending(new Error('Server did not return proper data for successful login'))
                         await this.deactivate()
-                        reject('Server did not return proper data for successful login')
                     }
                     return
                 }
@@ -313,8 +247,8 @@ export class StompConnectionManager {
                 const connectedInfo: ConnectedInfo = JSON.parse(connectedInfoJson)
                 if (connectedInfo.replyToId == null) {
                     if (!this.initialConnectionSuccessful) {
+                        activation.failIfPending(new Error('Server did not return a replyToId for successful login'))
                         await this.deactivate()
-                        reject('Server did not return a replyToId for successful login')
                     }
                     return
                 }
@@ -348,6 +282,96 @@ export class StompConnectionManager {
     }
 
     /**
+     * One connection attempt of the activation, run by stompjs before it opens the socket: the session
+     * check, the attempt budget, the reconnect jitter, and the socket or headers the attempt needs.
+     * A fatal outcome ends the activation from here and the attempt still resolves.
+     */
+    private async prepareAttempt(activation: StompActivation,
+                                 options: ConnectOptions,
+                                 server: ServerInfo,
+                                 headerAuth: boolean): Promise<void> {
+        const credentialsResolver: CredentialsResolver | undefined = options.credentials
+        const userWebSocketFactory = options.webSocketFactory
+        const usesPreparedSocket = userWebSocketFactory != null || headerAuth
+        const url = buildBrokerUrl(server)
+
+        // Cookie-auth clients (browser, headerless credentials) can't read a rejected WS
+        // upgrade, so probe the session over a readable REST status first — same host as
+        // the socket, at the fixed SESSION_CHECK_PATH. A 401 means the cookie isn't (or is
+        // no longer) valid — not retriable, so fail fast: this rejects the initial connect
+        // and surfaces a fatal error on a later reconnect, instead of looping on an
+        // unauthenticated socket. Other statuses (incl. a server without the route) proceed.
+        if(!usesPreparedSocket){
+            const sessionCheckUrl = buildServerUrl(server, 'http') + SESSION_CHECK_PATH
+            try {
+                const res = await fetch(sessionCheckUrl, { credentials: 'include' })
+                if(res.status === 401){
+                    // Not signed in (or the session expired) — an expected outcome, not a
+                    // failure; fail the connect and the app routes to /login from here.
+                    await this.signalFatal(activation, new Error('Authentication required'))
+                    return
+                }
+            } catch (e) {
+                // Couldn't reach the check (network/CORS) — treat as transient and let the socket
+                // try; the connection attempt that follows reports the real outcome.
+                this.debugLogger('Session check at %s failed: %O', sessionCheckUrl, e)
+            }
+        }
+
+        // If max connections are set, then make sure we have not exceeded that threshold
+        if(options?.maxConnectionAttempts){
+            this.connectionAttempts++
+
+            if(this.connectionAttempts > options.maxConnectionAttempts){
+                this.maxConnectionAttemptsReached = true
+                // signalFatal rejects a still-pending activate() with this reason
+                await this.signalFatal(activation, new Error(
+                    'Max number of reconnection attempts reached',
+                    { cause: this.lastWebsocketError ?? undefined }
+                ))
+                return
+            }else{
+                await this.connectionJitterDelay(activation);
+            }
+        }else{
+            await this.connectionJitterDelay(activation);
+        }
+        // a deactivate() during the delay ends the attempt before it produces anything
+        if (activation.ended) {
+            return
+        }
+
+        if(userWebSocketFactory){
+            try {
+                activation.preparedSocket = await userWebSocketFactory()
+            } catch (e) {
+                await this.signalFatal(activation, new Error('WebSocket factory failed', { cause: e }))
+            }
+        } else if (headerAuth) {
+            // resolved on every attempt so short-lived credentials refresh each connect
+            try {
+                const resolved = await credentialsResolver!.resolve(server)
+                if (resolved?.authHeaders == null) {
+                    await this.signalFatal(activation, new Error(
+                        'Credentials resolver no longer supplies auth headers: ' + credentialsResolver!.name))
+                } else {
+                    // The Node/Bun WebSocket accepts a `headers` option that the DOM lib typings omit.
+                    const WS = WebSocket as unknown as
+                        new (url: string, opts: {headers: Record<string, string>}) => IWebSocket
+                    activation.preparedSocket = new WS(url, {headers: resolved.authHeaders})
+                }
+            } catch (e) {
+                await this.signalFatal(activation, new Error('Credential resolution failed', { cause: e }))
+            }
+        }
+        // a deactivate() landed while the socket was being produced; stompjs will not take it
+        if (activation.ended && activation.preparedSocket) {
+            activation.preparedSocket.close()
+            activation.preparedSocket = null
+        }
+    }
+
+    /**
      * Ends the current activation. A second call while the socket is still closing returns the same
      * teardown; a call while inactive resolves at once.
      * @param force close the socket without a DISCONNECT frame
@@ -357,21 +381,22 @@ export class StompConnectionManager {
         let ret: Promise<void>
         if (activation) {
             this.activation = null
-            activation.ended = true
+            activation.end()
             const wasOpen = this.rxStomp.connected()
             this._replyToCri = null
             // a connect still waiting for its socket is settled now, not after the close round trip
-            activation.failIfPending('Deactivated before the connection was established')
+            activation.failIfPending(new Error('Deactivated before the connection was established'))
             // a socket produced for stompjs that it never took
             activation.preparedSocket?.close()
             activation.preparedSocket = null
-            const teardown: Promise<void> = this.rxStomp.deactivate({force: force}).finally(() => {
+            // stompjs resolves at once while an attempt is still in beforeConnect, so the attempt is waited for too
+            const teardown: Promise<void> = this.rxStomp.deactivate({force: force})
+                                                .then(() => activation.attempt ?? undefined)
+                                                .finally(() => {
                 // watch() subscriptions survive deactivation and re-subscribe on the next activation; the
                 // listeners this activation owns end with it
                 activation.unsubscribeAll()
-                if (this.teardown === teardown) {
-                    this.teardown = null
-                }
+                this.teardown = null
                 if (wasOpen) {
                     this.connectionLostHandler?.()
                 }
@@ -387,26 +412,28 @@ export class StompConnectionManager {
     /**
      * Make sure clients don't all try to reconnect at the same time.
      */
-    private async connectionJitterDelay(): Promise<void> {
+    private async connectionJitterDelay(activation: StompActivation): Promise<void> {
         if(this.initialConnectionSuccessful) {
             const randomJitter = Math.random() * this.JITTER_MAX;
             this.debugLogger(`Adding ${randomJitter}ms of jitter delay`)
-            return new Promise(resolve => setTimeout(resolve, randomJitter));
+            await activation.delay(randomJitter)
         }
     }
 
     /**
-     * Tears down the connection then publishes the failure to {@link fatalErrors}. Deactivating
-     * first means subscribers see the error already in its terminal state — no further reconnection
-     * attempts, no live rxStomp — so they can react without racing the cleanup. The error is also
-     * available to subscribers via {@link fatalErrors}; this only traces it for local debugging.
+     * Tears down the activation the failure belongs to, then publishes the failure to {@link fatalErrors}.
+     * Deactivating first means subscribers see the error already in its terminal state — no further
+     * reconnection attempts, no live rxStomp — so they can react without racing the cleanup.
      */
-    private async signalFatal(err: Error): Promise<void> {
-        this.debugLogger('Fatal error, deactivating connection: %O', err)
-        // a connect still waiting learns the cause, not the generic reason deactivate() would give it
-        this.activation?.failIfPending(err.message)
-        await this.deactivate()
-        this.fatalErrorsSubject.next(err)
+    private async signalFatal(activation: StompActivation, err: Error): Promise<void> {
+        // deactivate() has ended and reported this activation; a failure of its attempt is nobody's news
+        if (!activation.ended) {
+            this.debugLogger('Fatal error, deactivating connection: %O', err)
+            // a connect still waiting learns the cause, not the generic reason deactivate() would give it
+            activation.failIfPending(err)
+            await this.deactivate()
+            this.fatalErrorsSubject.next(err)
+        }
     }
 
 }

--- a/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/StompConnectionManager.ts
@@ -52,6 +52,8 @@ export class StompConnectionManager {
     private serverHeadersSubscription: Subscription | null = null
     private stompErrorsSubscription: Subscription | null = null
     private connectionStateSubscription: Subscription | null = null
+    // Rejects the activate() promise whose socket has not opened yet, so a fatal error or a deactivate()
+    // in that window settles the connect instead of leaving it waiting; null once the connection is up
     private failPendingActivation: ((reason: string) => void) | null = null
 
     private _replyToCri: string | null = null

--- a/kinotic-js/workspace/packages/core/test/ConnectionLifecycle.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ConnectionLifecycle.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { firstValueFrom, toArray } from 'rxjs'
+import { Event, EventConstants, type IEvent, type ConnectOptions, type IWebSocket } from '../src'
+import { EventBus } from '../src/api/event/EventBus'
+import { FakeStompServer, type FakeFrame, type FakeSocket } from './FakeStompServer'
+
+const SERVICE = 'srv://test~com.example.Service/echo'
+
+function options(server: FakeStompServer, extra: Partial<ConnectOptions> = {}): ConnectOptions {
+    return { server: { host: 'fake', useSSL: false }, webSocketFactory: server.factory as () => IWebSocket, ...extra }
+}
+
+// answers every SEND with a single-value reply carrying the request's correlation id
+function echo(frame: FakeFrame, socket: FakeSocket): void {
+    socket.message(frame.headers[EventConstants.REPLY_TO_HEADER]!, {
+        [EventConstants.CORRELATION_ID_HEADER]: frame.headers[EventConstants.CORRELATION_ID_HEADER]!,
+        [EventConstants.CONTENT_TYPE_HEADER]: EventConstants.CONTENT_JSON,
+        [EventConstants.CONTROL_HEADER]: EventConstants.CONTROL_VALUE_COMPLETE
+    }, JSON.stringify('echoed'))
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+describe('connection lifecycle', () => {
+
+    it('answers a request over a connection and the reply destination names the connection', async () => {
+        const server = new FakeStompServer()
+        server.onSend = echo
+        const bus = new EventBus()
+        const connected = await bus.connect(options(server))
+        expect(connected.replyToId).toBe('reply-1')
+
+        const reply = await bus.request(new Event(SERVICE))
+        expect(JSON.parse(reply.getDataString())).toBe('echoed')
+        const send = server.current.received.find(f => f.command === 'SEND')!
+        expect(send.headers[EventConstants.REPLY_TO_HEADER]).toMatch(/^reply:\/\/reply-1:[0-9a-f-]{36}@/)
+        await bus.disconnect()
+    })
+
+    it('fails the calls in flight when the socket drops, reports the loss once, and reconnects on a fresh destination', async () => {
+        const server = new FakeStompServer()
+        const bus = new EventBus()
+        let lost = 0
+        bus.connectionLost.subscribe(() => lost++)
+        await bus.connect(options(server))
+        const firstSocket = server.current
+
+        const pending = bus.request(new Event(SERVICE))
+        await sleep(10)
+        firstSocket.drop()
+        await expect(pending).rejects.toThrow('Connection lost')
+        expect(lost).toBe(1)
+
+        // rx-stomp reconnects after its delay plus the client's jitter; the new socket mints a new destination
+        server.onSend = echo
+        const deadline = Date.now() + 15_000
+        while (!bus.isConnected() && Date.now() < deadline) {
+            await sleep(50)
+        }
+        expect(bus.isConnected()).toBe(true)
+        expect(server.current).not.toBe(firstSocket)
+        await bus.request(new Event(SERVICE))
+        const firstReplyTo = firstSocket.received.find(f => f.command === 'SEND')!.headers[EventConstants.REPLY_TO_HEADER]
+        const secondReplyTo = server.current.received.find(f => f.command === 'SEND')!.headers[EventConstants.REPLY_TO_HEADER]
+        expect(secondReplyTo).not.toBe(firstReplyTo)
+        expect(lost).toBe(1)
+        await bus.disconnect()
+        expect(lost).toBe(2)
+    }, 30_000)
+
+    it('rejects a connect still waiting for its socket when disconnect() is called', async () => {
+        const server = new FakeStompServer()
+        server.silent = true
+        const bus = new EventBus()
+        const connecting = bus.connect(options(server))
+        await sleep(20)
+        await bus.disconnect()
+        await expect(connecting).rejects.toBe('Deactivated before the connection was established')
+        expect(bus.isConnectionActive()).toBe(false)
+    })
+
+    it('connects again while the previous activation is still closing after a fatal error', async () => {
+        const server = new FakeStompServer()
+        server.closeDelayMs = 300
+        server.onSend = echo
+        const bus = new EventBus()
+        await bus.connect(options(server))
+
+        // Two ERROR frames before the socket closes: the second fatal is reported while the first one's
+        // teardown is still waiting on the close, and the reconnect is issued from that notification
+        let reconnects = 0
+        const reconnected = new Promise<void>((resolve, reject) => {
+            bus.fatalErrors.subscribe(() => {
+                if (reconnects++ === 0) {
+                    bus.connect(options(server)).then(() => resolve(), reject)
+                }
+            })
+        })
+        server.current.error('rejected by the gateway')
+        server.current.refuse('rejected by the gateway again')
+        await reconnected
+
+        expect(bus.isConnected()).toBe(true)
+        const reply = await bus.request(new Event(SERVICE))
+        expect(JSON.parse(reply.getDataString())).toBe('echoed')
+        await bus.disconnect()
+    })
+
+    it('closes a socket produced for a connect that was deactivated while the socket was being made', async () => {
+        const server = new FakeStompServer()
+        const bus = new EventBus()
+        const slowFactory = async (): Promise<IWebSocket> => {
+            await sleep(200)
+            return server.factory()
+        }
+        const connecting = bus.connect(options(server, { webSocketFactory: slowFactory }))
+        await sleep(50)
+        await bus.disconnect()
+        await expect(connecting).rejects.toBe('Deactivated before the connection was established')
+        await sleep(300)
+        expect(server.sockets.length).toBe(1)
+        expect(server.sockets[0]!.closedByClient).toBe(true)
+    })
+
+    it('ends a stream on a bodiless completion without emitting it as a value', async () => {
+        const server = new FakeStompServer()
+        server.onSend = (frame, socket) => {
+            const replyTo = frame.headers[EventConstants.REPLY_TO_HEADER]!
+            const correlationId = frame.headers[EventConstants.CORRELATION_ID_HEADER]!
+            socket.message(replyTo, { [EventConstants.CORRELATION_ID_HEADER]: correlationId,
+                                      [EventConstants.CONTENT_TYPE_HEADER]: EventConstants.CONTENT_JSON }, '1')
+            socket.message(replyTo, { [EventConstants.CORRELATION_ID_HEADER]: correlationId,
+                                      [EventConstants.CONTROL_HEADER]: EventConstants.CONTROL_VALUE_COMPLETE })
+        }
+        const bus = new EventBus()
+        await bus.connect(options(server))
+        const values: IEvent[] = await firstValueFrom(bus.requestStream(new Event(SERVICE), true).pipe(toArray()))
+        expect(values.map(v => v.getDataString())).toEqual(['1'])
+        await bus.disconnect()
+    })
+
+    it('refuses a request while the connection is down instead of caching a stale reply destination', async () => {
+        const server = new FakeStompServer()
+        server.onSend = echo
+        const bus = new EventBus()
+        await bus.connect(options(server))
+        server.current.drop()
+        await sleep(10)
+        await expect(bus.request(new Event(SERVICE))).rejects.toThrow('not connected')
+        await bus.disconnect()
+    })
+})

--- a/kinotic-js/workspace/packages/core/test/ConnectionLifecycle.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ConnectionLifecycle.test.ts
@@ -75,7 +75,7 @@ describe('connection lifecycle', () => {
         const connecting = bus.connect(options(server))
         await sleep(20)
         await bus.disconnect()
-        await expect(connecting).rejects.toBe('Deactivated before the connection was established')
+        await expect(connecting).rejects.toThrow('Deactivated before the connection was established')
         expect(bus.isConnectionActive()).toBe(false)
     })
 
@@ -86,20 +86,21 @@ describe('connection lifecycle', () => {
         const bus = new EventBus()
         await bus.connect(options(server))
 
-        // Two ERROR frames before the socket closes: the second fatal is reported while the first one's
-        // teardown is still waiting on the close, and the reconnect is issued from that notification
-        let reconnects = 0
+        // Two ERROR frames before the socket closes: the second lands on the activation the first one ended,
+        // so one fatal is reported, and the reconnect is issued from that notification
+        const fatals: Error[] = []
         const reconnected = new Promise<void>((resolve, reject) => {
-            bus.fatalErrors.subscribe(() => {
-                if (reconnects++ === 0) {
-                    bus.connect(options(server)).then(() => resolve(), reject)
-                }
+            bus.fatalErrors.subscribe(error => {
+                fatals.push(error)
+                bus.connect(options(server)).then(() => resolve(), reject)
             })
         })
         server.current.error('rejected by the gateway')
         server.current.refuse('rejected by the gateway again')
         await reconnected
+        await sleep(400)
 
+        expect(fatals.length).toBe(1)
         expect(bus.isConnected()).toBe(true)
         const reply = await bus.request(new Event(SERVICE))
         expect(JSON.parse(reply.getDataString())).toBe('echoed')
@@ -116,11 +117,115 @@ describe('connection lifecycle', () => {
         const connecting = bus.connect(options(server, { webSocketFactory: slowFactory }))
         await sleep(50)
         await bus.disconnect()
-        await expect(connecting).rejects.toBe('Deactivated before the connection was established')
+        await expect(connecting).rejects.toThrow('Deactivated before the connection was established')
         await sleep(300)
         expect(server.sockets.length).toBe(1)
         expect(server.sockets[0]!.closedByClient).toBe(true)
     })
+
+    it('rejects the connect with the server defect when CONNECTED carries no connected-info', async () => {
+        const server = new FakeStompServer()
+        server.connectedInfo = false
+        const bus = new EventBus()
+        await expect(bus.connect(options(server))).rejects.toThrow('Server did not return proper data for successful login')
+        expect(bus.isConnectionActive()).toBe(false)
+    })
+
+    it('reports no fatal for a socket factory that fails after disconnect() ended its activation', async () => {
+        const server = new FakeStompServer()
+        const bus = new EventBus()
+        const fatals: Error[] = []
+        bus.fatalErrors.subscribe(error => fatals.push(error))
+        const failingFactory = async (): Promise<IWebSocket> => {
+            await sleep(100)
+            throw new Error('refresh failed')
+        }
+        const connecting = bus.connect(options(server, { webSocketFactory: failingFactory }))
+        await sleep(20)
+        await bus.disconnect()
+        await expect(connecting).rejects.toThrow('Deactivated before the connection was established')
+        await sleep(200)
+        expect(fatals).toEqual([])
+    })
+
+    it('reports no fatal when disconnect() closes a socket that was still connecting on the last attempt of the budget', async () => {
+        const server = new FakeStompServer()
+        server.openDelayMs = 200
+        const bus = new EventBus()
+        const fatals: Error[] = []
+        bus.fatalErrors.subscribe(error => fatals.push(error))
+        const connecting = bus.connect(options(server, { maxConnectionAttempts: 1 }))
+        await sleep(20)
+        await bus.disconnect()
+        await expect(connecting).rejects.toThrow('Deactivated before the connection was established')
+        await sleep(50)
+        expect(fatals).toEqual([])
+        expect(bus.isConnectionActive()).toBe(false)
+    })
+
+    it('settles a disconnect() issued right behind a connect() the server never answers', async () => {
+        const server = new FakeStompServer()
+        server.silent = true
+        const bus = new EventBus()
+        const connecting = bus.connect(options(server))
+        const disconnecting = bus.disconnect()
+        await expect(Promise.race([disconnecting, sleep(1000).then(() => { throw new Error('disconnect still pending') })])).resolves.toBeUndefined()
+        await expect(connecting).rejects.toThrow('Disconnected before the connection was started')
+        expect(bus.isConnectionActive()).toBe(false)
+    })
+
+    it('a reconnect attempt of an activation that disconnect() ended never acts on the next activation', async () => {
+        const server = new FakeStompServer()
+        server.onSend = echo
+        const bus = new EventBus()
+        const fatals: Error[] = []
+        bus.fatalErrors.subscribe(error => fatals.push(error))
+        let calls = 0
+        let reconnectAttemptInFactory: () => void = () => {}
+        const attemptReachedFactory = new Promise<void>(resolve => reconnectAttemptInFactory = resolve)
+        const factory = async (): Promise<IWebSocket> => {
+            const call = ++calls
+            // the reconnect attempt of the first activation: disconnect() ends the activation while it waits here
+            if (call === 2) {
+                reconnectAttemptInFactory()
+                await sleep(300)
+                throw new Error('refresh failed')
+            }
+            await sleep(50)
+            return server.factory()
+        }
+        await bus.connect(options(server, { webSocketFactory: factory }))
+        server.current.drop()
+        await attemptReachedFactory
+        await bus.disconnect()
+        await bus.connect(options(server, { webSocketFactory: factory }))
+        await sleep(300)
+
+        expect(bus.isConnected()).toBe(true)
+        expect(fatals).toEqual([])
+        expect(server.sockets.length).toBe(2)
+        const reply = await bus.request(new Event(SERVICE))
+        expect(JSON.parse(reply.getDataString())).toBe('echoed')
+        await bus.disconnect()
+    }, 15_000)
+
+    it('grants a connection the full attempt budget again for its reconnects', async () => {
+        const server = new FakeStompServer()
+        server.onSend = echo
+        const bus = new EventBus()
+        const fatals: Error[] = []
+        bus.fatalErrors.subscribe(error => fatals.push(error))
+        await bus.connect(options(server, { maxConnectionAttempts: 1 }))
+        server.current.drop()
+
+        const deadline = Date.now() + 15_000
+        while (!bus.isConnected() && fatals.length === 0 && Date.now() < deadline) {
+            await sleep(50)
+        }
+        expect(fatals).toEqual([])
+        expect(bus.isConnected()).toBe(true)
+        await bus.disconnect()
+    }, 20_000)
 
     it('ends a stream on a bodiless completion without emitting it as a value', async () => {
         const server = new FakeStompServer()

--- a/kinotic-js/workspace/packages/core/test/FakeStompServer.ts
+++ b/kinotic-js/workspace/packages/core/test/FakeStompServer.ts
@@ -1,0 +1,181 @@
+import type { IWebSocket } from '../src'
+import { EventConstants } from '../src'
+
+/**
+ * A STOMP frame as the fake server parsed or built it.
+ */
+export interface FakeFrame {
+    command: string
+    headers: Record<string, string>
+    body: string
+}
+
+/**
+ * An in-process STOMP server behind a WebSocket factory, so the client's connection lifecycle can be
+ * driven without a gateway: it answers CONNECT with a connected-info header, records subscriptions and
+ * sends, delivers MESSAGE frames back on a subscription, and can drop the socket, refuse with ERROR, or
+ * stay silent. One FakeSocket per connection attempt; the latest is the live one.
+ */
+export class FakeStompServer {
+
+    public readonly sockets: FakeSocket[] = []
+    /** Answers a SEND with frames to deliver to the client; null delivers nothing. */
+    public onSend: ((frame: FakeFrame, socket: FakeSocket) => void) | null = null
+    /** When true, CONNECT is never answered. */
+    public silent: boolean = false
+    /** Milliseconds between the client's close() and the socket reporting closed. */
+    public closeDelayMs: number = 0
+    private replyToCounter: number = 0
+
+    public readonly factory = (): IWebSocket => {
+        const socket = new FakeSocket(this, 'reply-' + (++this.replyToCounter))
+        this.sockets.push(socket)
+        return socket
+    }
+
+    public get current(): FakeSocket {
+        return this.sockets[this.sockets.length - 1]!
+    }
+}
+
+export class FakeSocket implements IWebSocket {
+
+    public url: string = 'ws://fake/v1'
+    public binaryType?: string
+    public readyState: number = 0
+    public onopen: ((ev?: any) => any) | undefined | null = null
+    public onclose: ((ev?: any) => any) | undefined | null = null
+    public onerror: ((ev: any) => any) | undefined | null = null
+    public onmessage: ((ev: any) => any) | undefined | null = null
+    public readonly received: FakeFrame[] = []
+    /** subscription id by destination, as the client subscribed */
+    public readonly subscriptions: Map<string, string> = new Map()
+    public closedByClient: boolean = false
+    private messageId: number = 0
+
+    constructor(private readonly server: FakeStompServer, public readonly replyToId: string) {
+        setTimeout(() => {
+            if (this.readyState === 0) {
+                this.readyState = 1
+                this.onopen?.({})
+            }
+        }, 0)
+    }
+
+    public send(data: string | ArrayBuffer): void {
+        const text = typeof data === 'string' ? data : new TextDecoder().decode(data)
+        for (const raw of text.split('\0')) {
+            if (raw.trim().length === 0) {
+                continue
+            }
+            const frame = parseFrame(raw)
+            this.received.push(frame)
+            this.handle(frame)
+        }
+    }
+
+    public close(): void {
+        this.closedByClient = true
+        this.finish(1000, 'closed by client', this.server.closeDelayMs)
+    }
+
+    /** The network drops: the socket reports an unclean close without the client asking. */
+    public drop(): void {
+        this.finish(1006, 'dropped', 0)
+    }
+
+    /** The server sends an ERROR frame and keeps the socket open. */
+    public error(message: string): void {
+        this.deliver({ command: 'ERROR', headers: { message }, body: '' })
+    }
+
+    /** The server refuses the connection with an ERROR frame and closes, as the gateway does. */
+    public refuse(message: string): void {
+        this.error(message)
+        this.finish(1002, 'refused', this.server.closeDelayMs)
+    }
+
+    /** Delivers a MESSAGE on the subscription the client holds for the destination. */
+    public message(destination: string, headers: Record<string, string>, body?: string): void {
+        const subscription = this.subscriptions.get(destination)
+        if (subscription === undefined) {
+            throw new Error('the client is not subscribed to ' + destination)
+        }
+        this.deliver({
+            command: 'MESSAGE',
+            headers: { subscription, destination, 'message-id': String(++this.messageId), ...headers },
+            body: body ?? ''
+        })
+    }
+
+    private handle(frame: FakeFrame): void {
+        switch (frame.command) {
+            case 'CONNECT':
+            case 'STOMP':
+                if (!this.server.silent) {
+                    const connectedInfo = JSON.stringify({ replyToId: this.replyToId, participant: { id: 'test' } })
+                    this.deliver({ command: 'CONNECTED',
+                                   headers: { version: '1.2', 'heart-beat': '0,0', [EventConstants.CONNECTED_INFO_HEADER]: connectedInfo },
+                                   body: '' })
+                }
+                break
+            case 'SUBSCRIBE':
+                this.subscriptions.set(frame.headers['destination']!, frame.headers['id']!)
+                break
+            case 'UNSUBSCRIBE':
+                for (const [destination, id] of this.subscriptions) {
+                    if (id === frame.headers['id']) {
+                        this.subscriptions.delete(destination)
+                    }
+                }
+                break
+            case 'SEND':
+                this.server.onSend?.(frame, this)
+                break
+            case 'DISCONNECT':
+                if (frame.headers['receipt']) {
+                    this.deliver({ command: 'RECEIPT', headers: { 'receipt-id': frame.headers['receipt'] }, body: '' })
+                }
+                break
+        }
+    }
+
+    private deliver(frame: FakeFrame): void {
+        if (this.readyState !== 1) {
+            return
+        }
+        const headers = Object.entries(frame.headers).map(([key, value]) => key + ':' + value).join('\n')
+        const body = frame.body
+        const contentLength = body.length > 0 ? '\ncontent-length:' + new TextEncoder().encode(body).length : ''
+        const raw = frame.command + '\n' + headers + contentLength + '\n\n' + body + '\0'
+        setTimeout(() => this.onmessage?.({ data: raw }), 0)
+    }
+
+    // CLOSING until the close event fires, as a real WebSocket is; stompjs waits for that event
+    private finish(code: number, reason: string, delayMs: number): void {
+        if (this.readyState >= 2) {
+            return
+        }
+        this.readyState = 2
+        setTimeout(() => {
+            this.readyState = 3
+            this.onclose?.({ code, reason, wasClean: code === 1000 })
+        }, delayMs)
+    }
+}
+
+function parseFrame(raw: string): FakeFrame {
+    const text = raw.replace(/^\n+/, '')
+    const separator = text.indexOf('\n\n')
+    const head = separator === -1 ? text : text.substring(0, separator)
+    const body = separator === -1 ? '' : text.substring(separator + 2)
+    const [command, ...headerLines] = head.split('\n')
+    const headers: Record<string, string> = {}
+    for (const line of headerLines) {
+        const colon = line.indexOf(':')
+        if (colon > 0) {
+            headers[line.substring(0, colon)] = line.substring(colon + 1).replace(/\\c/g, ':').replace(/\\n/g, '\n')
+        }
+    }
+    return { command: command!, headers, body }
+}

--- a/kinotic-js/workspace/packages/core/test/FakeStompServer.ts
+++ b/kinotic-js/workspace/packages/core/test/FakeStompServer.ts
@@ -23,6 +23,10 @@ export class FakeStompServer {
     public onSend: ((frame: FakeFrame, socket: FakeSocket) => void) | null = null
     /** When true, CONNECT is never answered. */
     public silent: boolean = false
+    /** When false, CONNECTED carries no connected-info header. */
+    public connectedInfo: boolean = true
+    /** Milliseconds a new socket stays CONNECTING before it opens. */
+    public openDelayMs: number = 0
     /** Milliseconds between the client's close() and the socket reporting closed. */
     public closeDelayMs: number = 0
     private replyToCounter: number = 0
@@ -59,7 +63,7 @@ export class FakeSocket implements IWebSocket {
                 this.readyState = 1
                 this.onopen?.({})
             }
-        }, 0)
+        }, server.openDelayMs)
     }
 
     public send(data: string | ArrayBuffer): void {
@@ -76,6 +80,10 @@ export class FakeSocket implements IWebSocket {
 
     public close(): void {
         this.closedByClient = true
+        // closing a socket that never opened reports an error first, as a WebSocket does
+        if (this.readyState === 0) {
+            this.onerror?.({})
+        }
         this.finish(1000, 'closed by client', this.server.closeDelayMs)
     }
 
@@ -113,10 +121,11 @@ export class FakeSocket implements IWebSocket {
             case 'CONNECT':
             case 'STOMP':
                 if (!this.server.silent) {
-                    const connectedInfo = JSON.stringify({ replyToId: this.replyToId, participant: { id: 'test' } })
-                    this.deliver({ command: 'CONNECTED',
-                                   headers: { version: '1.2', 'heart-beat': '0,0', [EventConstants.CONNECTED_INFO_HEADER]: connectedInfo },
-                                   body: '' })
+                    const headers: Record<string, string> = { version: '1.2', 'heart-beat': '0,0' }
+                    if (this.server.connectedInfo) {
+                        headers[EventConstants.CONNECTED_INFO_HEADER] = JSON.stringify({ replyToId: this.replyToId, participant: { id: 'test' } })
+                    }
+                    this.deliver({ command: 'CONNECTED', headers, body: '' })
                 }
                 break
             case 'SUBSCRIBE':

--- a/kinotic-js/workspace/packages/core/test/ServiceInvocationSupervisor.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ServiceInvocationSupervisor.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import { BehaviorSubject, type Observable, of } from 'rxjs'
+import { Event, EventConstants, RpcError, type ConnectOptions, type IWebSocket } from '../src'
+import { EventBus } from '../src/api/event/EventBus'
+import { ServiceIdentifier } from '../src/api/ServiceIdentifier'
+import { ServiceInvocationSupervisor } from '../src/internal/api/ServiceInvocationSupervisor'
+import { FakeStompServer, type FakeFrame, type FakeSocket } from './FakeStompServer'
+
+const SERVICE = new ServiceIdentifier('com.example', 'SupervisedService')
+const ADDRESS = SERVICE.cri().baseResource()
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+// The service under supervision. BigInt values are what the converter cannot serialise: JSON.stringify
+// throws on them.
+class SupervisedService {
+    public readonly current = new BehaviorSubject<unknown>(1n)
+    public release: (value: string) => void = () => {}
+
+    unserialisable(): Observable<unknown> {
+        return of(1n, 2n, 3n)
+    }
+
+    unserialisableOpen(): Observable<unknown> {
+        return this.current
+    }
+
+    fail(): string {
+        throw new RangeError('out of range')
+    }
+
+    /** Resolves when the test calls release. */
+    slow(): Promise<string> {
+        return new Promise(resolve => this.release = resolve)
+    }
+
+    greet(): string {
+        return 'hi'
+    }
+}
+
+function options(server: FakeStompServer): ConnectOptions {
+    return { server: { host: 'fake', useSSL: false }, webSocketFactory: server.factory as () => IWebSocket }
+}
+
+async function startSupervised(server: FakeStompServer): Promise<{ bus: EventBus, service: SupervisedService, supervisor: ServiceInvocationSupervisor }> {
+    const bus = new EventBus()
+    const service = new SupervisedService()
+    const supervisor = new ServiceInvocationSupervisor(SERVICE, service, bus, () => null)
+    supervisor.start()
+    await bus.connect(options(server))
+    return { bus, service, supervisor }
+}
+
+// Delivers an invocation of the method on the service's subscription, addressed the way the gateway
+// addresses one: the method is the path of the destination
+function invoke(socket: FakeSocket, method: string, correlationId: string): void {
+    socket.message(ADDRESS, {
+        destination: `${ADDRESS}/${method}`,
+        [EventConstants.REPLY_TO_HEADER]: `reply://${socket.replyToId}:caller@kinotic.js.EventBus/replyHandler`,
+        [EventConstants.CORRELATION_ID_HEADER]: correlationId,
+        [EventConstants.CONTENT_TYPE_HEADER]: EventConstants.CONTENT_JSON
+    })
+}
+
+function replies(socket: FakeSocket): FakeFrame[] {
+    return socket.received.filter(f => f.command === 'SEND')
+}
+
+// The reply as the caller's EventBus would see it
+function asEvent(frame: FakeFrame): Event {
+    const event = new Event(frame.headers['destination']!, new Map(Object.entries(frame.headers)))
+    event.setDataString(frame.body)
+    return event
+}
+
+describe('service invocation supervisor', () => {
+
+    it('answers a synchronous stream whose values cannot be serialised with one error reply and no completion', async () => {
+        const server = new FakeStompServer()
+        const { bus, supervisor } = await startSupervised(server)
+
+        invoke(server.current, 'unserialisable', 'c1')
+        await sleep(50)
+
+        const sent = replies(server.current)
+        expect(sent.length).toBe(1)
+        expect(sent[0]!.headers[EventConstants.ERROR_HEADER]).toBeDefined()
+        expect(sent[0]!.headers[EventConstants.CORRELATION_ID_HEADER]).toBe('c1')
+        expect(sent[0]!.headers[EventConstants.CONTROL_HEADER]).toBeUndefined()
+        expect(RpcError.fromEvent(asEvent(sent[0]!)).exceptionName).toBe('TypeError')
+        supervisor.stop()
+        await bus.disconnect()
+    })
+
+    it('ends a stream that fails on a value while its source is still inside subscribe', async () => {
+        const server = new FakeStompServer()
+        const { bus, service, supervisor } = await startSupervised(server)
+
+        invoke(server.current, 'unserialisableOpen', 'c1')
+        await sleep(50)
+
+        expect(replies(server.current).length).toBe(1)
+        expect(service.current.observed).toBe(false)
+        supervisor.stop()
+        await bus.disconnect()
+    })
+
+    it('describes the exception a method threw so a caller reads it as it reads a Java one', async () => {
+        const server = new FakeStompServer()
+        const { bus, supervisor } = await startSupervised(server)
+
+        invoke(server.current, 'fail', 'c1')
+        await sleep(50)
+
+        const sent = replies(server.current)
+        expect(sent.length).toBe(1)
+        expect(sent[0]!.headers[EventConstants.ERROR_HEADER]).toBe('out of range')
+        expect(JSON.parse(sent[0]!.body)).toEqual({ exceptionName: 'RangeError', exceptionClass: 'RangeError', errorMessage: 'out of range' })
+        const error = RpcError.fromEvent(asEvent(sent[0]!))
+        expect(error.exceptionName).toBe('RangeError')
+        expect(error.exceptionClass).toBe('RangeError')
+        expect(error.message).toBe('out of range')
+        supervisor.stop()
+        await bus.disconnect()
+    })
+
+    it('drops the result of an invocation received on a connection that was lost and answers one received on the next', async () => {
+        const server = new FakeStompServer()
+        const { bus, service, supervisor } = await startSupervised(server)
+        const firstSocket = server.current
+
+        invoke(firstSocket, 'slow', 'c1')
+        await sleep(50)
+        firstSocket.drop()
+        await sleep(10)
+
+        // rx-stomp reconnects after its delay plus the client's jitter
+        const deadline = Date.now() + 15_000
+        while (!bus.isConnected() && Date.now() < deadline) {
+            await sleep(50)
+        }
+        expect(bus.isConnected()).toBe(true)
+        expect(server.current).not.toBe(firstSocket)
+        await sleep(50)
+
+        service.release('late')
+        await sleep(50)
+        expect(replies(firstSocket)).toEqual([])
+        expect(replies(server.current)).toEqual([])
+
+        invoke(server.current, 'greet', 'c2')
+        await sleep(50)
+        const sent = replies(server.current)
+        expect(sent.length).toBe(1)
+        expect(sent[0]!.headers[EventConstants.CORRELATION_ID_HEADER]).toBe('c2')
+        expect(sent[0]!.headers[EventConstants.CONTROL_HEADER]).toBe(EventConstants.CONTROL_VALUE_COMPLETE)
+        expect(JSON.parse(sent[0]!.body)).toBe('hi')
+        supervisor.stop()
+        await bus.disconnect()
+    }, 30_000)
+})

--- a/kinotic-js/workspace/packages/vm-manager/src/index.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/index.ts
@@ -56,6 +56,11 @@ const RECONNECT_MAX_DELAY_MS = 120000
 const RECONNECT_MIN_JITTER_MS = 1000
 const RECONNECT_MAX_JITTER_MS = 5000
 
+// How long a graceful disconnect may take before the process exits with the socket still open. A
+// half-open socket answers neither the DISCONNECT frame nor the close, so a graceful disconnect on
+// one lasts the heartbeat timeout plus the WebSocket close timeout; the exit closes it instead.
+const DISCONNECT_TIMEOUT_MS = 5000
+
 // The node runs whichever provider it is configured for and nothing else, so a provider it
 // cannot construct is a fatal misconfiguration rather than a capability to omit
 function createProvider(reportStatus: (workload: Workload) => void): IVmProvider {
@@ -236,7 +241,7 @@ async function shutdown() {
         clearTimeout(heartbeatTimer)
     }
     await alloyManager?.stop()
-    await Kinotic.disconnect()
+    await Promise.race([Kinotic.disconnect(), Bun.sleep(DISCONNECT_TIMEOUT_MS)])
     process.exit(0)
 }
 

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/VmNodeService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/VmNodeService.java
@@ -4,6 +4,7 @@ import io.vertx.core.Future;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.system.api.model.workload.VmNode;
+import org.kinotic.system.api.model.workload.VmNodeStatus;
 
 /**
  * Service for managing {@link VmNode} entities.
@@ -20,5 +21,25 @@ public interface VmNodeService extends IdentifiableCrudService<VmNode, String> {
      * @return a future that will complete with a suitable node, or null if none available
      */
     Future<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb);
+
+    /**
+     * Sets a node's {@link VmNode#getStatus() status}, leaving every other field of the record as it is,
+     * and completes once the change is visible to {@link #findAvailableNode}.
+     * @param nodeId the id of the node to update
+     * @param status the node's new status
+     * @return a future that will complete when the status is stored, or fail if the node is not registered
+     */
+    Future<Void> updateStatusSync(String nodeId, VmNodeStatus status);
+
+    /**
+     * Sets a node's unallocated resources, leaving every other field of the record as it is, and completes
+     * once the change is visible to {@link #findAvailableNode}.
+     * @param nodeId the id of the node to update
+     * @param availableCpus the number of vCPUs not allocated to any workload
+     * @param availableMemoryMb the memory not allocated to any workload, in megabytes
+     * @param availableDiskMb the disk space not allocated to any workload, in megabytes
+     * @return a future that will complete when the allocation is stored, or fail if the node is not registered
+     */
+    Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb);
 
 }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/repositories/VmNodeRepository.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/repositories/VmNodeRepository.java
@@ -5,9 +5,12 @@ import org.kinotic.domain.internal.api.repositories.AbstractRepository;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import io.vertx.core.Future;
 import org.kinotic.system.api.model.workload.VmNode;
+import org.kinotic.system.api.model.workload.VmNodeStatus;
 import org.kinotic.system.api.model.workload.VmNodeStatusType;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 public class VmNodeRepository extends AbstractRepository<VmNode> {
@@ -25,6 +28,27 @@ public class VmNodeRepository extends AbstractRepository<VmNode> {
                                                     atLeast("availableCpus", requiredCpus),
                                                     atLeast("availableMemoryMb", requiredMemoryMb),
                                                     atLeast("availableDiskMb", requiredDiskMb))));
+    }
+
+    /**
+     * Sets a node's status through a partial update touching only {@code status}, visible to search on
+     * completion.
+     */
+    public Future<Void> updateStatusSync(String nodeId, VmNodeStatus status) {
+        return crudServiceTemplate.partialUpdateSync(indexName, nodeId, Map.of("status", status), false);
+    }
+
+    /**
+     * Sets a node's unallocated resources through a partial update touching only the {@code available*}
+     * fields, visible to search on completion.
+     */
+    public Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb) {
+        return crudServiceTemplate.partialUpdateSync(indexName,
+                                                     nodeId,
+                                                     Map.of("availableCpus", availableCpus,
+                                                            "availableMemoryMb", availableMemoryMb,
+                                                            "availableDiskMb", availableDiskMb),
+                                                     false);
     }
 
     private static Query atLeast(String field, int required) {

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeOrchestrationService.java
@@ -1,13 +1,13 @@
 package org.kinotic.system.internal.api.services;
 
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import org.kinotic.system.api.workload.VmManagerProxy;
 import org.kinotic.core.api.utils.KinoticUtil;
 import org.kinotic.core.api.service.ServiceIdentifier;
 import org.kinotic.core.api.event.ListenerStatus;
 import org.kinotic.core.api.event.EventBusService;
 import org.kinotic.core.api.event.CRI;
-import io.vertx.core.Promise;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +44,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
     private final VmNodeService vmNodeService;
     private final WorkloadService workloadService;
     private final EventBusService eventBusService;
+    private final Vertx vertx;
     private ScheduledExecutorService scheduler;
 
     @PostConstruct
@@ -94,7 +95,8 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                                 .setAvailableCpus(registration.getTotalCpus() - allocatedCpus)
                                 .setAvailableMemoryMb(registration.getTotalMemoryMb() - allocatedMemoryMb)
                                 .setAvailableDiskMb(registration.getTotalDiskMb() - allocatedDiskMb)
-                                .setStatus(new VmNodeStatus());
+                                .setStatus(new VmNodeStatus())
+                                .setLastSeen(new Date());
                         log.info("Re-registering VmNode: {} ({})", existing.getName(), existing.getId());
                         ret = vmNodeService.saveSync(existing);
                     } else {
@@ -108,6 +110,7 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                         node.setAvailableDiskMb(registration.getTotalDiskMb());
                         node.setWorkloadDataDir(registration.getWorkloadDataDir());
                         node.setStatus(new VmNodeStatus());
+                        node.setLastSeen(new Date());
                         log.info("Registering new VmNode: {} ({})", node.getName(), node.getId());
                         ret = vmNodeService.saveSync(node);
                     }
@@ -130,6 +133,8 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                                 new IllegalArgumentException("Node not registered: " + nodeId));
                     } else if (node.getStatus().getType() != reported
                             || !Objects.equals(node.getStatus().getHealthMessage(), message)) {
+                        // a heartbeat is the only evidence the node is alive; no other save stamps lastSeen
+                        node.setLastSeen(new Date());
                         if (message != null) {
                             log.warn("VmNode {} is not fit for workloads: {}", nodeId, message);
                         } else {
@@ -140,10 +145,9 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                         // has to be in the index before the next placement reads it
                         ret = vmNodeService.saveSync(node);
                     } else {
-                        // lastSeen is stamped by DefaultVmNodeService.beforeSave. Only
-                        // checkNodeHealth reads it, via a search against a heartbeatTimeoutSeconds
-                        // cutoff, so a refresh wait costs the caller the index refresh interval
-                        // and buys nothing.
+                        node.setLastSeen(new Date());
+                        // Only checkNodeHealth reads lastSeen, through a search against the
+                        // heartbeatTimeoutSeconds cutoff, so waiting for the index refresh buys nothing
                         ret = vmNodeService.save(node);
                     }
                     return ret;
@@ -225,10 +229,10 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
         Validate.notNull(nodeId, "Node id cannot be null");
         ServiceIdentifier vmManager = KinoticUtil.serviceIdentifierOf(VmManagerProxy.class);
         CRI address = new ServiceIdentifier(vmManager.zone(), vmManager.namespace(), vmManager.name(), nodeId, vmManager.version()).cri();
-        // the first emission is the current registration state; completes on the monitor's delivery context
-        Promise<ListenerStatus> registration = Promise.promise();
-        eventBusService.monitorListenerStatus(address).next().subscribe(registration::complete, registration::fail);
-        return registration.future()
+        // the first emission is the current registration state; it arrives on the monitor's delivery
+        // context, and the caller's context is restored before anything else runs
+        return Future.fromCompletionStage(eventBusService.monitorListenerStatus(address).next().toFuture(),
+                                          vertx.getOrCreateContext())
                            .compose(status -> status == ListenerStatus.ACTIVE
                                    ? Future.succeededFuture()
                                    : vmNodeService.findById(nodeId).compose(node -> markUnreachable(nodeId, node)));

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeOrchestrationService.java
@@ -245,16 +245,17 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
             ret = Future.succeededFuture();
         } else {
             log.warn("VmNode {} ({}) is unreachable and holds no vm-manager registration, taking no workloads", node.getName(), nodeId);
-            node.setStatus(new VmNodeStatus(VmNodeStatusType.UNREACHABLE, node.getStatus().getHealthMessage()));
-            // findAvailableNode selects on status.type with a search, so the change has to be indexed first
-            ret = vmNodeService.saveSync(node).mapEmpty();
+            // Only the status is written, so a heartbeat that landed after the read keeps its lastSeen.
+            // findAvailableNode selects on status.type with a search, so the change has to be indexed first.
+            ret = vmNodeService.updateStatusSync(nodeId,
+                                                 new VmNodeStatus(VmNodeStatusType.UNREACHABLE, node.getStatus().getHealthMessage()));
         }
         return ret;
     }
 
     /**
      * Periodically marks every node that has not sent a heartbeat within the timeout OFFLINE, whatever it
-     * reported last, and marks the workloads running on it FAILED.
+     * reported last, and marks every workload still on it FAILED.
      */
     private void checkNodeHealth() {
         try {
@@ -273,9 +274,11 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                                 log.warn("VmNode {} ({}) missed heartbeat, marking OFFLINE",
                                          node.getName(), node.getId());
 
-                                node.setStatus(new VmNodeStatus(VmNodeStatusType.OFFLINE, node.getStatus().getHealthMessage()));
-                                vmNodeService.saveSync(node)
-                                        .compose(offlineNode -> markNodeWorkloadsFailed(offlineNode.getId()))
+                                // Only the status is written, so a heartbeat that landed after findAll read
+                                // the node keeps its lastSeen
+                                vmNodeService.updateStatusSync(node.getId(),
+                                                               new VmNodeStatus(VmNodeStatusType.OFFLINE, node.getStatus().getHealthMessage()))
+                                        .compose(v -> markNodeWorkloadsFailed(node.getId()))
                                         .onFailure(error -> log.error("Error handling offline node {}", node.getId(), error));
                             }
                         }
@@ -291,8 +294,10 @@ public class DefaultVmNodeOrchestrationService implements VmNodeOrchestrationSer
                 .compose(page -> {
                     Future<Void> chain = Future.succeededFuture();
                     for (Workload workload : page.getContent()) {
+                        // a STOPPING workload is one whose stop never got an answer from the node
                         if (workload.getStatus() == WorkloadStatus.RUNNING
-                                || workload.getStatus() == WorkloadStatus.STARTING) {
+                                || workload.getStatus() == WorkloadStatus.STARTING
+                                || workload.getStatus() == WorkloadStatus.STOPPING) {
                             chain = chain.compose(v -> {
                                 log.warn("Marking workload {} as FAILED due to node {} going offline",
                                          workload.getId(), nodeId);

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeService.java
@@ -8,7 +8,6 @@ import org.kinotic.system.api.services.VmNodeService;
 import org.kinotic.system.internal.api.repositories.VmNodeRepository;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
 
 @Component
 public class DefaultVmNodeService extends AbstractCrudService<VmNode> implements VmNodeService {
@@ -29,7 +28,6 @@ public class DefaultVmNodeService extends AbstractCrudService<VmNode> implements
     protected Future<Void> beforeSave(VmNode entity) {
         Validate.notNull(entity, "VmNode cannot be null");
         Validate.notNull(entity.getId(), "VmNode id cannot be null");
-        entity.setLastSeen(new Date());
         return Future.succeededFuture();
     }
 

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeService.java
@@ -4,6 +4,7 @@ import io.vertx.core.Future;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.domain.internal.api.services.AbstractCrudService;
 import org.kinotic.system.api.model.workload.VmNode;
+import org.kinotic.system.api.model.workload.VmNodeStatus;
 import org.kinotic.system.api.services.VmNodeService;
 import org.kinotic.system.internal.api.repositories.VmNodeRepository;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,19 @@ public class DefaultVmNodeService extends AbstractCrudService<VmNode> implements
     @Override
     public Future<VmNode> findAvailableNode(int requiredCpus, int requiredMemoryMb, int requiredDiskMb) {
         return vmNodeRepository.findAvailableNode(requiredCpus, requiredMemoryMb, requiredDiskMb);
+    }
+
+    @Override
+    public Future<Void> updateStatusSync(String nodeId, VmNodeStatus status) {
+        Validate.notNull(nodeId, "VmNode id cannot be null");
+        Validate.notNull(status, "VmNode status cannot be null");
+        return vmNodeRepository.updateStatusSync(nodeId, status);
+    }
+
+    @Override
+    public Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb) {
+        Validate.notNull(nodeId, "VmNode id cannot be null");
+        return vmNodeRepository.updateAllocationSync(nodeId, availableCpus, availableMemoryMb, availableDiskMb);
     }
 
     @Override

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
@@ -68,15 +68,16 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                     workload.setNodeId(node.getId());
                     workload.setStatus(WorkloadStatus.STARTING);
 
-                    // Persist the workload and update node resource allocation
+                    // Persist the workload and update node resource allocation. Only the allocation is
+                    // written, so a heartbeat that landed after the placement read keeps its lastSeen.
                     return persistRedacted(workload)
-                            .compose(savedWorkload -> {
-                                node.setAvailableCpus(node.getAvailableCpus() - savedWorkload.getVcpus());
-                                node.setAvailableMemoryMb(node.getAvailableMemoryMb() - savedWorkload.getMemoryMb());
-                                node.setAvailableDiskMb(node.getAvailableDiskMb() - savedWorkload.getDiskSizeMb());
-                                return vmNodeService.saveSync(node)
-                                        .map(savedWorkload);
-                            })
+                            .compose(savedWorkload ->
+                                vmNodeService.updateAllocationSync(node.getId(),
+                                                                   node.getAvailableCpus() - savedWorkload.getVcpus(),
+                                                                   node.getAvailableMemoryMb() - savedWorkload.getMemoryMb(),
+                                                                   node.getAvailableDiskMb() - savedWorkload.getDiskSizeMb())
+                                        .map(savedWorkload)
+                            )
                             .compose(savedWorkload ->
                                 // Dispatch to the VmManager on the selected node. For a
                                 // non-detached workload the reply arrives once the run ends.
@@ -162,22 +163,24 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                     // Dispatch destroy to the VmManager on the workload's node
                     return verifyingNodeOnFailure(workload.getNodeId(), vmManagerProxy.destroyWorkload(workload.getNodeId(), workloadId))
                             .compose(v ->
-                                // Free allocated resources on the node
+                                // Free allocated resources on the node. Only the allocation is written, so a
+                                // heartbeat that landed after the read keeps its lastSeen.
                                 vmNodeService.findById(workload.getNodeId())
                                         .compose(node -> {
-                                            Future<VmNode> ret;
+                                            Future<Void> ret;
                                             if (node != null) {
-                                                node.setAvailableCpus(Math.min(node.getTotalCpus(), node.getAvailableCpus() + workload.getVcpus()));
-                                                node.setAvailableMemoryMb(Math.min(node.getTotalMemoryMb(), node.getAvailableMemoryMb() + workload.getMemoryMb()));
-                                                node.setAvailableDiskMb(Math.min(node.getTotalDiskMb(), node.getAvailableDiskMb() + workload.getDiskSizeMb()));
-                                                ret = vmNodeService.saveSync(node);
+                                                ret = vmNodeService.updateAllocationSync(
+                                                        node.getId(),
+                                                        Math.min(node.getTotalCpus(), node.getAvailableCpus() + workload.getVcpus()),
+                                                        Math.min(node.getTotalMemoryMb(), node.getAvailableMemoryMb() + workload.getMemoryMb()),
+                                                        Math.min(node.getTotalDiskMb(), node.getAvailableDiskMb() + workload.getDiskSizeMb()));
                                             } else {
-                                                ret = Future.succeededFuture(node);
+                                                ret = Future.succeededFuture();
                                             }
                                             return ret;
                                         })
                             )
-                            .compose(node -> workloadService.deleteById(workloadId));
+                            .compose(v -> workloadService.deleteById(workloadId));
                 });
     }
 

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubVmNodeService.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubVmNodeService.java
@@ -4,20 +4,28 @@ import io.vertx.core.Future;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.system.api.model.workload.VmNode;
+import org.kinotic.system.api.model.workload.VmNodeStatus;
 import org.kinotic.system.api.services.VmNodeService;
+import tools.jackson.databind.ObjectMapper;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 /**
  * In-memory stand-in for the Elasticsearch backed {@link VmNodeService}.
- * {@link #findAvailableNode} always places on {@link #availableNode}.
+ * {@link #findAvailableNode} always places on {@link #availableNode}. Records are stored and
+ * returned as serialization round-trips the way Elasticsearch documents are, so a caller's
+ * mutation of an entity after a save never alters the stored record, and a full save writes
+ * back exactly what the caller's copy holds. The partial updates change only their fields on
+ * the stored record and fail when the node has no record, as the real update does.
  */
 public class StubVmNodeService implements VmNodeService {
 
-    public final Map<String, VmNode> saved = new LinkedHashMap<>();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public final Map<String, VmNode> saved = new ConcurrentHashMap<>();
 
     public VmNode availableNode;
 
@@ -27,8 +35,34 @@ public class StubVmNodeService implements VmNodeService {
     }
 
     @Override
+    public Future<Void> updateStatusSync(String nodeId, VmNodeStatus status) {
+        return update(nodeId, node -> node.setStatus(status));
+    }
+
+    @Override
+    public Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb) {
+        return update(nodeId, node -> node.setAvailableCpus(availableCpus)
+                                          .setAvailableMemoryMb(availableMemoryMb)
+                                          .setAvailableDiskMb(availableDiskMb));
+    }
+
+    private Future<Void> update(String nodeId, Consumer<VmNode> partial) {
+        Future<Void> ret;
+        VmNode stored = saved.get(nodeId);
+        if (stored == null) {
+            ret = Future.failedFuture(new IllegalStateException("No VmNode record for " + nodeId));
+        } else {
+            partial.accept(stored);
+            // re-put so a reader on another thread sees the mutation through the map's happens-before
+            saved.put(nodeId, stored);
+            ret = Future.succeededFuture();
+        }
+        return ret;
+    }
+
+    @Override
     public Future<VmNode> save(VmNode entity) {
-        saved.put(entity.getId(), entity);
+        saved.put(entity.getId(), snapshot(entity));
         return Future.succeededFuture(entity);
     }
 
@@ -49,7 +83,12 @@ public class StubVmNodeService implements VmNodeService {
 
     @Override
     public Future<VmNode> findById(String id) {
-        return Future.succeededFuture(saved.get(id));
+        VmNode stored = saved.get(id);
+        return Future.succeededFuture(stored == null ? null : snapshot(stored));
+    }
+
+    private static VmNode snapshot(VmNode entity) {
+        return MAPPER.readValue(MAPPER.writeValueAsBytes(entity), VmNode.class);
     }
 
     @Override
@@ -70,7 +109,7 @@ public class StubVmNodeService implements VmNodeService {
 
     @Override
     public Future<Page<VmNode>> findAll(Pageable pageable) {
-        List<VmNode> all = new ArrayList<>(saved.values());
+        List<VmNode> all = saved.values().stream().map(StubVmNodeService::snapshot).toList();
         return Future.succeededFuture(new Page<>(all, (long) all.size()));
     }
 

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
@@ -1,6 +1,12 @@
 package org.kinotic.system.internal.api.services;
 
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import org.kinotic.core.api.event.CRI;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 import static org.mockito.ArgumentMatchers.any;
@@ -58,7 +64,7 @@ public class WorkloadOrchestrationTest {
         eventBus = mock(EventBusService.class);
         when(eventBus.monitorListenerStatus(any())).thenReturn(Flux.just(ListenerStatus.INACTIVE));
         properties = new KinoticSystemApiProperties();
-        nodeOrchestration = new DefaultVmNodeOrchestrationService(properties, nodes, workloads, eventBus);
+        nodeOrchestration = new DefaultVmNodeOrchestrationService(properties, nodes, workloads, eventBus, Vertx.vertx());
         orchestration = new DefaultWorkloadOrchestrationService(nodeOrchestration, vmManager,
                                                                 nodes, workloads);
     }
@@ -68,9 +74,38 @@ public class WorkloadOrchestrationTest {
         nodes.saveSync(nodes.availableNode);
         vmManager.failStartWith = new RpcMissingServiceException("no vm-manager registered for node-1");
 
+        Exception failure = assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
+        assertInstanceOf(RpcMissingServiceException.class, failure.getCause());
+
+        // the registration checked is the vm-manager scoped to this node, the address the proxy sends to
+        ArgumentCaptor<CRI> watched = ArgumentCaptor.forClass(CRI.class);
+        verify(eventBus).monitorListenerStatus(watched.capture());
+        assertEquals(NODE_ID, watched.getValue().scope());
+        assertTrue(watched.getValue().raw().contains("VmManager"), watched.getValue().raw());
+        assertEquals(VmNodeStatusType.UNREACHABLE, nodes.saved.get(NODE_ID).getStatus().getType());
+    }
+
+    @Test
+    public void ordinaryStartFailureDoesNotVerifyTheNode() throws Exception {
+        nodes.saveSync(nodes.availableNode);
+        vmManager.failStartWith = new RuntimeException("node exploded");
+
         assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
 
+        verify(eventBus, never()).monitorListenerStatus(any());
+        assertEquals(VmNodeStatusType.ONLINE, nodes.saved.get(NODE_ID).getStatus().getType());
+    }
+
+    @Test
+    public void heartbeatBringsAnUnreachableNodeBackOnline() throws Exception {
+        nodes.saveSync(nodes.availableNode);
+        vmManager.failStartWith = new RpcMissingServiceException("gone");
+        assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
         assertEquals(VmNodeStatusType.UNREACHABLE, nodes.saved.get(NODE_ID).getStatus().getType());
+
+        await(nodeOrchestration.heartbeat(NODE_ID, List.of()));
+
+        assertEquals(VmNodeStatusType.ONLINE, nodes.saved.get(NODE_ID).getStatus().getType());
     }
 
     @Test

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
@@ -17,12 +17,14 @@ import org.kinotic.core.api.exceptions.RpcServiceUnavailableException;
 import org.kinotic.core.api.exceptions.RpcMissingServiceException;
 import org.kinotic.core.api.event.ListenerStatus;
 import org.kinotic.core.api.event.EventBusService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kinotic.system.api.config.KinoticSystemApiProperties;
 import org.kinotic.system.api.model.workload.VmNode;
 import org.kinotic.system.api.model.workload.VmNodeStatus;
 import org.kinotic.system.api.model.workload.VmNodeStatusType;
+import org.kinotic.system.api.workload.VmNodeRegistration;
 import org.kinotic.management.api.model.workload.Workload;
 import org.kinotic.management.api.model.workload.WorkloadStatus;
 import org.kinotic.system.api.workload.WorkloadStatusReport;
@@ -50,6 +52,7 @@ public class WorkloadOrchestrationTest {
     private StubVmNodeService nodes;
     private StubVmManagerProxy vmManager;
     private EventBusService eventBus;
+    private Vertx vertx;
     private KinoticSystemApiProperties properties;
     private DefaultVmNodeOrchestrationService nodeOrchestration;
     private DefaultWorkloadOrchestrationService orchestration;
@@ -59,19 +62,25 @@ public class WorkloadOrchestrationTest {
         workloads = new StubWorkloadService();
         nodes = new StubVmNodeService();
         nodes.availableNode = new VmNode(NODE_ID, "node-1", "host-1");
+        nodes.saveSync(nodes.availableNode);
         vmManager = new StubVmManagerProxy();
         // the node's vm-manager registration, as the cluster reports it: absent unless a test says otherwise
         eventBus = mock(EventBusService.class);
         when(eventBus.monitorListenerStatus(any())).thenReturn(Flux.just(ListenerStatus.INACTIVE));
         properties = new KinoticSystemApiProperties();
-        nodeOrchestration = new DefaultVmNodeOrchestrationService(properties, nodes, workloads, eventBus, Vertx.vertx());
+        vertx = Vertx.vertx();
+        nodeOrchestration = new DefaultVmNodeOrchestrationService(properties, nodes, workloads, eventBus, vertx);
         orchestration = new DefaultWorkloadOrchestrationService(nodeOrchestration, vmManager,
                                                                 nodes, workloads);
     }
 
+    @AfterEach
+    void tearDown() throws Exception {
+        await(vertx.close());
+    }
+
     @Test
     public void unreachableVmManagerMarksItsNodeUnreachableAtOnce() throws Exception {
-        nodes.saveSync(nodes.availableNode);
         vmManager.failStartWith = new RpcMissingServiceException("no vm-manager registered for node-1");
 
         Exception failure = assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
@@ -82,12 +91,45 @@ public class WorkloadOrchestrationTest {
         verify(eventBus).monitorListenerStatus(watched.capture());
         assertEquals(NODE_ID, watched.getValue().scope());
         assertTrue(watched.getValue().raw().contains("VmManager"), watched.getValue().raw());
-        assertEquals(VmNodeStatusType.UNREACHABLE, nodes.saved.get(NODE_ID).getStatus().getType());
+        assertEquals(VmNodeStatusType.UNREACHABLE, awaitNodeStatus(VmNodeStatusType.UNREACHABLE));
+    }
+
+    @Test
+    public void markingUnreachableLeavesLastSeenAlone() throws Exception {
+        // The placement read (availableNode) predates this heartbeat, so a full save of it would
+        // put the older lastSeen back
+        Date heartbeatAt = await(nodeOrchestration.heartbeat(NODE_ID, List.of())).getLastSeen();
+        vmManager.failStartWith = new RpcMissingServiceException("gone");
+
+        assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
+
+        assertEquals(VmNodeStatusType.UNREACHABLE, awaitNodeStatus(VmNodeStatusType.UNREACHABLE));
+        assertEquals(heartbeatAt, nodes.saved.get(NODE_ID).getLastSeen());
+    }
+
+    @Test
+    public void registeringANewNodeStampsLastSeen() throws Exception {
+        Date before = new Date();
+
+        await(nodeOrchestration.registerNode(new VmNodeRegistration("node-2", "node-2", "host-2")));
+
+        assertFalse(nodes.saved.get("node-2").getLastSeen().before(before));
+    }
+
+    @Test
+    public void reRegisteringANodeStampsLastSeen() throws Exception {
+        VmNode node = nodes.saved.get(NODE_ID);
+        node.setLastSeen(new Date(System.currentTimeMillis() - 10_000));
+        nodes.saveSync(node);
+        Date before = new Date();
+
+        await(nodeOrchestration.registerNode(new VmNodeRegistration(NODE_ID, "node-1", "host-1")));
+
+        assertFalse(nodes.saved.get(NODE_ID).getLastSeen().before(before));
     }
 
     @Test
     public void ordinaryStartFailureDoesNotVerifyTheNode() throws Exception {
-        nodes.saveSync(nodes.availableNode);
         vmManager.failStartWith = new RuntimeException("node exploded");
 
         assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
@@ -98,10 +140,9 @@ public class WorkloadOrchestrationTest {
 
     @Test
     public void heartbeatBringsAnUnreachableNodeBackOnline() throws Exception {
-        nodes.saveSync(nodes.availableNode);
         vmManager.failStartWith = new RpcMissingServiceException("gone");
         assertThrows(Exception.class, () -> await(orchestration.deployWorkload(newWorkload())));
-        assertEquals(VmNodeStatusType.UNREACHABLE, nodes.saved.get(NODE_ID).getStatus().getType());
+        assertEquals(VmNodeStatusType.UNREACHABLE, awaitNodeStatus(VmNodeStatusType.UNREACHABLE));
 
         await(nodeOrchestration.heartbeat(NODE_ID, List.of()));
 
@@ -110,7 +151,6 @@ public class WorkloadOrchestrationTest {
 
     @Test
     public void reachableVmManagerKeepsItsNodeOnlineWhenACallFails() throws Exception {
-        nodes.saveSync(nodes.availableNode);
         when(eventBus.monitorListenerStatus(any())).thenReturn(Flux.just(ListenerStatus.ACTIVE));
         vmManager.failStartWith = new RpcServiceUnavailableException("the gateway serving it left mid-call");
 
@@ -131,11 +171,44 @@ public class WorkloadOrchestrationTest {
 
         nodeOrchestration.init();
         try {
-            long deadline = System.currentTimeMillis() + 10_000;
-            while (nodes.saved.get(NODE_ID).getStatus().getType() != VmNodeStatusType.OFFLINE && System.currentTimeMillis() < deadline) {
-                Thread.sleep(100);
-            }
-            assertEquals(VmNodeStatusType.OFFLINE, nodes.saved.get(NODE_ID).getStatus().getType());
+            assertEquals(VmNodeStatusType.OFFLINE, awaitNodeStatus(VmNodeStatusType.OFFLINE));
+            assertEquals(WorkloadStatus.FAILED, workloads.saved.get(deployed.getId()).getStatus());
+        } finally {
+            nodeOrchestration.destroy();
+        }
+    }
+
+    @Test
+    public void silentUnreachableNodeGoesOffline() throws Exception {
+        properties.getSystemApi().getVmNode().setHealthCheckIntervalSeconds(1);
+        properties.getSystemApi().getVmNode().setHeartbeatTimeoutSeconds(1);
+        VmNode node = nodes.saved.get(NODE_ID);
+        node.setStatus(new VmNodeStatus(VmNodeStatusType.UNREACHABLE, null));
+        node.setLastSeen(new Date(System.currentTimeMillis() - 10_000));
+        nodes.saveSync(node);
+
+        nodeOrchestration.init();
+        try {
+            assertEquals(VmNodeStatusType.OFFLINE, awaitNodeStatus(VmNodeStatusType.OFFLINE));
+        } finally {
+            nodeOrchestration.destroy();
+        }
+    }
+
+    @Test
+    public void silentNodeFailsItsStoppingWorkload() throws Exception {
+        properties.getSystemApi().getVmNode().setHealthCheckIntervalSeconds(1);
+        properties.getSystemApi().getVmNode().setHeartbeatTimeoutSeconds(1);
+        // a stop whose reply never came back from the node leaves the record STOPPING
+        Workload deployed = await(orchestration.deployWorkload(newWorkload()));
+        workloads.saved.get(deployed.getId()).setStatus(WorkloadStatus.STOPPING);
+        VmNode node = nodes.saved.get(NODE_ID);
+        node.setLastSeen(new Date(System.currentTimeMillis() - 10_000));
+        nodes.saveSync(node);
+
+        nodeOrchestration.init();
+        try {
+            assertEquals(VmNodeStatusType.OFFLINE, awaitNodeStatus(VmNodeStatusType.OFFLINE));
             assertEquals(WorkloadStatus.FAILED, workloads.saved.get(deployed.getId()).getStatus());
         } finally {
             nodeOrchestration.destroy();
@@ -306,6 +379,19 @@ public class WorkloadOrchestrationTest {
 
     private static <T> T await(Future<T> future) throws Exception {
         return future.toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Returns the stored status type of {@link #NODE_ID} once it is {@code expected}, or whatever it is
+     * when the wait runs out. Status writes made by verifyNode's continuation land on the Vertx
+     * context and by the reaper on its scheduler thread, after the call the test awaited returned.
+     */
+    private VmNodeStatusType awaitNodeStatus(VmNodeStatusType expected) throws Exception {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (nodes.saved.get(NODE_ID).getStatus().getType() != expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        return nodes.saved.get(NODE_ID).getStatus().getType();
     }
 
     private static Workload newWorkload() {

--- a/website/content/02.platform/01.architecture.md
+++ b/website/content/02.platform/01.architecture.md
@@ -37,3 +37,16 @@ scheme://[scope@]resourceName[/path][#version]
 ```
 
 The RPC gateway uses CRIs to route requests to the correct service instance, apply versioning, and enforce scope-based multi-tenancy. See the [CRI Format](/platform/reference/cri-format) reference for details.
+
+### Never block the event loop
+
+A Java service published with `@Publish` is invoked on a Vert.x event loop it shares with the other services on the node, the same rule Vert.x sets for its own handlers. A method returns a `Future`, `CompletableFuture`, `Mono` or `Flux` and lets the work complete off the loop; a method that is slow, because it blocks on a synchronous client, a lock or a sleep, or because it does heavy CPU work, hands that work off inside itself:
+
+```java
+@Override
+public Future<Report> render(String id) {
+    return vertx.executeBlocking(() -> renderer.render(id));   // the loop is free while the worker runs
+}
+```
+
+The platform never hands off on a service's behalf. A method that blocks stalls every service sharing its loop, and Vert.x's blocked-thread checker reports it in the log.

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -122,7 +122,7 @@ Each node re-checks these and sends what it can no longer guarantee with its hea
 
 `VmNode.status` carries both parts: `status.type` is `ONLINE`, `DRAINING`, `UNREACHABLE`, or `OFFLINE`, and `status.healthMessage` is why, or null when the node is fit. The system console shows the reason on the node.
 
-A node that loses its connection to the server — a server restart, a network partition — reconnects on its own and is `ONLINE` again with its next heartbeat. The orchestrator marks it `OFFLINE` after `heartbeatTimeoutSeconds` without one, whatever it reported last, and fails the workloads running on it. A call to the node's vm-manager that cannot be delivered is an earlier sign: the orchestrator checks the vm-manager's registration at once and, finding none, marks the node `UNREACHABLE`, so nothing is placed on it while the heartbeat timeout runs; its next heartbeat brings it back to `ONLINE`.
+A node that loses its connection to the server — a server restart, a network partition — reconnects on its own and is `ONLINE` again with its next heartbeat. The orchestrator marks it `OFFLINE` after `heartbeatTimeoutSeconds` without one, whatever it reported last, and fails every workload still on it — starting, running, or stopping. Only a heartbeat or a registration writes `lastSeen`; a status or allocation change leaves it as it is, so it never hides a heartbeat from the timeout. A call to the node's vm-manager that cannot be delivered is an earlier sign: the orchestrator checks the vm-manager's registration at once and, finding none, marks the node `UNREACHABLE`, so nothing is placed on it while the heartbeat timeout runs; its next heartbeat brings it back to `ONLINE`.
 
 | Provider | What it re-checks |
 |---|---|

--- a/website/content/02.platform/11.service-call-liveness.md
+++ b/website/content/02.platform/11.service-call-liveness.md
@@ -44,7 +44,7 @@ What the caller receives, in every runtime:
 | `RpcMissingServiceException` | rejected at send, no registration for the address | never executed |
 | `RpcServiceUnavailableException` | the node that took the call left the cluster while it was in flight, its acknowledgement never arrived, or the service stopped while producing a stream | may or may not have executed |
 
-Callers of non-idempotent operations should treat the second as ambiguous and check before retrying. In TypeScript a failed call rejects with an `RpcError`, whose `exceptionName` and `exceptionClass` name the exception the server caught, so a caller branches on `exceptionName === 'RpcServiceUnavailableException'` rather than on the message.
+Callers of non-idempotent operations should treat the second as ambiguous and check before retrying. In TypeScript a failed call rejects with an `RpcError`, whose `exceptionName` and `exceptionClass` name the exception the server caught — for a service hosted in TypeScript, the class of the error it threw, whose name fills both — so a caller branches on `exceptionName === 'RpcServiceUnavailableException'` rather than on the message.
 
 A service that stops, on a rolling update or any other graceful shutdown, stops accepting calls first, then answers every call it already has before its node leaves the cluster, so those calls complete normally and no lease fails. Streams it was producing cannot be finished; each one ends with `RpcServiceUnavailableException` at its subscriber the moment the service stops. The wait for the in-flight calls is bounded, so a call that never finishes cannot hold the shutdown.
 


### PR DESCRIPTION
Based on `develop` after #551–#554 merged. A four-way adversarial review of everything the series landed (kinotic-core, gateway, TS client, orchestrator), every finding traced in code before it was fixed. Plan: `docs/future-prompts/Node failure handling for service proxies.md`, new "Review fixes" section.

## Real hangs and broken behaviour

**Every TS `invokeStream` ended with a trailing `null`** (since Phase 1). stompjs never yields an absent body:

```ts
// @stomp/stompjs parser on 'MESSAGE\ndestination:reply://x\ncontrol:complete\n\n\0'
binaryBody: Uint8Array(0) []          // nullish: false
// EventBus.ts — so a stream's bodiless completion had data "present" and was emitted as a value
if (value.data.isPresent() || !sendControlEvents) { subscriber.next(value) }
```
```ts
// after: an empty body is no body where frames become events
return new Event(destination, headers, message.binaryBody.length > 0 ? message.binaryBody : undefined)
```

**A TS stream killed its own connection on the second value.** The reply grant was one send per delivered invocation, consumed by the first reply, and `ZoneRules` refuses `reply://` outright:

```java
// StompAuthorizer.sendAllowed
return temporarySendGrants.remove(cri.raw()) || zoneRules.sendAllowed(cri);
```
```java
// after — EndpointConnectionHandler.send: a reply to a pending invocation's own destination is allowed while it is pending
if (outgoingInvocations.owesReply(incomingEvent)) { outgoingInvocations.observeReply(incomingEvent); services.eventBusService.send(incomingEvent); }
```

**A lease could fall out of the watcher's node index**, so the call never failed when its node left:

```java
// DefaultRequestLivenessWatcher.watch — before: the add ran after computeIfAbsent returned the set
correlationIdsByNode.computeIfAbsent(nodeId, _ -> ConcurrentHashMap.newKeySet()).add(correlationId);
// after: the add runs under the key's lock
correlationIdsByNode.compute(nodeId, (_, ids) -> { Set<String> ret = ids != null ? ids : ConcurrentHashMap.newKeySet(); ret.add(correlationId); return ret; });
```

**Reply-consumer collision on reconnect.** The reply discriminator was minted once per client instance, so a reconnect inside the heartbeat window shared `reply://R:U@…` with the previous socket's still-registered consumer. Minted on every CONNECTED.

**A request during a pending `connect()` cached the reply subscription on a null or stale address.** `requestStream` requires a connection and reads the address at subscribe time.

**The session touch resurrected a logged-out session.** vertx-web's clustered store checks the version only on an existing entry, so the open socket's touch wrote the handler's copy back after logout had deleted it. `flushSession` reads first and never re-creates.

## Contained damage

- `DefaultRpcServiceProxyHandle.settle()` released the lease before removing the map entry; the entry goes first. The reply handler looks up once.
- `DefaultVmNodeService.beforeSave` stamped `lastSeen` on every save; only `heartbeat()` and `registerNode()` stamp it. `verifyNode` keeps the caller's context.
- TS supervisor: unserialisable values, unknown controls, and a frame with no reply-to no longer throw; `connectionLost` fires on OPEN-to-CLOSED only; `disconnect()` deactivates first so a pending connect cannot hold it.
- A NONE keep-alive connection deleted a login session it had not created; `disconnected()` duplicated `closed()`; membership snapshots are taken on the delivery context.

## Second pass: the TS connection layer and the Java supervisor

**`StompConnectionManager` is reworked around a `StompActivation` per `activate()` call.** It owns the listeners, the pending reject, a socket produced for stompjs, and the `beforeConnect` attempt stompjs is awaiting. stompjs resolves `deactivate()` at once while `_connect` is parked in `beforeConnect`, and that continuation then opened a socket for whichever activation was active by the time it resumed:

```ts
// after — deactivate(): the teardown outlasts the attempt, so the next activation cannot be active when the continuation runs
const teardown = this.rxStomp.deactivate({force}).then(() => activation.attempt ?? undefined).finally(...)
// signalFatal(activation, err): a fatal raised by an ended activation's attempt or listener is not published
if (!activation.ended) { activation.failIfPending(err); await this.deactivate(); this.fatalErrorsSubject.next(err) }
```
Also: a bad CONNECTED frame rejects with its own reason; the reconnect jitter ends with the activation; `activate()` rejects with `Error`s; each connection's reconnects get the full attempt budget; `EventBus.connect()` queued behind a `disconnect()` never starts. `FakeStompServer` drives it all in `ConnectionLifecycle.test.ts` (13 tests).

**`ServiceInvocationSupervisor`:** every way a stream ends early answers its caller (INACTIVE on the reply listener, the listener monitor ending, a `stop()` after the drain began), `fail()` sends that reply once, a duplicate correlation id is answered, an unknown control cancels the source, a single-value reply that cannot be sent is answered from `onNext` and from an empty completion alike.

**Invocations run on the delivery context.** The dispatch went through `vertx.executeBlocking(callable)`, the ordered overload, so the synchronous slice of every invocation of one service ran one at a time on one worker (four concurrent 500 ms blocking calls: 2177 ms on one thread). Every `@Publish`ed handler in the tree returns a `Future`, `CompletableFuture`, `Mono` or `Flux` and every Elasticsearch use is the async client, so the hop bought nothing:

```java
// after — the same contract Vert.x sets for an event loop; a slow handler hands off inside itself
enterInFlight();
try { processEvent(event); } finally { leaveInFlight(); }
```
The rule is stated in the platform architecture docs ("Never block the event loop"). The stream registry uses `putIfAbsent` and removes inline, the in-flight count is a pair of plain methods, and `JacksonTokenizer` is a synchronous call. `RpcTests.testInvocationsOfOneServiceOverlap` pins four delayed results of one service finishing together.

## Third pass: every remaining finding of the second review

All eleven items in `docs/future-prompts/Node failure review round two.md` are resolved; the doc keeps them as the record.

**A cancel is published, not routed.** With two instances of an unscoped service, `cancelRequest` sent the cancel to the shared address and round-robin could hand it to the instance without the stream. Vert.x cannot send to one node on a shared address and its node selector sees only the address, so instead of a per-node control address the cancel goes to every instance; the one holding the correlation id acts, the others already ignore an id they do not hold:

```java
// DefaultRpcServiceProxyHandle — the proxy's cancel and its orphan reaper; EndpointConnectionHandler does the same for a client's control event
eventBusService.publish(Event.create(serviceCri, metadata, null));
```
`RpcLivenessTests.testCancelReachesTheInstanceProducingTheStream` registers a sibling consumer on the address after the stream started and asserts both it and the producer see the cancel.

**A refused reply killed the client's connection.** A value crossing a cancel, or a reply finished after a reconnect, hit a `reply://` send the connection no longer owed, and `DefaultStompServerHandler` answered with `sendErrorAndDisconnect`, which failed every invocation the connection owed and marked the node UNREACHABLE. Such a reply is dropped and the send succeeds. On the TS side the supervisor drops results of invocations received on a connection that has since been lost (`connectionGeneration`), so it stops producing them at all.

**A lost-node failure racing a reply released the whole proxy.** `VertxFutureRpcReturnValueHandler` used `Promise.complete`/`fail`, which throw in Vert.x 5 on a completed promise, and the reply handler's catch called `release()` on the singleton. `tryComplete`/`tryFail` throughout; `RpcTests.testFutureHandlerSettlesOnceUnderCompetingSignals`.

**Gateway:** lease keys are qualified per connection, so two clients' equal correlation ids never overwrite or settle each other's lease; a CONNECTION keep-alive touches the session at connect (the upgrade response never reaches the store) and every quarter of the timeout, so one failed flush is retried before the stored copy expires; a control event's reply-to earns no one-shot grant; a reused subscription id unregisters the consumer it named before; a requester whose reply listener is gone is answered with `RpcServiceUnavailableException` as well as the stream cancelled, so a registration this node had not seen yet gets an error instead of silence. Six new tests in `EndpointConnectionHandlerTests` (15 total).

**Core, small:** `McpToolInvoker` completes a call from its ack-failure path only when that path removed it; `invoke()` re-checks `released` after its put.

**System API:** `deployWorkload`, `destroyWorkload`, `markUnreachable` and the reaper wrote back the whole `VmNode` they had read, carrying a `lastSeen` older than a heartbeat that landed in between. Status and allocation are partial updates now (`VmNodeService.updateStatusSync`, `updateAllocationSync`), so only a heartbeat or a registration writes `lastSeen`; the reaper fails STOPPING workloads on a silent node with the rest. `WorkloadOrchestrationTest` polls for state written on the Vertx context and adds five tests (22 total). The allocation is still a read-modify-write here; #559, stacked on this PR, makes it an atomic reservation.

**TS supervisor:** a synchronous source whose value cannot be serialised sends one error reply and is unsubscribed, instead of one per value plus a completion; the error body is `{exceptionName, exceptionClass, errorMessage}`, the shape `RpcError.fromEvent` and the Java converter read; the vm-manager bounds its graceful disconnect on shutdown. Four tests drive the supervisor through a real `EventBus` over the fake STOMP server.

## Verification

- `kinotic-core` full suite 114 tests, `kinotic-domain` 11, `EndpointConnectionHandlerTests` 15, `WorkloadOrchestrationTest` 22: all green.
- Core and vm-manager `tsc` clean; `ConnectionLifecycle.test.ts` 13 and `ServiceInvocationSupervisor.test.ts` 4 pass; core `bun test` at the same environment baseline as before (9 files needing the vitest container setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY)_