### PR TITLE
System API: a workload's room on a node is reserved and released atomically

### DIFF
--- a/docs/future-prompts/Node failure handling for service proxies.md
+++ b/docs/future-prompts/Node failure handling for service proxies.md
@@ -510,8 +510,9 @@ dropped instead of ending the connection, and a TS service drops results for inv
 connection; `VertxFutureRpcReturnValueHandler` completes idempotently; lease keys are qualified per
 connection; a CONNECTION keep-alive touches the session at connect and every quarter of the timeout;
 a control event earns no reply grant; a reused subscription id ends its predecessor; a requester whose
-listener is gone is answered as well as cancelled; VmNode status and allocation are partial updates so
-only a heartbeat writes `lastSeen`, and the reaper takes STOPPING workloads with the rest; the TS
+listener is gone is answered as well as cancelled; VmNode status is a partial update and the allocation an atomic scripted
+reservation and release, so only a heartbeat writes `lastSeen` and two concurrent deploys can never both
+take a node's last room; the reaper takes STOPPING workloads with the rest; the TS
 supervisor stops a synchronous stream on its first unsendable value, answers with the
 `{exceptionName, exceptionClass, errorMessage}` shape every runtime reads, and the vm-manager bounds
 its graceful disconnect on shutdown.

--- a/docs/future-prompts/Node failure review round two.md
+++ b/docs/future-prompts/Node failure review round two.md
@@ -94,7 +94,8 @@ the reaper write back the `lastSeen` they read. A heartbeat inside their read-to
 overwritten with the older value. It can reap a live node only when two heartbeat intervals exceed
 the timeout (defaults 30 s against 90 s cannot), but the two knobs are set independently on node and
 server. Fix: partial updates for status and allocation through `CrudServiceTemplate.partialUpdateSync`,
-exposed as `VmNodeService.updateStatusSync` and `updateAllocationSync`, so only a heartbeat or a
+exposed as `VmNodeService.updateStatusSync` and, for the allocation, `reserveSync`/`releaseSync`
+(scripted updates that are atomic per node, so concurrent deploys cannot both take the same room), so only a heartbeat or a
 registration ever writes `lastSeen`. Also: the reaper skips `STOPPING`, so a workload whose stop
 failed on a dead node stays STOPPING forever; include it.
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
@@ -7,6 +7,7 @@ import co.elastic.clients.elasticsearch._types.FieldSort;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.OpType;
 import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
@@ -19,6 +20,7 @@ import co.elastic.clients.elasticsearch.core.mget.MultiGetResponseItem;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import co.elastic.clients.elasticsearch.indices.*;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpMapperBase;
 import co.elastic.clients.transport.JsonEndpoint;
@@ -41,6 +43,7 @@ import tools.jackson.databind.type.TypeFactory;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -624,6 +627,36 @@ public class CrudServiceTemplate {
                                                         .refresh(Refresh.WaitFor),
                                                   Map.class)
                                           .thenApply(response -> null));
+    }
+
+    /**
+     * Runs a Painless script against a document using {@link Refresh#WaitFor}, guaranteeing read-your-write
+     * semantics for subsequent queries. The script reads and writes the document in one shard operation, so a
+     * read-modify-write expressed in it cannot lose a concurrent writer's change; a conflicting concurrent
+     * write is retried server-side. A script that sets {@code ctx.op} to {@code noop} leaves the document as
+     * it is and the future completes with false.
+     *
+     * @param indexName name of the index
+     * @param id        of the document to update
+     * @param source    the Painless source, reading its inputs from {@code params}
+     * @param params    the values the script reads as {@code params.<name>}
+     * @return a {@link Future} that will complete with true when the script changed the document and false
+     * when it declined, or fail when the document does not exist
+     */
+    public Future<Boolean> scriptedUpdateSync(String indexName,
+                                              String id,
+                                              String source,
+                                              Map<String, Object> params) {
+        Map<String, JsonData> scriptParams = new HashMap<>();
+        params.forEach((name, value) -> scriptParams.put(name, JsonData.of(value)));
+        return toFuture(esAsyncClient.update(u -> u.index(indexName)
+                                                        .id(id)
+                                                        .script(s -> s.source(src -> src.scriptString(source))
+                                                                      .params(scriptParams))
+                                                        .retryOnConflict(UPDATE_CONFLICT_RETRIES)
+                                                        .refresh(Refresh.WaitFor),
+                                                  Map.class)
+                                          .thenApply(response -> response.result() != Result.NoOp));
     }
 
     /**

--- a/kinotic-system-api/src/main/java/org/kinotic/system/api/services/VmNodeService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/api/services/VmNodeService.java
@@ -32,14 +32,28 @@ public interface VmNodeService extends IdentifiableCrudService<VmNode, String> {
     Future<Void> updateStatusSync(String nodeId, VmNodeStatus status);
 
     /**
-     * Sets a node's unallocated resources, leaving every other field of the record as it is, and completes
-     * once the change is visible to {@link #findAvailableNode}.
-     * @param nodeId the id of the node to update
-     * @param availableCpus the number of vCPUs not allocated to any workload
-     * @param availableMemoryMb the memory not allocated to any workload, in megabytes
-     * @param availableDiskMb the disk space not allocated to any workload, in megabytes
-     * @return a future that will complete when the allocation is stored, or fail if the node is not registered
+     * Reserves resources on a node for a workload: takes them from the node's unallocated capacity if it has
+     * them all, atomically against every other reservation and release on the node, and completes once the
+     * change is visible to {@link #findAvailableNode}.
+     * @param nodeId the id of the node to reserve on
+     * @param cpus the vCPUs the workload needs
+     * @param memoryMb the memory the workload needs, in megabytes
+     * @param diskMb the disk space the workload needs, in megabytes
+     * @return a future that will complete with true when the resources are reserved and false when the node
+     * no longer has them, or fail if the node is not registered
      */
-    Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb);
+    Future<Boolean> reserveSync(String nodeId, int cpus, int memoryMb, int diskMb);
+
+    /**
+     * Returns a workload's resources to a node's unallocated capacity, never past the node's totals, atomically
+     * against every other reservation and release on the node, and completes once the change is visible to
+     * {@link #findAvailableNode}.
+     * @param nodeId the id of the node to release on
+     * @param cpus the vCPUs the workload held
+     * @param memoryMb the memory the workload held, in megabytes
+     * @param diskMb the disk space the workload held, in megabytes
+     * @return a future that will complete when the resources are released, or fail if the node is not registered
+     */
+    Future<Void> releaseSync(String nodeId, int cpus, int memoryMb, int diskMb);
 
 }

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/repositories/VmNodeRepository.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/repositories/VmNodeRepository.java
@@ -15,6 +15,24 @@ import java.util.Map;
 @Component
 public class VmNodeRepository extends AbstractRepository<VmNode> {
 
+    // declines with noop rather than going negative, so the caller learns the capacity was taken
+    private static final String RESERVE_SCRIPT = """
+            if (ctx._source.availableCpus < params.cpus
+                    || ctx._source.availableMemoryMb < params.memoryMb
+                    || ctx._source.availableDiskMb < params.diskMb) {
+                ctx.op = 'noop';
+            } else {
+                ctx._source.availableCpus -= params.cpus;
+                ctx._source.availableMemoryMb -= params.memoryMb;
+                ctx._source.availableDiskMb -= params.diskMb;
+            }
+            """;
+    private static final String RELEASE_SCRIPT = """
+            ctx._source.availableCpus = Math.min(ctx._source.totalCpus, ctx._source.availableCpus + params.cpus);
+            ctx._source.availableMemoryMb = Math.min(ctx._source.totalMemoryMb, ctx._source.availableMemoryMb + params.memoryMb);
+            ctx._source.availableDiskMb = Math.min(ctx._source.totalDiskMb, ctx._source.availableDiskMb + params.diskMb);
+            """;
+
     public VmNodeRepository(CrudServiceTemplate crudServiceTemplate) {
         super("kinotic_vm_node", VmNode.class, crudServiceTemplate);
     }
@@ -39,16 +57,25 @@ public class VmNodeRepository extends AbstractRepository<VmNode> {
     }
 
     /**
-     * Sets a node's unallocated resources through a partial update touching only the {@code available*}
-     * fields, visible to search on completion.
+     * Takes the resources from a node's unallocated {@code available*} fields in one shard operation, so two
+     * reservations can never both be granted the same capacity, visible to search on completion.
+     * @return true when the node had the capacity and it is now reserved, false when it did not
      */
-    public Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb) {
-        return crudServiceTemplate.partialUpdateSync(indexName,
-                                                     nodeId,
-                                                     Map.of("availableCpus", availableCpus,
-                                                            "availableMemoryMb", availableMemoryMb,
-                                                            "availableDiskMb", availableDiskMb),
-                                                     false);
+    public Future<Boolean> reserveSync(String nodeId, int cpus, int memoryMb, int diskMb) {
+        return crudServiceTemplate.scriptedUpdateSync(indexName, nodeId, RESERVE_SCRIPT, allocationParams(cpus, memoryMb, diskMb));
+    }
+
+    /**
+     * Returns the resources to a node's unallocated {@code available*} fields in one shard operation, never
+     * past the node's totals, visible to search on completion.
+     */
+    public Future<Void> releaseSync(String nodeId, int cpus, int memoryMb, int diskMb) {
+        return crudServiceTemplate.scriptedUpdateSync(indexName, nodeId, RELEASE_SCRIPT, allocationParams(cpus, memoryMb, diskMb))
+                                  .mapEmpty();
+    }
+
+    private static Map<String, Object> allocationParams(int cpus, int memoryMb, int diskMb) {
+        return Map.of("cpus", cpus, "memoryMb", memoryMb, "diskMb", diskMb);
     }
 
     private static Query atLeast(String field, int required) {

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultVmNodeService.java
@@ -33,9 +33,15 @@ public class DefaultVmNodeService extends AbstractCrudService<VmNode> implements
     }
 
     @Override
-    public Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb) {
+    public Future<Boolean> reserveSync(String nodeId, int cpus, int memoryMb, int diskMb) {
         Validate.notNull(nodeId, "VmNode id cannot be null");
-        return vmNodeRepository.updateAllocationSync(nodeId, availableCpus, availableMemoryMb, availableDiskMb);
+        return vmNodeRepository.reserveSync(nodeId, cpus, memoryMb, diskMb);
+    }
+
+    @Override
+    public Future<Void> releaseSync(String nodeId, int cpus, int memoryMb, int diskMb) {
+        Validate.notNull(nodeId, "VmNode id cannot be null");
+        return vmNodeRepository.releaseSync(nodeId, cpus, memoryMb, diskMb);
     }
 
     @Override

--- a/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
+++ b/kinotic-system-api/src/main/java/org/kinotic/system/internal/api/services/DefaultWorkloadOrchestrationService.java
@@ -29,6 +29,9 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
     // ever receives the real values
     private static final String REDACTED_SECRET_VALUE = "<redacted>";
 
+    // Placements a deploy may make before it gives up on the room concurrent deploys keep taking
+    private static final int PLACEMENT_ATTEMPTS = 3;
+
     private final VmNodeOrchestrationService nodeOrchestrationService;
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     private final VmManagerProxy vmManagerProxy;
@@ -53,31 +56,19 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
         Validate.notNull(workload.getImage(), "Workload image cannot be null");
 
         Future<VmNode> nodeFuture = workload.getNodeId() == null
-                ? nodeOrchestrationService.findAvailableNode(workload.getVcpus(), workload.getMemoryMb(), workload.getDiskSizeMb())
-                : requirePinnedNode(workload);
+                ? placeWorkload(workload, 1)
+                : reserveOnPinnedNode(workload);
         return nodeFuture
                 .compose(node -> {
-                    if (node == null) {
-                        return Future.failedFuture(
-                                new IllegalStateException("No available node with sufficient resources to deploy workload"));
-                    }
-
                     log.info("Selected node {} for workload {}", node.getId(), workload.getName());
 
                     // Assign the workload to the selected node
                     workload.setNodeId(node.getId());
                     workload.setStatus(WorkloadStatus.STARTING);
 
-                    // Persist the workload and update node resource allocation. Only the allocation is
-                    // written, so a heartbeat that landed after the placement read keeps its lastSeen.
                     return persistRedacted(workload)
-                            .compose(savedWorkload ->
-                                vmNodeService.updateAllocationSync(node.getId(),
-                                                                   node.getAvailableCpus() - savedWorkload.getVcpus(),
-                                                                   node.getAvailableMemoryMb() - savedWorkload.getMemoryMb(),
-                                                                   node.getAvailableDiskMb() - savedWorkload.getDiskSizeMb())
-                                        .map(savedWorkload)
-                            )
+                            // the reservation is the workload's; a record that cannot be written hands it back
+                            .recover(error -> release(node.getId(), workload).transform(_ -> Future.failedFuture(error)))
                             .compose(savedWorkload ->
                                 // Dispatch to the VmManager on the selected node. For a
                                 // non-detached workload the reply arrives once the run ends.
@@ -162,24 +153,7 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
 
                     // Dispatch destroy to the VmManager on the workload's node
                     return verifyingNodeOnFailure(workload.getNodeId(), vmManagerProxy.destroyWorkload(workload.getNodeId(), workloadId))
-                            .compose(v ->
-                                // Free allocated resources on the node. Only the allocation is written, so a
-                                // heartbeat that landed after the read keeps its lastSeen.
-                                vmNodeService.findById(workload.getNodeId())
-                                        .compose(node -> {
-                                            Future<Void> ret;
-                                            if (node != null) {
-                                                ret = vmNodeService.updateAllocationSync(
-                                                        node.getId(),
-                                                        Math.min(node.getTotalCpus(), node.getAvailableCpus() + workload.getVcpus()),
-                                                        Math.min(node.getTotalMemoryMb(), node.getAvailableMemoryMb() + workload.getMemoryMb()),
-                                                        Math.min(node.getTotalDiskMb(), node.getAvailableDiskMb() + workload.getDiskSizeMb()));
-                                            } else {
-                                                ret = Future.succeededFuture();
-                                            }
-                                            return ret;
-                                        })
-                            )
+                            .compose(v -> release(workload.getNodeId(), workload))
                             .compose(v -> workloadService.deleteById(workloadId));
                 });
     }
@@ -211,11 +185,44 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
     }
 
     /**
-     * Resolves a workload's pre-assigned node, failing unless it is registered, ONLINE, and
-     * has the capacity the workload requires — the same gates placement applies when it
-     * selects a node.
+     * Picks a node with room for the workload and reserves that room on it. The pick reads the index and the
+     * reservation is atomic on the node, so a concurrent deploy that took the same room in between is answered
+     * by a declined reservation, and the pick runs again on the capacity that is left.
      */
-    private Future<VmNode> requirePinnedNode(Workload workload) {
+    private Future<VmNode> placeWorkload(Workload workload, int attempt) {
+        return nodeOrchestrationService.findAvailableNode(workload.getVcpus(), workload.getMemoryMb(), workload.getDiskSizeMb())
+                .compose(node -> {
+                    Future<VmNode> ret;
+                    if (node == null) {
+                        ret = Future.failedFuture(
+                                new IllegalStateException("No available node with sufficient resources to deploy workload"));
+                    } else {
+                        ret = reserve(node, workload)
+                                .compose(reserved -> {
+                                    Future<VmNode> placed;
+                                    if (reserved) {
+                                        placed = Future.succeededFuture(node);
+                                    } else if (attempt < PLACEMENT_ATTEMPTS) {
+                                        log.info("Node {} was allocated to another workload while placing {}, picking again",
+                                                 node.getId(), workload.getName());
+                                        placed = placeWorkload(workload, attempt + 1);
+                                    } else {
+                                        placed = Future.failedFuture(new IllegalStateException(
+                                                "No available node with sufficient resources to deploy workload after "
+                                                        + PLACEMENT_ATTEMPTS + " placements"));
+                                    }
+                                    return placed;
+                                });
+                    }
+                    return ret;
+                });
+    }
+
+    /**
+     * Reserves the workload's room on its pre-assigned node, failing unless the node is registered, ONLINE,
+     * and has that room, the same gates placement applies when it picks a node.
+     */
+    private Future<VmNode> reserveOnPinnedNode(Workload workload) {
         String nodeId = workload.getNodeId();
         return vmNodeService.findById(nodeId)
                 .compose(node -> {
@@ -227,16 +234,23 @@ public class DefaultWorkloadOrchestrationService implements WorkloadOrchestratio
                         ret = Future.failedFuture(new IllegalStateException(
                                 "Node " + nodeId + " is not taking workloads (status: "
                                         + node.getStatus().getType() + ")"));
-                    } else if (node.getAvailableCpus() < workload.getVcpus()
-                            || node.getAvailableMemoryMb() < workload.getMemoryMb()
-                            || node.getAvailableDiskMb() < workload.getDiskSizeMb()) {
-                        ret = Future.failedFuture(new IllegalStateException(
-                                "Node " + nodeId + " lacks capacity for workload " + workload.getName()));
                     } else {
-                        ret = Future.succeededFuture(node);
+                        ret = reserve(node, workload)
+                                .compose(reserved -> reserved
+                                        ? Future.succeededFuture(node)
+                                        : Future.failedFuture(new IllegalStateException(
+                                                "Node " + nodeId + " lacks capacity for workload " + workload.getName())));
                     }
                     return ret;
                 });
+    }
+
+    private Future<Boolean> reserve(VmNode node, Workload workload) {
+        return vmNodeService.reserveSync(node.getId(), workload.getVcpus(), workload.getMemoryMb(), workload.getDiskSizeMb());
+    }
+
+    private Future<Void> release(String nodeId, Workload workload) {
+        return vmNodeService.releaseSync(nodeId, workload.getVcpus(), workload.getMemoryMb(), workload.getDiskSizeMb());
     }
 
     /**

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubVmNodeService.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/StubVmNodeService.java
@@ -19,7 +19,8 @@ import java.util.function.Consumer;
  * returned as serialization round-trips the way Elasticsearch documents are, so a caller's
  * mutation of an entity after a save never alters the stored record, and a full save writes
  * back exactly what the caller's copy holds. The partial updates change only their fields on
- * the stored record and fail when the node has no record, as the real update does.
+ * the stored record, atomically per node, and fail when the node has no record, as the real
+ * updates do.
  */
 public class StubVmNodeService implements VmNodeService {
 
@@ -40,24 +41,35 @@ public class StubVmNodeService implements VmNodeService {
     }
 
     @Override
-    public Future<Void> updateAllocationSync(String nodeId, int availableCpus, int availableMemoryMb, int availableDiskMb) {
-        return update(nodeId, node -> node.setAvailableCpus(availableCpus)
-                                          .setAvailableMemoryMb(availableMemoryMb)
-                                          .setAvailableDiskMb(availableDiskMb));
+    public Future<Boolean> reserveSync(String nodeId, int cpus, int memoryMb, int diskMb) {
+        boolean[] reserved = new boolean[1];
+        // one node's reservations serialize under the map's lock, as the scripted update does on the shard
+        return update(nodeId, node -> {
+            reserved[0] = node.getAvailableCpus() >= cpus && node.getAvailableMemoryMb() >= memoryMb && node.getAvailableDiskMb() >= diskMb;
+            if (reserved[0]) {
+                node.setAvailableCpus(node.getAvailableCpus() - cpus)
+                    .setAvailableMemoryMb(node.getAvailableMemoryMb() - memoryMb)
+                    .setAvailableDiskMb(node.getAvailableDiskMb() - diskMb);
+            }
+        }).map(v -> reserved[0]);
+    }
+
+    @Override
+    public Future<Void> releaseSync(String nodeId, int cpus, int memoryMb, int diskMb) {
+        return update(nodeId, node -> node.setAvailableCpus(Math.min(node.getTotalCpus(), node.getAvailableCpus() + cpus))
+                                          .setAvailableMemoryMb(Math.min(node.getTotalMemoryMb(), node.getAvailableMemoryMb() + memoryMb))
+                                          .setAvailableDiskMb(Math.min(node.getTotalDiskMb(), node.getAvailableDiskMb() + diskMb)));
     }
 
     private Future<Void> update(String nodeId, Consumer<VmNode> partial) {
-        Future<Void> ret;
-        VmNode stored = saved.get(nodeId);
-        if (stored == null) {
-            ret = Future.failedFuture(new IllegalStateException("No VmNode record for " + nodeId));
-        } else {
-            partial.accept(stored);
-            // re-put so a reader on another thread sees the mutation through the map's happens-before
-            saved.put(nodeId, stored);
-            ret = Future.succeededFuture();
-        }
-        return ret;
+        // computeIfPresent holds the entry's lock while partial runs, and the re-put publishes the mutation
+        VmNode stored = saved.computeIfPresent(nodeId, (_, node) -> {
+            partial.accept(node);
+            return node;
+        });
+        return stored == null
+                ? Future.failedFuture(new IllegalStateException("No VmNode record for " + nodeId))
+                : Future.succeededFuture();
     }
 
     @Override

--- a/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
+++ b/kinotic-system-api/src/test/java/org/kinotic/system/internal/api/services/WorkloadOrchestrationTest.java
@@ -61,7 +61,10 @@ public class WorkloadOrchestrationTest {
     void setUp() {
         workloads = new StubWorkloadService();
         nodes = new StubVmNodeService();
+        // a node with room for the default workload; a deploy reserves on the stored record
         nodes.availableNode = new VmNode(NODE_ID, "node-1", "host-1");
+        nodes.availableNode.setTotalCpus(4).setTotalMemoryMb(4096).setTotalDiskMb(10240)
+                           .setAvailableCpus(4).setAvailableMemoryMb(4096).setAvailableDiskMb(10240);
         nodes.saveSync(nodes.availableNode);
         vmManager = new StubVmManagerProxy();
         // the node's vm-manager registration, as the cluster reports it: absent unless a test says otherwise
@@ -325,6 +328,33 @@ public class WorkloadOrchestrationTest {
 
         assertTrue(run.failed());
         assertNull(vmManager.lastStarted);
+    }
+
+    @Test
+    public void concurrentDeploysCannotOverAllocateANode() throws Exception {
+        // room for exactly one of the two workloads; the placement returns the same node to both
+        nodes.availableNode = registeredNode(NODE_ID, 1, 4096, 10240);
+
+        Future<Workload> first = orchestration.deployWorkload(newWorkload().setVcpus(1));
+        Future<Workload> second = orchestration.deployWorkload(newWorkload().setVcpus(1));
+        Future.join(first, second).toCompletionStage().toCompletableFuture().handle((v, t) -> null).get(5, TimeUnit.SECONDS);
+
+        assertTrue(first.succeeded() != second.succeeded(), "exactly one deploy may hold the node's last vCPU");
+        assertEquals(0, nodes.saved.get(NODE_ID).getAvailableCpus());
+        assertEquals(1, vmManager.started.size());
+    }
+
+    @Test
+    public void destroyReturnsTheWorkloadsReservation() throws Exception {
+        nodes.availableNode = registeredNode(NODE_ID, 4, 4096, 10240);
+
+        Workload deployed = await(orchestration.deployWorkload(newWorkload()));
+        assertEquals(4 - deployed.getVcpus(), nodes.saved.get(NODE_ID).getAvailableCpus());
+
+        await(orchestration.destroyWorkload(deployed.getId()));
+        assertEquals(4, nodes.saved.get(NODE_ID).getAvailableCpus());
+        assertEquals(4096, nodes.saved.get(NODE_ID).getAvailableMemoryMb());
+        assertEquals(10240, nodes.saved.get(NODE_ID).getAvailableDiskMb());
     }
 
     @Test

--- a/website/content/02.platform/03.configuration.md
+++ b/website/content/02.platform/03.configuration.md
@@ -105,7 +105,7 @@ A provider needs its host prepared for it, so the setting follows the node's pro
 
 ## Node capacity
 
-Each vm-manager node reports its capacity when it registers with the orchestrator. A workload is placed on the first online node whose unallocated capacity covers the workload's `vcpus`, `memoryMb`, and `diskSizeMb`.
+Each vm-manager node reports its capacity when it registers with the orchestrator. A workload is placed on the first online node whose unallocated capacity covers the workload's `vcpus`, `memoryMb`, and `diskSizeMb`, and that capacity is reserved on the node atomically, so two deployments placed at the same moment can never both take the same room; a deployment whose room was taken in between is placed again on what is left, up to three times.
 
 | Reported | Source on the node |
 |---|---|


### PR DESCRIPTION
Stacked on #558, whose partial-update commit it builds on (`VmNodeService.updateAllocationSync` is what this replaces). One commit.

## The race

The node's allocation was a read-modify-write: placement read the node, and the deploy later wrote `available - workload` back. Two deploys placed on one node at the same moment both subtracted from the same read, and the node ended up over-allocated:

```java
// DefaultWorkloadOrchestrationService.deployWorkload — before
vmNodeService.updateAllocationSync(node.getId(),
                                   node.getAvailableCpus() - savedWorkload.getVcpus(), ...)   // node was read before the other deploy wrote
```

## The fix

The reservation is one shard operation on the node, and it declines instead of going negative:

```java
// VmNodeRepository.RESERVE_SCRIPT — run by CrudServiceTemplate.scriptedUpdateSync
if (ctx._source.availableCpus < params.cpus
        || ctx._source.availableMemoryMb < params.memoryMb
        || ctx._source.availableDiskMb < params.diskMb) {
    ctx.op = 'noop';
} else {
    ctx._source.availableCpus -= params.cpus;
    ctx._source.availableMemoryMb -= params.memoryMb;
    ctx._source.availableDiskMb -= params.diskMb;
}
```
```java
// VmNodeService — replaces updateAllocationSync
Future<Boolean> reserveSync(String nodeId, int cpus, int memoryMb, int diskMb);   // false when the node no longer has the room
Future<Void> releaseSync(String nodeId, int cpus, int memoryMb, int diskMb);      // never past the node's totals
```

- `CrudServiceTemplate.scriptedUpdateSync` is new: a Painless script with `retryOnConflict` and `Refresh.WaitFor`, reporting whether the document changed (`result != NoOp`). Same `update` request `partialUpdateSync` already issues.
- `deployWorkload` reserves on the node it picked and picks again, up to three times, when another deploy took the room in between. A pinned deploy fails when its node lacks the room, which replaces the read-only capacity check. A workload record that cannot be written hands the reservation back.
- `destroyWorkload` releases through the script instead of reading the node and writing a computed value.
- `StubVmNodeService` serializes a node's updates under the map's entry lock, the way the shard does.

## Verification

- `WorkloadOrchestrationTest` 24 tests, two new: two deploys against a node with one vCPU leave exactly one running and zero available; destroy returns the reservation. Full `kinotic-system-api` suite green; `kinotic-domain` and `kinotic-management-api` compile against the changed interface.
- The Painless scripts run only against a real Elasticsearch, which this environment has no container for; their contract is pinned through the stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiTA3o5BHUTJHatFXkvoFY